### PR TITLE
Misc fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._
-
-
 ## One-line summary
 
 

--- a/springfield/base/templates/base-error.html
+++ b/springfield/base/templates/base-error.html
@@ -6,7 +6,6 @@
 
 {% extends 'base-protocol.html' %}
 
-{% block page_title_prefix %}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 
 {% block body_class %}{% endblock %}

--- a/springfield/base/templates/base-protocol.html
+++ b/springfield/base/templates/base-protocol.html
@@ -28,7 +28,7 @@
     {% block extra_meta %}{% endblock %}
 
     {% block shared_meta %}
-    <title>{% filter striptags %}{% block page_title %}{% endblock %}{% endfilter %}</title>
+    <title>{% filter striptags %}{% block page_title_full %}{% block page_title_prefix %}{% endblock %}{% block page_title %}{% endblock %}{% endblock page_title_full %}{% block page_title_suffix %} — Mozilla{% endblock %}{% endfilter %}</title>
     <meta name="description" content="{% filter striptags %}{% block page_desc %}{% endblock %}{% endfilter %}">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Firefox">

--- a/springfield/cms/templates/cms/simple_rich_text_page.html
+++ b/springfield/cms/templates/cms/simple_rich_text_page.html
@@ -6,7 +6,7 @@
 
 {% extends "cms/base-protocol.html" %}
 
-{% block page_title_prefix %}{{page.title}}{% endblock %}
+{% block page_title %}{{page.title}}{% endblock %}
 
 {% block content %}
 

--- a/springfield/firefox/templates/firefox/download/desktop/base.html
+++ b/springfield/firefox/templates/firefox/download/desktop/base.html
@@ -7,7 +7,7 @@
 {% extends "base-protocol.html" %}
 
 {# Bug 1438302,  Issue 13019: Avoid duplicate content for English pages. #}
-{%- block page_title -%}
+{%- block page_title_full -%}
   {%- if LANG == 'en-US' -%}
     Get Firefox for desktop — Mozilla (US)
   {%- elif LANG == 'en-GB' -%}
@@ -16,6 +16,8 @@
     {{ ftl('firefox-desktop-download-meta-title-v2', fallback='firefox-desktop-download-meta-title') }}
   {%- endif -%}
 {%- endblock -%}
+
+{% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}{{ ftl('firefox-desktop-download-meta-desc-v2', fallback='firefox-desktop-download-meta-desc') }}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/includes/sub-nav-firefox.html
+++ b/springfield/firefox/templates/firefox/includes/sub-nav-firefox.html
@@ -26,7 +26,7 @@
     },
     {
       'text': ftl('sub-navigation-features'),
-      'href': 'https://www.mozilla.org/' + LANG + '/firefox/features/',
+      'href': url('firefox.features.index'),
       'cta_name': 'Features'
     },
     {

--- a/springfield/firefox/templates/firefox/releases/notes.html
+++ b/springfield/firefox/templates/firefox/releases/notes.html
@@ -36,7 +36,6 @@
   {% endif %}
 {% endif %}
 
-{% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ release.product }} {{ channel_name }} {{ release.version }}, See All New Features, Updates and Fixes{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/releases/system_requirements.html
+++ b/springfield/firefox/templates/firefox/releases/system_requirements.html
@@ -10,7 +10,6 @@
 
 {% set channel_name = '' if release.channel == 'Release' else release.channel %}
 
-{% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ release.product }} {{ channel_name }} {{ version }} System Requirements{% endblock %}
 
 {% block body_id %}notes{% endblock %}

--- a/springfield/firefox/templates/firefox/testflight.html
+++ b/springfield/firefox/templates/firefox/testflight.html
@@ -8,11 +8,7 @@
 
 {% from "macros-protocol.html" import callout with context %}
 
-{% block page_title_prefix %}
-Firefox for iOS Beta —
-{% endblock %}
-
-{% block page_title %}TestFlight{% endblock %}
+{% block page_title_full %}Firefox for iOS Beta — TestFlight{% endblock %}
 
 {% block page_desc %}
 Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.


### PR DESCRIPTION
## One-line summary

- Reinstates `page_title_prefix` and `page_title_prefix` (which turns out are used on a small number of pages still)
- Fixes hard coded `/features/` page link in Firefox sub navigation.

## Issue / Bugzilla link

N/A

## Testing

Check page titles match what's in prod for mozorg:

- http://localhost:8000/en-US/download/
- http://localhost:8000/en-US/download/?xv=basic
- http://localhost:8000/en-US/ios/testflight/