### PR TITLE
Fix CDN and download tests

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -6,8 +6,9 @@ env:
   SLACK_CHANNEL_ID: CBX0KH5GA # #www-notify in MoCo Slack
   SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
 on:
-  schedule:
-    - cron: "0 11 * * *" # 11am daily
+  # DISABLED UNTIL www.firefox.com is properly up
+  # schedule:
+  #   - cron: "0 11 * * *" # 11am daily
   workflow_dispatch:
     inputs:
       springfield_service_hostname:

--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -6,8 +6,9 @@ env:
   SLACK_CHANNEL_ID: CBX0KH5GA # #www-notify in MoCo Slack
   SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
 on:
-  schedule:
-    - cron: "0 14 * * *" # 2pm daily
+  # Disable for now until prod is up and on www.firefox.com
+  # schedule:
+  #   - cron: "0 14 * * *" # 2pm daily
   workflow_dispatch:
     inputs:
       springfield_service_hostname:

--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -63,7 +63,7 @@ def get_ssllabs_results(base_url):
     (
         "/",
         "/download/",
-        "/about/",
+        "/privacy/websites/cookie-settings/",
     ),
 )
 @pytest.mark.nondestructive
@@ -78,10 +78,10 @@ def test_locale_redirect(url, base_url):
 @pytest.mark.parametrize(
     "url",
     (
-        # only in the GCS bucket
-        "/media/img/firefox/favicon-notice-196.d4686cdb823e.png",
-        # comes from springfield
-        "/media/protocol/img/logos/mozilla/black.40d1af88c248.svg",
+        # Only in the GCS bucket:
+        "/media/protocol/img/logos/firefox/logo.fedb52c912d6.svg",
+        # Comes from Springfield's codebase:
+        "/media/img/logos/m24/lockup-black.f2ddba3f0724.svg",
     ),
 )
 @pytest.mark.nondestructive


### PR DESCRIPTION
This is a first swing at making the CDN and Download tests pass, which are currently failing in part because they are intended for prod and we don't have prod up yet, and certainly not yet on www.firefox.com.

In the meantime, I've disabled the schedule and we should at least be able to run the tests against Dev to check that the paths they are seeking are correct, etc