### PR TITLE
(chore) L10N: reinstate updated Pontoon config for newsletters.ftl

### DIFF
--- a/.github/workflows/send_firefox_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_firefox_fluent_strings_to_l10n_org.yml
@@ -10,8 +10,8 @@ on:
     branches:
       - main
   workflow_dispatch:
-  #schedule:
-    #- cron: "0 0/3 * * *" # Every 3 hours
+  schedule:
+    - cron: "0 0/3 * * *" # Every 3 hours
 
 jobs:
   open_l10n_pr:

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -124,5 +124,23 @@ locales = [
     reference = "en/firefox/set-as-default/**/*.ftl"
     l10n = "{locale}/firefox/set-as-default/**/*.ftl"
 [[paths]]
+    reference = "en/newsletter/newsletters.ftl"
+    l10n = "{locale}/newsletter/newsletters.ftl"
+    locales = [
+        "bg",
+        "cs",
+        "de",
+        "es-ES",
+        "fr",
+        "hu",
+        "id",
+        "it",
+        "nl",
+        "pl",
+        "pt-BR",
+        "ru",
+        "zh-TW",
+    ]
+[[paths]]
     reference = "en/privacy/*.ftl"
     l10n = "{locale}/privacy/*.ftl"


### PR DESCRIPTION
...which got lost when pruning out mozorg-related Pontoon config

## Issue / Bugzilla link

Resolves #73 

## Testing

We should be able to see this change flow all the way from `mozmeao/springfield` to `mozilla-l10n/www-firefox-l10` and then back to `mozmeao/www-firefox-l10n`