### PR TITLE
Fix saucelabs errors after upgrades

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -26,14 +26,14 @@ def driver_log():
 def session_capabilities(pytestconfig, session_capabilities):
     driver = pytestconfig.getoption("driver")
     if driver == "SauceLabs":
-        session_capabilities.setdefault("tags", []).append("springfield")
+        sauce_options = session_capabilities.setdefault("sauce:options", {})
+        sauce_options.setdefault("tags", []).append("springfield")
 
         if session_capabilities.get("browserName", driver).lower() == "internet explorer":
             # Avoid default SauceLabs proxy for IE.
-            session_capabilities["avoidProxy"] = True
+            sauce_options["avoidProxy"] = True
 
-            # Use JavaScript events instead of native
-            # window events for more reliable IE testing.
+            # Use JavaScript events instead of native window events for more reliable IE testing.
             session_capabilities["se:ieOptions"] = {"nativeEvents": False}
 
     return session_capabilities


### PR DESCRIPTION
The error:
WebDriverException: Message: Sauce-specific capabilities are no longer accepted as W3C WebDriver capabilities: avoidProxy, tags. Ensure to enclose these in sauce:options capabilities.

