### PR TITLE
Fix wagtail admin  re panel naming

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -140,7 +140,7 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
             token_format: access_token
-            service_account:  artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+            service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
             workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - id: docker_login
@@ -152,7 +152,7 @@ jobs:
            password: ${{ steps.gcp_auth.outputs.access_token }}
 
       - id: push-existing-image-to-gar
-        name: Push existing stage image to GAR
+        name: Push existing image to GAR
         run: |-
              docker pull mozmeao/springfield:${{ needs.build_and_publish_public_images.outputs.long_sha }}
              docker tag mozmeao/springfield:${{ needs.build_and_publish_public_images.outputs.long_sha }} ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE }}:${{ env.TAG }}

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import models
 from django.shortcuts import redirect
 
+from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page as WagtailBasePage
 
@@ -23,11 +24,11 @@ class StructuralPage(AbstractSpringfieldCMSPage):
     # TO COME: guard rails on page hierarchy
     # subpage_types = []
     settings_panels = WagtailBasePage.settings_panels + [
-        "show_in_menus",
+        FieldPanel("show_in_menus"),
     ]
     content_panels = [
-        "title",
-        "slug",
+        FieldPanel("title"),
+        FieldPanel("slug"),
     ]
     promote_panels = []
 
@@ -60,7 +61,7 @@ class SimpleRichTextPage(AbstractSpringfieldCMSPage):
 
     # 2. Define editing UI by extending the default field list
     content_panels = AbstractSpringfieldCMSPage.content_panels + [
-        "content",
+        FieldPanel("content"),
     ]
 
     # 3. Specify HTML Template:
@@ -76,7 +77,7 @@ class ArticleIndexPageBase(AbstractSpringfieldCMSPage):
     )
 
     content_panels = AbstractSpringfieldCMSPage.content_panels + [
-        "sub_title",
+        FieldPanel("sub_title"),
     ]
 
     class Meta:
@@ -104,9 +105,9 @@ class ArticleDetailPageBase(AbstractSpringfieldCMSPage):
     )
 
     content_panels = AbstractSpringfieldCMSPage.content_panels + [
-        "image",
-        "desc",
-        "content",
+        FieldPanel("image"),
+        FieldPanel("desc"),
+        FieldPanel("content"),
     ]
 
     class Meta:

--- a/springfield/firefox/models.py
+++ b/springfield/firefox/models.py
@@ -4,6 +4,7 @@
 
 from django.db import models
 
+from wagtail.admin.panels import FieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import TranslatableMixin
 from wagtail.snippets.models import register_snippet
@@ -30,9 +31,9 @@ class FeaturesCallToActionSnippet(TranslatableMixin):
     )
 
     panels = [
-        "heading",
-        "desc",
-        "image",
+        FieldPanel("heading"),
+        FieldPanel("desc"),
+        FieldPanel("image"),
     ]
 
     class Meta(TranslatableMixin.Meta):
@@ -88,9 +89,9 @@ class FeaturesDetailPage(ArticleDetailPageBase):
     )
 
     content_panels = ArticleDetailPageBase.content_panels + [
-        "article_media",
-        "featured_article",
-        "call_to_action_bottom",
+        FieldPanel("article_media"),
+        FieldPanel("featured_article"),
+        FieldPanel("call_to_action_bottom"),
     ]
 
     def get_context(self, request, *args, **kwargs):


### PR DESCRIPTION
Wagtail 6.4 allows us to spec the fields to show on an editor view just by the string name of the field now, so `"myfield"` rather than `FieldPanel("myfield")`. We tried that in 469d64c but unfortunately it doesn't work for us, with `./manage.py migrate --check` (and probably other management commands) causing a blow up, blocking pre-commit locally.

```
...
  File "/Users/steve/.pyenv/versions/springfield/lib/python3.12/site-packages/wagtail/admin/panels/group.py", line 74, in on_model_bound
    self.children = [child.bind_to_model(self.model) for child in self.children]
                     ^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'bind_to_model'
```

This changeset returns us to the use of `FieldPanel()` and also tweaks a misleading logging typo around container-image building