### PR TITLE
Add `CSP_ORIGIN_HOST_FALLBACK` to appropriate CSP settings

### DIFF
--- a/springfield/settings/__init__.py
+++ b/springfield/settings/__init__.py
@@ -30,6 +30,9 @@ ROOT_URLCONF = "springfield.urls"
 # - if path is provided with trailing slash: the path is a prefix-match.
 #   - e.g. `https://example.com/api/` will match anything that starts with `https://example.com/api/`
 
+
+CSP_ORIGIN_HOST_FALLBACK = config("CSP_ORIGIN_HOST_FALLBACK", default="")
+
 _csp_default_src = {
     # Keep `default-src` minimal. Best to set resources in the specific directives.
     csp.constants.SELF,
@@ -38,6 +41,7 @@ _csp_connect_src = {
     # NOTE: Check if these need to be in the `_csp_form_action` list as well since we often
     # progressively enhance forms by using Javascript.
     csp.constants.SELF,
+    CSP_ORIGIN_HOST_FALLBACK,
     BASKET_URL,
     "www.googletagmanager.com",
     "www.google-analytics.com",
@@ -48,6 +52,7 @@ _csp_connect_src = {
 }
 _csp_font_src = {
     csp.constants.SELF,
+    CSP_ORIGIN_HOST_FALLBACK,
 }
 _csp_form_action = {
     csp.constants.SELF,
@@ -69,17 +74,20 @@ _csp_frame_src = {
 }
 _csp_img_src = {
     csp.constants.SELF,
+    CSP_ORIGIN_HOST_FALLBACK,
     "data:",
     "www.googletagmanager.com",
     "www.google-analytics.com",
 }
 _csp_media_src = {
     csp.constants.SELF,
+    CSP_ORIGIN_HOST_FALLBACK,
     "assets.mozilla.net",
     "videos.cdn.mozilla.net",
 }
 _csp_script_src = {
     csp.constants.SELF,
+    CSP_ORIGIN_HOST_FALLBACK,
     # TODO change settings so we don't need unsafes even in dev
     csp.constants.UNSAFE_INLINE,
     csp.constants.UNSAFE_EVAL,
@@ -91,6 +99,7 @@ _csp_script_src = {
 }
 _csp_style_src = {
     csp.constants.SELF,
+    CSP_ORIGIN_HOST_FALLBACK,
     # TODO fix things so that we don't need this
     csp.constants.UNSAFE_INLINE,
 }


### PR DESCRIPTION
## One-line summary

Springfield is accessible under different URLs (origin and CDN) but `STATIC_URL` points to specific URL. We encountered CSP issues when these don't match. This patch allows the origin host to be configured and added to the CSP where appropriate to allow the assets to load.

