### PR TITLE
Replace Firefox family logo with browser logo

### DIFF
--- a/springfield/firefox/templates/firefox/channel/base.html
+++ b/springfield/firefox/templates/firefox/channel/base.html
@@ -26,7 +26,7 @@
     'text':  ftl('sub-navigation-firefox'),
     'href':  url('firefox'),
     'cta_name': "Firefox",
-    'icon': static('protocol/img/logos/firefox/logo.svg')
+    'icon': static('protocol/img/logos/firefox/browser/logo.svg')
   },
   links=[
   {

--- a/springfield/firefox/templates/firefox/developer/index.html
+++ b/springfield/firefox/templates/firefox/developer/index.html
@@ -37,7 +37,7 @@
     title={
       'text':  ftl('sub-navigation-firefox'),
       'href':  url('firefox'),
-      'icon':  static('protocol/img/logos/firefox/logo.svg'),
+      'icon':  static('protocol/img/logos/firefox/browser/logo.svg'),
       'cta_name': 'Firefox'
     },
     links=[

--- a/springfield/firefox/templates/firefox/includes/sub-nav-firefox.html
+++ b/springfield/firefox/templates/firefox/includes/sub-nav-firefox.html
@@ -11,7 +11,7 @@
   title={
     'text':  ftl('sub-navigation-firefox'),
     'href':  url('firefox'),
-    'icon':  static('protocol/img/logos/firefox/logo.svg')
+    'icon':  static('protocol/img/logos/firefox/browser/logo.svg')
   },
   links=[
     {


### PR DESCRIPTION
## One-line summary

Replaces outdated Firefox family logo with regular browser logo.

## Issue / Bugzilla link

N/A

## Testing

- http://localhost:8000/en-US/download/
- http://localhost:8000/en-US/channel/desktop/
- http://localhost:8000/en-US/developer/