### PR TITLE
Add Release, Beta, and Developer Edition Linux/ARM64 builds to firefox/all

### DIFF
--- a/springfield/firefox/firefox_details.py
+++ b/springfield/firefox/firefox_details.py
@@ -86,8 +86,8 @@ class FirefoxDesktop(_ProductDetails):
         else:
             platforms = self.platform_labels.copy()
 
-        # Linux ARM64/AArch64 installers are only currently available for Nightly builds.
-        if channel != "nightly":
+        # Linux ARM64/AArch64 installers not available for ESR builds.
+        if channel == "esr":
             del platforms["linux64-aarch64"]
 
         return list(platforms.items())

--- a/springfield/firefox/tests/test_firefox_all.py
+++ b/springfield/firefox/tests/test_firefox_all.py
@@ -64,10 +64,10 @@ def test_all_step_1(client):
 @pytest.mark.parametrize(
     "product_slug, name, count",
     (
-        ("desktop-release", "Firefox", 9),
+        ("desktop-release", "Firefox", 10),
         ("desktop-esr", "Firefox Extended Support Release", 8),
-        ("desktop-beta", "Firefox Beta", 9),
-        ("desktop-developer", "Firefox Developer Edition", 8),
+        ("desktop-beta", "Firefox Beta", 10),
+        ("desktop-developer", "Firefox Developer Edition", 9),
         ("desktop-nightly", "Firefox Nightly", 9),
     ),
 )

--- a/springfield/firefox/tests/test_helpers.py
+++ b/springfield/firefox/tests/test_helpers.py
@@ -159,14 +159,14 @@ class TestDownloadButtons(TestCase):
         get_request.locale = "fr"
         doc = pq(render("{{ download_firefox() }}", {"request": get_request, "fluent_l10n": self.get_l10n(get_request.locale)}))
 
-        # The first 8 links should be for desktop.
+        # The first 9 links should be for desktop.
         links = doc(".download-list a")
 
-        for link in links[:8]:
+        for link in links[:9]:
             assert pq(link).attr("data-direct-link").startswith(settings.BOUNCER_URL)
 
-        # The ninth link is mobile and should not have the attr
-        assert pq(links[8]).attr("data-direct-link") is None
+        # The 10th link is mobile and should not have the attr
+        assert pq(links[9]).attr("data-direct-link") is None
 
     def test_nightly_desktop(self):
         """
@@ -206,7 +206,7 @@ class TestDownloadButtons(TestCase):
         )
 
         list = doc(".download-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
@@ -214,7 +214,8 @@ class TestDownloadButtons(TestCase):
         assert pq(list[4]).attr("class") == "os_win-msi"
         assert pq(list[5]).attr("class") == "os_osx"
         assert pq(list[6]).attr("class") == "os_linux64"
-        assert pq(list[7]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[8]).attr("class") == "os_linux"
 
     def test_beta_desktop(self):
         """The Beta channel should not have Windows 64 build yet"""
@@ -226,7 +227,7 @@ class TestDownloadButtons(TestCase):
         )
 
         list = doc(".download-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
@@ -234,7 +235,8 @@ class TestDownloadButtons(TestCase):
         assert pq(list[4]).attr("class") == "os_win-msi"
         assert pq(list[5]).attr("class") == "os_osx"
         assert pq(list[6]).attr("class") == "os_linux64"
-        assert pq(list[7]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[8]).attr("class") == "os_linux"
 
     def test_firefox_desktop(self):
         """The Release channel should not have Windows 64 build yet"""
@@ -244,7 +246,7 @@ class TestDownloadButtons(TestCase):
         doc = pq(render("{{ download_firefox(platform='desktop') }}", {"request": get_request, "fluent_l10n": self.get_l10n(get_request.locale)}))
 
         list = doc(".download-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
@@ -252,7 +254,8 @@ class TestDownloadButtons(TestCase):
         assert pq(list[4]).attr("class") == "os_win-msi"
         assert pq(list[5]).attr("class") == "os_osx"
         assert pq(list[6]).attr("class") == "os_linux64"
-        assert pq(list[7]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[8]).attr("class") == "os_linux"
 
     def test_latest_nightly_android(self):
         """The download button should have a Google Play link"""


### PR DESCRIPTION
## One-line summary

See https://github.com/mozilla/bedrock/pull/16066

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/download/all/