### PR TITLE
Bootup optimisations

### DIFF
--- a/bin/cron.py
+++ b/bin/cron.py
@@ -172,6 +172,14 @@ def schedule_file_jobs():
                 raise
 
 
+def schedule_l10n_jobs():
+    call_command("l10n_update --clean")
+
+    @scheduled_job("interval", minutes=DB_UPDATE_MINUTES)
+    def update_locales():
+        call_command("l10n_update")
+
+
 def main(args):
     has_jobs = False
     if "db" in args:
@@ -179,6 +187,9 @@ def main(args):
         has_jobs = True
     if "file" in args:
         schedule_file_jobs()
+        has_jobs = True
+    if "l10n" in args:
+        schedule_l10n_jobs()
         has_jobs = True
 
     if has_jobs:

--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -7,13 +7,15 @@
 # look for the required files and fail quickly if it's not there
 STARTUP_FILES=(
     "data/last-run-update_locales"
-    "data/last-run-download_database"
 )
 # If DATABASE_URL is defined, that means we're using Postgres not sqlite.
 # However, if DATABASE_URL is NOT defined, we need to be sure the sqlite DB file
-# is already present at startup
+# is already present at startup and that we've downloaded the latest one
 if [[ -z "$DATABASE_URL" ]]; then
-    STARTUP_FILES+=("data/springfield.db")
+    STARTUP_FILES+=(
+        "data/springfield.db"
+        "data/last-run-download_database"
+    )
 fi
 
 for fname in "${STARTUP_FILES[@]}"; do

--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -13,7 +13,6 @@ STARTUP_FILES=(
 # is already present at startup and that we've downloaded the latest one
 if [[ -z "$DATABASE_URL" ]]; then
     STARTUP_FILES+=(
-        "data/springfield.db"
         "data/last-run-download_database"
     )
 fi


### PR DESCRIPTION
* Remove need for the DB to be downloaded before startup if DATABASE_URL shows it's postgres
* Optimise speed of l10n updating by adding a new scheduled task that only does l10n files not also a DB; this avoids breaking demos and springfield-test

## Issue / Bugzilla link

Resolves #49 

## Testing

We're gonna need to try this on springfield-dev. I've got an infra PR here which disables the DB-download initContainer sidecar, and also uses the l10n-only scheduled job: https://github.com/mozilla-it/webservices-infra/pull/5518

We should also push main to run-integration-tests if Dev comes up fine after everything is merged