### PR TITLE
add GCP token file to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 .env
 **/__pycache__
 **/*.pyc
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
## One-line summary

To make sure generated credentials from `google-github-actions/auth` in CI are not included in any image.

- https://github.com/mozilla/bedrock/pull/16158

## Significant changes and points to review

The OIDC token is pretty short-lived, but still might be valid longer than build+push and then pull to exfiltrate it — an alternative/addition could be `run: docker logout` in the CI to revoke the token earlier once done.

Nonetheless this is not an issue in the current setup, where images are built logged-out, then pushed to public dockerhub repo with CI secrets, and only after that pulled, tagged, and published to GAR for deployment when logged-in only using the already built images from the previous job. So this is not a concern with the current runs, more of a failsafe in case the build would run logged-in for whatever reason.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/SE-4414
https://bugzilla.mozilla.org/show_bug.cgi?id=1959182

## Testing
