### PR TITLE
Migrate firefox/landing/get to springfield (Issue #128)

### DIFF
--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -46,3 +46,8 @@ download-button-using-debian = Using Debian, Ubuntu or any Debian-based distribu
 
 # Microsoft Windows Store badge
 download-button-get-it-from-microsoft = Get it from Microsoft
+
+# Variables
+#   $attrs (attrs) - link to https://support.mozilla.org/kb/marketing-data
+# “That you use it” is to mean that the user is opting in to sharing that they are continuing to use Firefox after installing it; not that Firefox is tracking their “usage” or what they’re using it for.
+download-button-share-how-you-discovered = Share how you discovered { -brand-name-firefox } and that you use it with { -brand-name-mozilla }’s marketing technology partners. This data is never sold or used to show you ads. <a { $attrs }>Learn how we use the data</a>.

--- a/l10n/en/firefox/download/desktop.ftl
+++ b/l10n/en/firefox/download/desktop.ftl
@@ -21,11 +21,19 @@ firefox-desktop-download-firefox = { -brand-name-firefox-browser }
 firefox-desktop-out-of-date = An even newer { -brand-name-firefox } is available. <a { $update_url }>Update to the latest version</a>
 
 firefox-desktop-download-get-the-browser = Get the browser that protects what’s important
-# shady is slang which suggests something is untrustworthy
+
+firefox-desktop-download-fast-reliable-private = Fast, reliable and private — for peace of mind online.
+
+# Obsolete string
 firefox-desktop-download-no-shady = No shady privacy policies or back doors for advertisers. Just a lightning fast browser that doesn’t sell you out.
+
 firefox-desktop-download-download-options = Download options and other languages
 firefox-desktop-download-browser-support = { -brand-name-firefox-browser } support
+
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
+firefox-desktop-download-do-what-you-do-v2 = Do what you do online.<br> { -brand-name-firefox-browser } has got you <strong>covered</strong>.
+
+# Obsolete string
 firefox-desktop-download-do-what-you-do = Do what you do online.<br> { -brand-name-firefox-browser } <strong>isn’t</strong> watching.
 
 firefox-desktop-download-we-block-the-ad = We block the ad trackers. You explore the internet faster.
@@ -116,6 +124,11 @@ firefox-desktop-download-from-security-to = From security to news to gaming, the
 #   $attrs (attrs) - link to https://www.mozilla.org/about/
 firefox-desktop-download-firefox-was-created = { -brand-name-firefox } was created by <a {$attrs }>{ -brand-name-mozilla }</a> as a faster, more private alternative to browsers like { -brand-name-ie }, and now { -brand-name-chrome }. Today, our mission-driven company and volunteer community continue to put your privacy above all else.
 
+# Variables:
+#   $attrs (attrs) - link to https://www.mozilla.org/privacy/firefox/
+firefox-desktop-download-as-the-internet-v2 = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy — that’s always been our thing. Learn more about our data practices in our <a { $attrs }>Privacy Notice</a>.
+
+# Obsolete string
 # Variables:
 #   $attrs (attrs) - link to https://www.mozilla.org/privacy/
 firefox-desktop-download-as-the-internet = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy  — we call it the <a { $attrs }>Personal Data Promise</a>: Take less. Keep it safe. No secrets. Your data, your web activity, your life online is protected with { -brand-name-firefox }.

--- a/media/css/firefox/landing/get/marketing-opt-out.scss
+++ b/media/css/firefox/landing/get/marketing-opt-out.scss
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
+.marketing-opt-out-checkbox-label {
+    max-width: 40em;
+    margin: 0 auto $spacing-lg;
+    font-weight: normal;
+
+    &.hidden {
+        display: none;
+    }
+
+    input[type="checkbox"] {
+        @include bidi(((margin-right, $spacing-sm, margin-left, 0),));
+        display: inline-block;
+        vertical-align: top;
+    }
+
+    .marketing-opt-out-text {
+        display: inline-block;
+        width: calc(100% - 40px);
+    }
+
+    .c-intro-download & {
+        max-width: none;
+    }
+}

--- a/media/js/base/stub-attribution/stub-attribution.js
+++ b/media/js/base/stub-attribution/stub-attribution.js
@@ -112,6 +112,27 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     /**
+     * Removes stub attribution cookie.
+     */
+    StubAttribution.removeCookie = function () {
+        window.Mozilla.Cookies.removeItem(
+            StubAttribution.COOKIE_CODE_ID,
+            '/',
+            undefined,
+            false,
+            'lax'
+        );
+
+        window.Mozilla.Cookies.removeItem(
+            StubAttribution.COOKIE_SIGNATURE_ID,
+            '/',
+            undefined,
+            false,
+            'lax'
+        );
+    };
+
+    /**
      * Gets stub attribution data from cookie.
      * @return {Object} - attribution_code, attribution_sig.
      */
@@ -200,6 +221,49 @@ if (typeof window.Mozilla === 'undefined') {
                 }
             }
         }
+    };
+
+    StubAttribution.removeLinkAttributionParams = function (href) {
+        if (href.indexOf('?') > 0) {
+            var params = new window._SearchParams(href.split('?')[1]);
+            var origin = href.split('?')[0];
+
+            if (
+                params.has('attribution_code') &&
+                params.has('attribution_sig')
+            ) {
+                params.remove('attribution_code');
+                params.remove('attribution_sig');
+                return (
+                    origin + '?' + window.decodeURIComponent(params.toString())
+                );
+            }
+        }
+
+        return href;
+    };
+
+    StubAttribution.cleanBouncerLinks = function () {
+        var downloadLinks = document.querySelectorAll('.download-link');
+
+        for (var i = 0; i < downloadLinks.length; i++) {
+            downloadLinks[i].href = StubAttribution.removeLinkAttributionParams(
+                downloadLinks[i].href
+            );
+
+            if (downloadLinks[i].hasAttribute('data-direct-link')) {
+                var attribute = StubAttribution.removeLinkAttributionParams(
+                    downloadLinks[i].getAttribute('data-direct-link')
+                );
+                downloadLinks[i].setAttribute('data-direct-link', attribute);
+            }
+        }
+    };
+
+    StubAttribution.removeAttributionData = function () {
+        StubAttribution.removeCookie();
+        StubAttribution.cleanBouncerLinks();
+        StubAttribution.requestComplete = false;
     };
 
     /**

--- a/media/js/firefox/landing/get/marketing-opt-out-init.es6.js
+++ b/media/js/firefox/landing/get/marketing-opt-out-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import MarketingOptOut from './marketing-opt-out.es6.js';
+
+MarketingOptOut.init();

--- a/media/js/firefox/landing/get/marketing-opt-out.es6.js
+++ b/media/js/firefox/landing/get/marketing-opt-out.es6.js
@@ -1,0 +1,216 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    hasConsentCookie,
+    getConsentCookie,
+    setConsentCookie,
+    consentRequired,
+    dntEnabled,
+    gpcEnabled
+} from '../../../base/consent/utils.es6';
+
+const MarketingOptOut = {};
+
+/**
+ * Processes attribution changes depending on checkbox state.
+ * @param {Boolean} checked - checkbox target value.
+ */
+MarketingOptOut.processAttributionRequest = (checked) => {
+    let previousPreferenceCookie;
+
+    /**
+     * Preserve previous preference cookie consent state if one exists
+     */
+    if (hasConsentCookie()) {
+        const cookie = getConsentCookie();
+        previousPreferenceCookie = cookie.preference;
+    }
+
+    /**
+     * If checked, consent to analytics and initiate attribution.
+     */
+    if (checked) {
+        setConsentCookie({
+            analytics: true,
+            preference:
+                previousPreferenceCookie !== undefined &&
+                previousPreferenceCookie !== null
+                    ? previousPreferenceCookie
+                    : true
+        });
+        window.Mozilla.StubAttribution.init(() => {
+            /**
+             * Rebind event listeners only after attribution
+             * request has been successful.
+             */
+            MarketingOptOut.bindEvents();
+        });
+    } else {
+        /**
+         * Else set a cookie that rejects analytics.
+         * Remove all existing attribution data.
+         */
+        setConsentCookie({
+            analytics: false,
+            preference:
+                previousPreferenceCookie !== undefined &&
+                previousPreferenceCookie !== null
+                    ? previousPreferenceCookie
+                    : true
+        });
+        window.Mozilla.StubAttribution.removeAttributionData();
+        MarketingOptOut.bindEvents();
+    }
+};
+
+/**
+ * Handles checkbox change event. Because checkbox state must be
+ * synced between all checkboxes on the page, we must temporarily
+ * unbind event listeners to avoid triggering multiple change
+ * events at once.
+ * @param {Object} e - change event object.
+ */
+MarketingOptOut.handleChangeEvent = (e) => {
+    MarketingOptOut.unbindEvents();
+    MarketingOptOut.setCheckboxState(e.target.checked);
+    MarketingOptOut.processAttributionRequest(e.target.checked);
+};
+
+/**
+ * Unbinds checkbox change event listeners and disables
+ * inputs when unbound.
+ */
+MarketingOptOut.unbindEvents = () => {
+    const checkboxes = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].removeEventListener(
+            'change',
+            MarketingOptOut.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = true;
+    }
+};
+
+/**
+ * Binds checkbox change event listeners and removes
+ * disabled states on inputs when bound.
+ */
+MarketingOptOut.bindEvents = () => {
+    const checkboxes = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].addEventListener(
+            'change',
+            MarketingOptOut.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = false;
+    }
+};
+
+/**
+ * Sets the checked state of all checkbox inputs.
+ * @param {Boolean} checked state
+ */
+MarketingOptOut.setCheckboxState = (checked) => {
+    const checkboxes = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].checked = checked;
+    }
+};
+
+/**
+ * Determines if marketing opt-out checkboxes should
+ * be displayed.
+ * @returns {Boolean}
+ */
+MarketingOptOut.shouldShowCheckbox = () => {
+    let show = false;
+
+    /**
+     * Has the visitor set a browser-level privacy flag?
+     */
+    if (dntEnabled() || gpcEnabled()) {
+        show = false;
+    } else if (window.Mozilla.StubAttribution.hasCookie()) {
+        /**
+         * Does the visitor have an existing attribution cookie?
+         */
+        show = true;
+    } else if (hasConsentCookie()) {
+        /**
+         * Does the visitor have an existing analytics consent cookie?
+         */
+        const cookie = getConsentCookie();
+        show = cookie.analytics ? true : false;
+    } else {
+        /**
+         * Is the visitor in EU/EAA?
+         */
+        show = consentRequired() ? false : true;
+    }
+
+    return show;
+};
+
+/**
+ * Displays checkboxes via CSS by removing the `hidden`
+ * class on their corresponding `<label>` parent elements.
+ * Also sets `checked=true` to enforce opt-out state.
+ */
+MarketingOptOut.showCheckbox = () => {
+    const labels = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-label'
+    );
+
+    for (let i = 0; i < labels.length; i++) {
+        labels[i].classList.remove('hidden');
+        labels[i].querySelector('.marketing-opt-out-checkbox-input').checked =
+            true;
+    }
+};
+
+/**
+ * Determines if marketing opt-out logic should run,
+ * based on existing attribution requirements.
+ * @returns {Boolean}
+ */
+MarketingOptOut.meetsRequirements = () => {
+    return (
+        typeof window.Mozilla.StubAttribution !== 'undefined' &&
+        window.Mozilla.StubAttribution.meetsRequirements()
+    );
+};
+
+/**
+ * Initializes marketing opt-out flow
+ * @returns {Boolean}.
+ */
+MarketingOptOut.init = () => {
+    if (!MarketingOptOut.meetsRequirements()) {
+        return false;
+    }
+
+    if (MarketingOptOut.shouldShowCheckbox()) {
+        MarketingOptOut.showCheckbox();
+        MarketingOptOut.bindEvents();
+        return true;
+    }
+
+    return false;
+};
+
+export default MarketingOptOut;

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -275,6 +275,12 @@
         "css/firefox/browsers/desktop/platform.scss"
       ],
       "name": "firefox_desktop_platform"
+    },
+    {
+      "files": [
+        "css/firefox/landing/get/marketing-opt-out.scss"
+      ],
+      "name": "firefox_marketing_opt_out"
     }
   ],
   "js": [
@@ -511,6 +517,12 @@
         "js/firefox/browsers/mobile-index.js"
       ],
       "name": "firefox-mobile-index"
+    },
+    {
+      "files": [
+        "js/firefox/landing/get/marketing-opt-out-init.es6.js"
+      ],
+      "name": "firefox_marketing_opt_out"
     }
   ]
 }

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -87,9 +87,11 @@
       <div class="c-block-body">
         <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox') }}</h1>
           <h2 class="mzp-has-zap-7">{{ ftl('firefox-desktop-download-get-the-browser') }}</h2>
-          <p>{{ ftl('firefox-desktop-download-no-shady') }}</p>
+          <p>{{ ftl('firefox-desktop-download-fast-reliable-private', fallback='firefox-desktop-download-no-shady') }}</p>
         <div class="c-intro-download">
-          {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+          {% block primary_cta %}
+            {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+          {% endblock %}
 
           <div class="c-intro-download-alt"><a href="{{ firefox_url('desktop', 'all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 
@@ -234,7 +236,7 @@
 {% endif %}
 
   <section class="t-highlights">
-    <h2 class="mzp-c-section-heading mzp-has-zap-11">{{ ftl('firefox-desktop-download-do-what-you-do') }}</h2>
+    <h2 class="mzp-c-section-heading mzp-has-zap-11">{{ ftl('firefox-desktop-download-do-what-you-do-v2', fallback='firefox-desktop-download-do-what-you-do') }}</h2>
 
     <div class="t-block c-block l-reversed">
       <div class="c-block-container">
@@ -384,7 +386,9 @@
           </ul>
         </div>
       </div>
-      {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
+      {% block features_cta %}
+        {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
+      {% endblock %}
 
     </div>
   </section>
@@ -496,7 +500,7 @@
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-your-privacy-comes') }}</h3>
         {% set privacy_href = 'https://www.mozilla.org/' + LANG + '/privacy/' + referrals %}
         {% set internet_attrs = 'href="%s" data-cta-text="Personal Data Promise"'|safe|format(privacy_href) %}
-        <p>{{ ftl('firefox-desktop-download-as-the-internet', attrs=internet_attrs) }}</p>
+        <p>{{ ftl('firefox-desktop-download-as-the-internet-v2', fallback='firefox-desktop-download-as-the-internet', attrs=internet_attrs) }}</p>
       </div>
     </div>
   </section>
@@ -547,7 +551,9 @@
         <p>{{ ftl('firefox-desktop-download-from-watching-a') }}</p>
       </div>
     </div>
-    {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+    {% block discover_cta %}
+      {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+    {% endblock %}
   </section>
 
   <section class="c-support">

--- a/springfield/firefox/templates/firefox/landing/get.html
+++ b/springfield/firefox/templates/firefox/landing/get.html
@@ -1,0 +1,51 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/download/desktop/download.html" %}
+
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_marketing_opt_out') }}
+{% endblock %}
+
+{% macro marketing_opt_out_checkbox(id='marketing-opt-out') -%}
+  <label for="{{ id }}" class="marketing-opt-out-checkbox-label hidden">
+    <input type="checkbox" id="{{ id }}" class="marketing-opt-out-checkbox-input">
+    <span class="marketing-opt-out-text">
+      {% set attrs = 'href="https://support.mozilla.org/kb/marketing-data" target="_blank" rel="noopener"' %}
+      {{ ftl('download-button-share-how-you-discovered', attrs=attrs)}}
+    </span>
+  </label>
+{%- endmacro %}
+
+{% block primary_cta %}
+  {{ marketing_opt_out_checkbox(id='marketing-opt-out-primary') }}
+  {{ download_firefox_thanks(dom_id='download-primary', locale_in_transition=True, download_location='primary cta') }}
+{% endblock %}
+
+{% block features_cta %}
+  {{ marketing_opt_out_checkbox(id='marketing-opt-out-features') }}
+  {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
+{% endblock %}
+
+{% block discover_cta %}
+  {{ marketing_opt_out_checkbox(id='marketing-opt-out-discover') }}
+  {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    {{ super() }}
+    <!--[if IE 9]><!-->
+      {# Ensure opt-out runs in IE 10 / 11 since we also support stub attribution for those browsers. #}
+      {{ js_bundle('firefox_marketing_opt_out') }}
+    <!--<![endif]-->
+  {% endif %}
+{% endblock %}

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -107,4 +107,5 @@ urlpatterns = (
     path("browsers/desktop/linux/", views.PlatformViewLinux.as_view(), name="firefox.browsers.desktop.linux"),
     path("browsers/desktop/mac/", views.PlatformViewMac.as_view(), name="firefox.browsers.desktop.mac"),
     path("browsers/desktop/windows/", views.PlatformViewWindows.as_view(), name="firefox.browsers.desktop.windows"),
+    page("landing/get/", "firefox/landing/get.html", ftl_files="firefox/download/desktop"),
 )

--- a/tests/unit/spec/base/stub-attribution/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution/stub-attribution.js
@@ -1220,37 +1220,174 @@ describe('stub-attribution.js', function () {
                 GA4_CLIENT_ID
             );
         });
-    });
 
-    it('should return null if GA4 client ID is not found', function () {
-        const dataLayer = [
-            {
-                event: 'page-id-loaded',
-                pageId: 'Homepage',
-                'gtm.uniqueEventId': 1
-            },
-            {
-                'gtm.start': 1678700450438,
-                event: 'gtm.js',
-                'gtm.uniqueEventId': 2
-            },
-            {
-                event: 'gtm.dom',
-                'gtm.uniqueEventId': 12
-            },
-            {
-                event: 'gtm.load',
-                'gtm.uniqueEventId': 13
-            }
-        ];
+        it('should return null if GA4 client ID is not found', function () {
+            const dataLayer = [
+                {
+                    event: 'page-id-loaded',
+                    pageId: 'Homepage',
+                    'gtm.uniqueEventId': 1
+                },
+                {
+                    'gtm.start': 1678700450438,
+                    event: 'gtm.js',
+                    'gtm.uniqueEventId': 2
+                },
+                {
+                    event: 'gtm.dom',
+                    'gtm.uniqueEventId': 12
+                },
+                {
+                    event: 'gtm.load',
+                    'gtm.uniqueEventId': 13
+                }
+            ];
 
-        expect(Mozilla.StubAttribution.getGtagClientID(dataLayer)).toBeNull();
-    });
-
-    it('should return a null if accessing GTAG API throws an error', function () {
-        window.dataLayer = sinon.stub().throws(function () {
-            return new Error();
+            expect(
+                Mozilla.StubAttribution.getGtagClientID(dataLayer)
+            ).toBeNull();
         });
-        expect(Mozilla.StubAttribution.getGtagClientID()).toBeNull();
+
+        it('should return a null if accessing GTAG API throws an error', function () {
+            window.dataLayer = sinon.stub().throws(function () {
+                return new Error();
+            });
+            expect(Mozilla.StubAttribution.getGtagClientID()).toBeNull();
+        });
+    });
+
+    describe('removeAttributionData', function () {
+        beforeEach(function () {
+            const winUrl =
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const win64Url =
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const transitionalUrl =
+                'https://www.mozilla.org/firefox/download/thanks/';
+            const winStageUrl =
+                'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const win64StageUrl =
+                'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const winDevUrl =
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const win64DevUrl =
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const macOSNightlyUrl =
+                'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const macOSBetaUrl =
+                'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const macOSDevUrl =
+                'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const macOSEsrUrl =
+                'https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+            const macOSUrl =
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig';
+
+            const downloadMarkup = `<ul class="download-list">
+                    <li><a id="link-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winUrl}">Download</a></li>
+                    <li><a id="link-direct-win" class="download-link" data-download-version="win" href="${winUrl}">Download</a></li>
+                    <li><a id="link-direct-win64" class="download-link" data-download-version="win64" href="${win64Url}">Download</a></li>
+                    <li><a id="link-stage-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winStageUrl}">Download</a></li>
+                    <li><a id="link-stage-direct-win" class="download-link" data-download-version="win" href="${winStageUrl}">Download</a></li>
+                    <li><a id="link-stage-direct-win64" class="download-link" data-download-version="win64" href="${win64StageUrl}">Download</a></li>
+                    <li><a id="link-dev-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winDevUrl}">Download</a></li>
+                    <li><a id="link-dev-direct-win" class="download-link" data-download-version="win" href="${winDevUrl}">Download</a></li>
+                    <li><a id="link-dev-direct-win64" class="download-link" data-download-version="win64" href="${win64DevUrl}">Download</a></li>
+                    <li><a id="link-macos-nightly" class="download-link" data-download-version="osx" href="${macOSNightlyUrl}">Download</a></li>
+                    <li><a id="link-macos-beta" class="download-link" data-download-version="osx" href="${macOSBetaUrl}">Download</a></li>
+                    <li><a id="link-macos-dev" class="download-link" data-download-version="osx" href="${macOSDevUrl}">Download</a></li>
+                    <li><a id="link-macos-esr" class="download-link" data-download-version="osx" href="${macOSEsrUrl}">Download</a></li>
+                    <li><a id="link-macos" class="download-link" data-download-version="osx" href="${macOSUrl}">Download</a></li>
+                </ul>`;
+            document.body.insertAdjacentHTML('beforeend', downloadMarkup);
+        });
+
+        afterEach(function () {
+            const content = document.querySelector('.download-list');
+            content.parentNode.removeChild(content);
+        });
+
+        it('should existing attribution cookies', function () {
+            const data = {
+                attribution_code: 'foo',
+                attribution_sig: 'bar'
+            };
+
+            Mozilla.StubAttribution.setCookie(data);
+            expect(Mozilla.StubAttribution.hasCookie()).toBeTrue();
+
+            Mozilla.StubAttribution.removeAttributionData();
+
+            // attribution cookies should be removed
+            expect(Mozilla.StubAttribution.hasCookie()).toBeFalse();
+
+            // prod download links cleaned
+            expect(
+                document
+                    .getElementById('link-transitional')
+                    .getAttribute('data-direct-link')
+            ).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US'
+            );
+            expect(document.getElementById('link-direct-win').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US'
+            );
+            expect(document.getElementById('link-direct-win64').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US'
+            );
+
+            // stage download links cleaned
+            expect(
+                document
+                    .getElementById('link-stage-transitional')
+                    .getAttribute('data-direct-link')
+            ).toEqual(
+                'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win&lang=en-US'
+            );
+            expect(
+                document.getElementById('link-stage-direct-win').href
+            ).toEqual(
+                'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win&lang=en-US'
+            );
+            expect(
+                document.getElementById('link-stage-direct-win64').href
+            ).toEqual(
+                'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win64&lang=en-US'
+            );
+
+            // dev download links cleaned
+            expect(
+                document
+                    .getElementById('link-dev-transitional')
+                    .getAttribute('data-direct-link')
+            ).toEqual(
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US'
+            );
+            expect(document.getElementById('link-dev-direct-win').href).toEqual(
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US'
+            );
+            expect(
+                document.getElementById('link-dev-direct-win64').href
+            ).toEqual(
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US'
+            );
+
+            // macOS links cleaned
+            expect(document.getElementById('link-macos-nightly').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US'
+            );
+            expect(document.getElementById('link-macos-beta').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US'
+            );
+            expect(document.getElementById('link-macos-dev').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US'
+            );
+            expect(document.getElementById('link-macos-esr').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US'
+            );
+            expect(document.getElementById('link-macos').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US'
+            );
+        });
     });
 });

--- a/tests/unit/spec/firefox/landing/marketing-opt-out.js
+++ b/tests/unit/spec/firefox/landing/marketing-opt-out.js
@@ -1,0 +1,343 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import MarketingOptOut from '../../../../../media/js/firefox/landing/get/marketing-opt-out.es6';
+
+const labelSelector = '.marketing-opt-out-checkbox-label.hidden';
+const checkboxSelector = '.marketing-opt-out-checkbox-input:checked';
+
+describe('marketing-opt-out.es6.js', function () {
+    beforeEach(function () {
+        const optOut = `<div id="opt-out">
+            <label for="marketing-opt-out-primary" class="marketing-opt-out-checkbox-label hidden">
+                <input type="checkbox" id="marketing-opt-out-primary" class="marketing-opt-out-checkbox-input">.
+            </label>
+            <label for="marketing-opt-out-secondary" class="marketing-opt-out-checkbox-label hidden">
+                <input type="checkbox" id="marketing-opt-out-secondary" class="marketing-opt-out-checkbox-input">.
+            </label>
+        </div>`;
+
+        document.body.insertAdjacentHTML('beforeend', optOut);
+    });
+
+    afterEach(function () {
+        const optOut = document.getElementById('opt-out');
+        optOut.parentNode.removeChild(optOut);
+
+        document
+            .getElementsByTagName('html')[0]
+            .removeAttribute('data-needs-consent');
+    });
+
+    describe('init()', function () {
+        it('should return false if attribution requirements are not satisfied', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(false);
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeFalse();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(2);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return false if GPC is enabled', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeFalse();
+            delete window.Mozilla.gpcEnabled;
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(2);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return false if DNT is enabled', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeFalse();
+            delete window.Mozilla.dntEnabled;
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(2);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return true if attribution cookie exists', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'hasCookie').and.returnValue(
+                true
+            );
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeTrue();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(0);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+        });
+
+        it('should return true if consent cookie accepts analytics', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'hasCookie').and.returnValue(
+                false
+            );
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(true);
+
+            const obj = {
+                analytics: true,
+                preference: true
+            };
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify(obj)
+            );
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeTrue();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(0);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+        });
+
+        it('should return false if consent cookie rejects analytics', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'hasCookie').and.returnValue(
+                false
+            );
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(true);
+
+            const obj = {
+                analytics: false,
+                preference: true
+            };
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify(obj)
+            );
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeFalse();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(2);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return false if visitor is in EU/EAA country', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'hasCookie').and.returnValue(
+                false
+            );
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(false);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'True');
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeFalse();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(2);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return true if visitor is outside EU/EAA', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'hasCookie').and.returnValue(
+                false
+            );
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(false);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'False');
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeTrue();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(0);
+
+            const checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+        });
+
+        it('should remove attribution data and reject analytics when visitor unchecks input', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(MarketingOptOut, 'shouldShowCheckbox').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'removeAttributionData');
+            spyOn(window.Mozilla.Cookies, 'setItem');
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeTrue();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(0);
+
+            let checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+
+            document.getElementById('marketing-opt-out-primary').click();
+            expect(
+                window.Mozilla.StubAttribution.removeAttributionData
+            ).toHaveBeenCalled();
+            expect(window.Mozilla.Cookies.setItem).toHaveBeenCalledWith(
+                'moz-consent-pref',
+                '{"analytics":false,"preference":true}',
+                jasmine.any(String),
+                '/',
+                null,
+                false,
+                'lax'
+            );
+
+            checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should opt back into analytics and init attribution if visitor re-checks input', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(MarketingOptOut, 'shouldShowCheckbox').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'init');
+            spyOn(window.Mozilla.Cookies, 'setItem');
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeTrue();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(0);
+
+            let checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+
+            // Opt out
+            document.getElementById('marketing-opt-out-primary').click();
+
+            checkboxes = document.querySelectorAll(
+                '.marketing-opt-out-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+
+            // Opt in
+            document.getElementById('marketing-opt-out-secondary').click();
+            expect(window.Mozilla.StubAttribution.init).toHaveBeenCalled();
+            expect(window.Mozilla.Cookies.setItem).toHaveBeenCalledWith(
+                'moz-consent-pref',
+                '{"analytics":true,"preference":true}',
+                jasmine.any(String),
+                '/',
+                null,
+                false,
+                'lax'
+            );
+
+            checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+        });
+
+        it('should remember a previous preference cookie choice if it exists', function () {
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(MarketingOptOut, 'shouldShowCheckbox').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'hasCookie').and.returnValue(
+                false
+            );
+            spyOn(window.Mozilla.StubAttribution, 'removeAttributionData');
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'setItem');
+
+            const obj = {
+                analytics: true,
+                preference: false
+            };
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify(obj)
+            );
+
+            const result = MarketingOptOut.init();
+            expect(result).toBeTrue();
+
+            const labels = document.querySelectorAll(labelSelector);
+            expect(labels.length).toEqual(0);
+
+            let checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(2);
+
+            document.getElementById('marketing-opt-out-primary').click();
+            expect(
+                window.Mozilla.StubAttribution.removeAttributionData
+            ).toHaveBeenCalled();
+            expect(window.Mozilla.Cookies.setItem).toHaveBeenCalledWith(
+                'moz-consent-pref',
+                '{"analytics":false,"preference":false}',
+                jasmine.any(String),
+                '/',
+                null,
+                false,
+                'lax'
+            );
+
+            checkboxes = document.querySelectorAll(checkboxSelector);
+            expect(checkboxes.length).toEqual(0);
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Migrates marketing ToS opt-out landing page from bedrock.

## Significant changes and points to review

See https://github.com/mozilla/bedrock/pull/15992 for page specific behavior  to test.

## Issue / Bugzilla link

#128

## Testing

http://localhost:8000/en-US/landing/get/