### PR TITLE
(feat) Port unsupported-browsers page from Bedrock

### DIFF
--- a/media/css/firefox/unsupported-systems.scss
+++ b/media/css/firefox/unsupported-systems.scss
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.c-header-logo {
+    @media #{$mq-sm} {
+        margin-top: $layout-sm;
+    }
+}
+
+.c-header-main {
+    @include text-title-md;
+    margin-top: $spacing-lg;
+}
+
+.c-header-subhead {
+    @include text-body-lg;
+}
+
+.c-help-block {
+    margin: $layout-md 0;
+}
+
+.c-help-block-title {
+    @include text-title-xs;
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -154,6 +154,12 @@
     },
     {
       "files": [
+        "css/firefox/unsupported-systems.scss"
+      ],
+      "name": "firefox_unsupported_systems"
+    },
+    {
+      "files": [
         "css/firefox/default/landing.scss"
       ],
       "name": "firefox-default-landing"

--- a/springfield/firefox/templates/firefox/unsupported-systems.html
+++ b/springfield/firefox/templates/firefox/unsupported-systems.html
@@ -1,0 +1,48 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "base-protocol.html" %}
+
+{% block page_title %}Unsupported Systems{% endblock %}
+{% block page_desc %}We’re sorry to report this, but your computer does not meet the minimum system requirements to run this version.{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-emphasis-box') }}
+  {{ css_bundle('firefox_unsupported_systems') }}
+{% endblock %}
+
+{% block content %}
+<main class="mzp-l-content mzp-t-content-md">
+  <header class="">
+    <a href="{{ url('firefox') }}"><img src="{{ static('protocol/img/logos/firefox/browser/logo-word-hor.svg') }}" alt="Firefox" width="347" height="64"></a>
+    <h1 class="c-header-main">Thanks for choosing Firefox!</h1>
+    <p class="c-header-subhead">We’re sorry to report this, but your computer does not meet the minimum system requirements to run this version.</p>
+  </header>
+
+  <section class="c-help-block mzp-c-emphasis-box">
+    <h2 class="c-help-block-title">Need <span>Help?</span></h2>
+    <p>Our Support page has plenty of answers, including full instructions for downloading and installing Firefox and a live chat feature to guide you through any tricky spots.</p>
+    <a href="https://support.mozilla.org/products/firefox">Visit Firefox Support</a>
+  </section>
+
+  <section class="c-help-block">
+    <h2 class="c-help-block-title">For more information on supported systems</h2>
+    <a href="{{ url('firefox.sysreq') }}">View System Requirements</a>
+  </section>
+
+  <div class="c-help-block">
+    <p>
+      To make your computer more secure, we recommend upgrading your operating system to a newer version
+      as soon as possible (plus, you’ll be able to use Firefox!). But, if you can’t do so, here are some
+      alternate browsers that should be compatible with your current system:
+    </p>
+    <ul class="mzp-u-list-styled">
+      <li><a href="https://www.opera.com/">Opera</a> for Windows 95 and above and Mac OS 10.3 and above</li>
+      <li><a href="http://www.icab.de/">iCab</a> for Mac OS 10.3 and above</li>
+    </ul>
+  </div>
+</main>
+{% endblock %}

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -108,6 +108,7 @@ urlpatterns = (
     path("browsers/desktop/mac/", views.PlatformViewMac.as_view(), name="firefox.browsers.desktop.mac"),
     path("browsers/desktop/windows/", views.PlatformViewWindows.as_view(), name="firefox.browsers.desktop.windows"),
     page("browsers/mobile/get-app/", "firefox/browsers/mobile/get-app.html", ftl_files=["firefox/browsers/mobile/get-app"]),
+    page("browsers/unsupported-systems/", "firefox/unsupported-systems.html"),
     page("landing/get/", "firefox/landing/get.html", ftl_files="firefox/download/desktop"),
     page(
         "compare/",


### PR DESCRIPTION
From www.mozilla.org/firefox/unsupported-systems/ to /browsers/unsupported-systems

Note that this page was not localised in Bedrock, so isn't localised here.

## Significant changes and points to review

Instead of pointing to /new/ (which doesn't exist in Springfield), I'm pointing to the root page, ahead of https://github.com/mozmeao/springfield/issues/116 landing

## Issue / Bugzilla link

Part of #128

## Testing

Compare http://localhost:8000/en-US/browsers/unsupported-systems/ with https://www.mozilla.org/en-US/firefox/unsupported-systems/
