### PR TITLE
Set GH deployment env based on CI env outputs

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -162,7 +162,7 @@ jobs:
   upload_static_assets:
     name: Upload static assets
     runs-on: ubuntu-latest
-    environment: build
+    environment: ${{ needs.push_image_to_gar.outputs.deployment_env }}
     needs: [build_and_publish_public_images, push_image_to_gar]
     permissions:
       contents: read


### PR DESCRIPTION
## One-line summary

Attempt to reinstate individual deployment environments on GitHub and their reporting from Actions (+to properly categorize pushes based on dev-, stage-, test-, and prod-triggered events).

## Significant changes and points to review

Before trying on bedrock https://github.com/mozilla/bedrock/issues/16266 figured I should attempt being brave here;) It's based on prior art from the CD pipeline author elsewhere [mozilla/kitsune#L128](https://github.com/mozilla/kitsune/blob/1.2.10/.github/workflows/build-and-push.yml#L128) and makes sense comparing the two repos' deployment reporting.

The value comes from the `*_image_tag` steps above:
https://github.com/mozmeao/springfield/blob/0175650c453f448ebd29cfa6f656917fc520f1b0/.github/workflows/build-and-push.yml#L78-L81

and is consumed in this job anyways on the cli:
https://github.com/mozmeao/springfield/blob/0175650c453f448ebd29cfa6f656917fc520f1b0/.github/workflows/build-and-push.yml#L211-L212

which already has the preceding job in `needs:` for good measure.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16266

## Testing

With the envs basically not used for anything here on GH (all the CD is done elsewhere), being empty, having no rules etc., the idea is the CI should be able to create them and not trip over some branch protections and such. — Basically upon landing in main the "dev" env should be listed for the trigger instead of "build" once the CI finishes pushing the images.