### PR TITLE
Update appstore test to gb URLs

### DIFF
--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}

--- a/tests/playwright/specs/products/firefox/firefox-home.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-home.spec.js
@@ -67,7 +67,7 @@ test.describe(
             await expect(iosMenuLink).toBeVisible();
             await expect(iosMenuLink).toHaveAttribute(
                 'href',
-                /^https:\/\/apps.apple.com\/us\/app\/apple-store\//
+                /^https:\/\/apps.apple.com\/gb\/app\/apple-store\//
             );
 
             // close menu


### PR DESCRIPTION
## One-line summary

Following up from #154, the locale would change the appstore links, too.

## Significant changes and points to review

To point to a different version of the page, a different locale is used. This renders some URLs with different values.