### PR TITLE
(feat) Move set-as-default pages to below a landing/ path

### DIFF
--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -479,7 +479,7 @@ class TestFirefoxGA(TestCase):
 # Issue 13253: Ensure that Firefox can continue to refer to this URL.
 class TestFirefoxSetAsDefaultThanks(TestCase):
     def test_firefox_set_as_default_thanks(self):
-        resp = self.client.get("/default/thanks/", follow=True)
+        resp = self.client.get("/landing/set-as-default/thanks/", follow=True)
         assert resp.status_code == 200, "Ensure this URL continues to work, see issue 13253"
         assert resp.templates[0].name == "firefox/default/thanks.html"
 

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -96,9 +96,9 @@ urlpatterns = (
     path("stub_attribution_code/", views.stub_attribution_code, name="firefox.stub_attribution_code"),
     # Issue 8432
     # Issue 13253: Ensure that Firefox can continue to refer to this URL.
-    page("default/thanks/", "firefox/default/thanks.html", ftl_files="firefox/set-as-default/thanks"),
+    page("landing/set-as-default/thanks/", "firefox/default/thanks.html", ftl_files="firefox/set-as-default/thanks"),
     # Default browser campaign
-    page("default/", "firefox/default/landing.html", ftl_files="firefox/set-as-default/landing"),
+    page("landing/set-as-default/", "firefox/default/landing.html", ftl_files="firefox/set-as-default/landing"),
     page("analytics-tests/", "firefox/analytics-tests/ga-index.html"),
     page("browsers/mobile/", "firefox/browsers/mobile/index.html", ftl_files=["firefox/browsers/mobile/index"]),
     page("browsers/mobile/android/", "firefox/browsers/mobile/android.html", ftl_files=["firefox/browsers/mobile/android"]),


### PR DESCRIPTION
URL path change for the already-ported set-as-default pages

L10N files are also already set up.

## Issue / Bugzilla link

#128

## Testing

* http://localhost:8000/en-US/landing/set-as-default/ links to http://localhost:8000/en-US/landing/set-as-default/thanks/
* http://localhost:8000/it/landing/set-as-default/ links to http://localhost:8000/it/landing/set-as-default/thanks/
