### PR TITLE
Remove unused IE sanity tests config

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -42,7 +42,7 @@ jobs:
           - LABEL: test-ie-saucelabs
             BROWSER_NAME: internet explorer
             DRIVER: SauceLabs
-            MARK_EXPRESSION: "smoke or sanity"
+            MARK_EXPRESSION: smoke
             PLATFORM: Windows 10
             PYTEST_PROCESSES: 8
           - LABEL: test-headless

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ testpaths =
 markers =
     download
     headless
-    sanity
     skip_if_firefox
     skip_if_internet_explorer
     skip_if_not_firefox


### PR DESCRIPTION
## One-line summary

Clean up after removed Selenium IE sanity tests.

## Significant changes and points to review

The tests are all gone. This only cleans up the leftover markers configured to run.