### PR TITLE
Remove tertiary navs (Fix #158)

### DIFF
--- a/l10n/en/sub_navigation.ftl
+++ b/l10n/en/sub_navigation.ftl
@@ -8,6 +8,7 @@ sub-navigation-firefox = { -brand-name-firefox }
 sub-navigation-compare-browsers = Compare Browsers
 sub-navigation-firefox-for-desktop = { -brand-name-firefox } for Desktop
 sub-navigation-release-notes = Release Notes
+sub-navigation-release-channels = Release Channels
 sub-navigation-desktop = Desktop
 sub-navigation-mobile = Mobile
 sub-navigation-android = { -brand-name-android }

--- a/springfield/firefox/templates/firefox/browsers/compare/base-article.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/base-article.html
@@ -19,10 +19,6 @@
 
 {% block page_title %}{{ self.article_title() }}{% endblock %}
 
-{% block sub_navigation %}
-  {% include 'firefox/browsers/compare/includes/subnav.html' %}
-{% endblock %}
-
 {% block content %}
 <div class="compare-article-container">
   <div class="mzp-l-content mzp-t-content-md">

--- a/springfield/firefox/templates/firefox/browsers/compare/index.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/index.html
@@ -30,10 +30,6 @@
 
 {% block body_class %}compare-index{% endblock %}
 
-{% block sub_navigation %}
-  {% include 'firefox/includes/sub-nav-firefox.html' %}
-{% endblock %}
-
 {% block content %}
 {{ callout (
   title=self.page_title(),

--- a/springfield/firefox/templates/firefox/browsers/desktop/base.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/base.html
@@ -72,10 +72,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block sub_navigation %}
- {% include '/firefox/includes/desktop-platform-sub-nav.html' %}
-{% endblock %}
-
 {% block content %}
 <main class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
   {% call split(

--- a/springfield/firefox/templates/firefox/browsers/desktop/index.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/index.html
@@ -42,9 +42,6 @@
 {% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
 {% set _entrypoint = 'firefox.com-firefox-desktop' %}
 
-{% block sub_navigation %}
-{% endblock %}
-
 {% block content %}
 <main>
   <header class="c-main-header mzp-l-content mzp-t-content-md">

--- a/springfield/firefox/templates/firefox/browsers/mobile/android.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/android.html
@@ -49,10 +49,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block sub_navigation %}
-  {% include 'firefox/includes/sub-nav-firefox.html' %}
-{% endblock %}
-
 {% block content %}
 <main>
   {% call split(

--- a/springfield/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/focus.html
@@ -45,10 +45,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block sub_navigation %}
-  {% include 'firefox/includes/sub-nav-firefox.html' %}
-{% endblock %}
-
 {% block content %}
 <main>
   {% call split(

--- a/springfield/firefox/templates/firefox/browsers/mobile/get-app.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/get-app.html
@@ -29,10 +29,6 @@
 {% set android_url = play_store_url('firefox', 'firefox-browsers-mobile-get-app') %}
 {% set ios_url = app_store_url('firefox', 'firefox-browsers-mobile-get-app') %}
 
-{% block sub_navigation %}
-  {% include 'firefox/includes/sub-nav-firefox.html' %}
-{% endblock %}
-
 {% block content %}
 <main class="mzp-l-content mzp-t-content-md mzp-t-firefox">
   <section>

--- a/springfield/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/ios.html
@@ -49,10 +49,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block sub_navigation %}
-  {% include 'firefox/includes/sub-nav-firefox.html' %}
-{% endblock %}
-
 {% block content %}
 <main>
   {% call split(

--- a/springfield/firefox/templates/firefox/channel/base.html
+++ b/springfield/firefox/templates/firefox/channel/base.html
@@ -23,10 +23,9 @@
 {% block sub_navigation %}
 {{ sub_nav(
   title={
-    'text':  ftl('sub-navigation-firefox'),
-    'href':  url('firefox'),
+    'text':  ftl('sub-navigation-release-channels'),
+    'href':  url('firefox.channel.desktop'),
     'cta_name': "Firefox",
-    'icon': static('protocol/img/logos/firefox/browser/logo.svg')
   },
   links=[
   {

--- a/springfield/firefox/templates/firefox/developer/index.html
+++ b/springfield/firefox/templates/firefox/developer/index.html
@@ -32,34 +32,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block sub_navigation %}
-  {{ sub_nav(
-    title={
-      'text':  ftl('sub-navigation-firefox'),
-      'href':  url('firefox'),
-      'icon':  static('protocol/img/logos/firefox/browser/logo.svg'),
-      'cta_name': 'Firefox'
-    },
-    links=[
-      {
-        'text':  ftl('sub-navigation-enterprise'),
-        'href':  url('firefox.enterprise.index'),
-        'cta_name': 'Enterprise'
-      },
-      {
-        'text':  ftl('sub-navigation-nightly-and-beta'),
-        'href':  url('firefox.channel.desktop'),
-        'cta_name': 'Nightly and Beta'
-      },
-      {
-        'text':  ftl('sub-navigation-all-languages', fallback='download-button-systems-languages'),
-        'href':  url('firefox.all'),
-        'cta_name': 'All Languages'
-      }
-    ]
-  ) }}
-{% endblock %}
-
 {% block content %}
 <main>
   <div class="mzp-l-content mzp-t-content-md t-center">

--- a/springfield/firefox/templates/firefox/download/basic/base_download.html
+++ b/springfield/firefox/templates/firefox/download/basic/base_download.html
@@ -48,9 +48,6 @@
   {% endif %}
 {% endblock %}
 
-{% block sub_navigation %}
-{% endblock %}
-
 {% block content %}
 <main class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
   {% call split(

--- a/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
@@ -30,9 +30,6 @@
    <![endif]-->
  {% endblock %}
 
- {% block sub_navigation %}
- {% endblock %}
-
  {% block content %}
 
  {% if outdated %}

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -59,9 +59,6 @@
   ) }}
 {%- endmacro %}
 
-{% block sub_navigation %}
-{% endblock %}
-
 {% block content %}
 
 {% set show_mr106_browser_promo = switch('download-firefox-mr106-promo', ['en-US', 'en-CA', 'en-GB', 'fr', 'de']) %}

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -27,9 +27,6 @@
   {% endwith %}
 {% endblock %}
 
-{% block sub_navigation %}
-{% endblock %}
-
 {% block content %}
 <main>
   {% call split(

--- a/springfield/firefox/templates/firefox/features/base-article.html
+++ b/springfield/firefox/templates/firefox/features/base-article.html
@@ -19,6 +19,7 @@
 {% block page_title %}{{ self.article_title() }}{% endblock %}
 
 {% block content %}
+{# <!-- hiding breadcrumbs temporarily, but preserving code so we can have them back -->
 <nav class="mzp-c-breadcrumb">
   <ol class="mzp-c-breadcrumb-list">
     <li class="mzp-c-breadcrumb-item">
@@ -33,6 +34,7 @@
     </li>
   </ol>
 </nav>
+#}
 
 <div class="feature-article-container">
   <div class="mzp-l-content mzp-t-content-md">

--- a/springfield/firefox/templates/firefox/features/cms/index.html
+++ b/springfield/firefox/templates/firefox/features/cms/index.html
@@ -22,9 +22,6 @@
   {{ css_bundle('firefox-features-index')}}
 {% endblock %}
 
-{% block sub_navigation %}
-{% endblock %}
-
 {% block content %}
   {{ callout (
     title=page.title,

--- a/springfield/firefox/templates/firefox/features/index.html
+++ b/springfield/firefox/templates/firefox/features/index.html
@@ -32,9 +32,6 @@
 
 {% block body_class %}features-index{% endblock %}
 
-{% block sub_navigation %}
-{% endblock %}
-
 {% block content %}
 {{ callout (
   title=self.page_title(),

--- a/tests/playwright/specs/a11y/components/sub-navigation.spec.js
+++ b/tests/playwright/specs/a11y/components/sub-navigation.spec.js
@@ -10,7 +10,7 @@ const openPage = require('../../../scripts/open-page');
 const { createReport, scanPageElement } = require('../includes/helpers');
 const { subNavigationLocator } = require('../includes/locators');
 const { test, expect } = require('@playwright/test');
-const testURL = '/en-US/compare/chrome';
+const testURL = '/en-US/channel/desktop';
 
 test.describe(
     'Sub-navigation (desktop)',


### PR DESCRIPTION
## One-line summary

Removes most tertiary navs

## Significant changes and points to review

I'll remove it from the download, developer, feature, and compare pages as their child pages can be found either from their parent page or from the header/footer nav.

I'm going to leave channel and release notes ones as there are no other ways to navigate to the other pages without those menus.

This also means I can point the test at the channel page 🙂 

## Issue / Bugzilla link

Fix #158

## Testing

http://localhost:8000/en-US/
http://localhost:8000/en-US/browsers/desktop/mac/
http://localhost:8000/en-US/developer/
http://localhost:8000/en-US/channel/desktop/
http://localhost:8000/en-US/compare/
http://localhost:8000/en-US/compare/chrome/
http://localhost:8000/en-US/features/
http://localhost:8000/en-US/features/password-manager/