### PR TITLE
Use localized home link

### DIFF
--- a/springfield/base/templates/includes/navigation/navigation.html
+++ b/springfield/base/templates/includes/navigation/navigation.html
@@ -9,7 +9,7 @@
   <div class="m24-c-navigation-l-content">
     <div class="m24-c-navigation-container">
       <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>
-      <a class="m24-c-navigation-logo-link" href="/" data-link-text="firefox home icon" data-link-position="nav">
+      <a class="m24-c-navigation-logo-link" href="{{ url('firefox') }}" data-link-text="firefox home icon" data-link-position="nav">
         <img class="m24-c-navigation-logo-image" src="{{ static('img/logos/firefox/logo-word-hor.svg') }}" alt="{{ ftl('navigation-firefox-home') }}" width="120" height="40">
       </a>
       <div class="m24-c-navigation-items" id="m24-c-navigation-items" data-testid="m24-navigation-menu-items">


### PR DESCRIPTION
## One-line summary

Keeps the same locale when clicking the nav logo.

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozmeao/springfield/pull/146#discussion_r2102406733

## Testing
