### PR TITLE
Add icons to header and footer links which go off site (#114, #115)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -190,6 +190,16 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
         text-decoration-thickness: 1px;
     }
 
+    // link out icon
+    a[href^="http"]::after {
+        content: '';
+        background: url('/media/img/icons/external.svg') no-repeat bottom center / contain;
+        display: inline-block;
+        height: 1em;
+        margin-left: $spacing-sm;
+        vertical-align: baseline;
+        width: 12px
+    }
 }
 
 // Basic hover interactions with JavaScript disabled or not supported.

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -32,9 +32,20 @@ $image-path: '/media/protocol/img';
     }
 }
 
-// .is-closed[aria-hidden="true"] {
-//     display: none;
-// }
+// external link icon
+.mzp-c-footer-section a[href^="http"]::after {
+    content: '';
+    background: url('/media/img/icons/external-white.svg') no-repeat bottom center / contain;
+    display: inline-block;
+    height: 1em;
+    margin-left: $spacing-sm;
+    vertical-align: baseline;
+    width: 12px
+}
+
+.is-closed[aria-hidden="true"] {
+    display: none;
+}
 
 @media screen and (min-width: #{$screen-sm}) and (max-width: #{$screen-lg - 1px}) {
     .mzp-c-footer-sections {

--- a/media/img/icons/external-white.svg
+++ b/media/img/icons/external-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-name="Ebene 1" viewBox="0 0 16 16"><path d="M9.25 1.5h4.189L7.116 7.823l1.061 1.06L14.5 2.56v4.19H16V0H9.25v1.5z" style="fill:#fff"/><path d="M11.972 9h-1.5v5.5h-9v-9h5.5V4h-7v12h12V9z" style="fill:#fff"/></svg>

--- a/media/img/icons/external.svg
+++ b/media/img/icons/external.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-name="Ebene 1" viewBox="0 0 16 16"><path d="M9.25 1.5h4.189L7.116 7.823l1.061 1.06L14.5 2.56v4.19H16V0H9.25v1.5z"/><path d="M11.972 9h-1.5v5.5h-9v-9h5.5V4h-7v12h12V9z"/></svg>

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -461,6 +461,7 @@
       "files": [
         "js/base/banners/m24-pencil-banner-init.es6.js",
         "js/base/protocol/init-details.es6.js",
+        "js/base/protocol/init-footer.es6.js",
         "js/base/protocol/init-lang-switcher.es6.js",
         "js/base/protocol/protocol-sub-navigation.js",
         "js/base/base-page-init.js",

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -16,8 +16,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             {{ ftl('footer-download') }}
           </h2>
           <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
-            <!-- TKTK  links to download need special stuff, use helper here -->
-            <li><a href="{{ url('firefox.download.thanks') }}" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></li>
+             {# Download link should be locale neutral see bedrock issue 7982 #}
+            <li><a href="/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></li>
             <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
             <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
             <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -31,14 +31,12 @@
                 </a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/" data-link-text="Support" data-link-position="topnav - support">
-                 {{ ftl('navigation-support') }}
-                </a>
+                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/?{{utm_params}}" data-link-text="Add-Ons" data-link-position="topnav - addons">
-                 {{ ftl('navigation-add-ons') }}
-                </a>
+                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/?{{utm_params}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
             </li>
            </ul>
         </div>
@@ -46,9 +44,8 @@
           <h3 class="m24-c-menu-subtitle">{{ ftl('navigation-learn') }}</h3>
           <ul class="m24-mzp-l-content">
             <li>
-                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/?{{utm_params}}" data-link-text="Blog" data-link-position="topnav - blog">
-                 {{ ftl('navigation-blog') }}
-                </a>
+                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/?{{utm_params}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
             </li>
             <li>
                 <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.compare.index') }}" data-link-text="Compare" data-link-position="topnav - compare">
@@ -56,9 +53,8 @@
                 </a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts?{{utm_params}}" data-link-text="Podcast" data-link-position="topnav - podcast">
-                 {{ ftl('navigation-podcast') }}
-                </a>
+                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts?{{utm_params}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## One-line summary

Add icons to header and footer links which go off site.

## Significant changes and points to review

- adds black and white version of icon
- adds the JS to collapse the footer at smallest screen sizes, and a CSS fix
- 

## Issue / Bugzilla link

Header #114 
Footer #115

## Testing

http://localhost:8000/en-US/