### PR TITLE
Add icon to indicate drop down to nav (#114)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -192,6 +192,24 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
 }
 
+.m24-c-menu .mzp-has-drop-down.m24-c-menu-category {
+     h2::after {
+        content: '';
+        background: url('/media/img/icons/caret-sprite.svg') no-repeat bottom left / auto 12px;
+        display: inline-block;
+        height: 1em;
+        margin-left: $spacing-sm;
+        vertical-align: baseline;
+        width: 12px;
+    }
+
+    &.mzp-is-selected {
+        h2::after {
+            background-position: bottom right;
+        }
+    }
+}
+
 // Basic hover interactions with JavaScript disabled or not supported.
 .m24-c-menu.m24-mzp-is-basic .m24-c-menu-category {
     padding-top: 12px;

--- a/media/img/icons/caret-sprite.svg
+++ b/media/img/icons/caret-sprite.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" data-name="Ebene 1" viewBox="0 0 34 16">
+  <path d="M14.641 5.299 8 11.939l-6.641-6.64-1.06 1.06L8 14.061l7.701-7.702-1.06-1.06z"/>
+  <path d="M 33.702 13.001 L 26.001 5.3 L 18.3 13.001 L 19.36 14.061 L 26.001 7.422 L 32.642 14.061 L 33.702 13.001 Z" style="stroke-width: 1;"/>
+</svg>


### PR DESCRIPTION
## One-line summary

Add icon to indicate drop down to nav

## Significant changes and points to review

- adds CSS to display and swap the icon 
- adds a sprite with both icons (avoids a delay displaying up icon while image is requested) 

## Issue / Bugzilla link

#114 

## Testing

http://localhost:8000/en-US/ and interact with the header nav.