### PR TITLE
Set fixed height on top nav for better alignment

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -207,7 +207,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
         content: '';
         background: url('/media/img/icons/caret-sprite.svg') no-repeat bottom left / auto 12px;
         display: inline-block;
-        height: 1em;
+        height: 12px;
         margin-left: $spacing-sm;
         vertical-align: baseline;
         width: 12px;


### PR DESCRIPTION
## One-line summary

Features & Resources don't share the same height and no longer look vertically aligned
<img width="329" alt="Screenshot 2025-05-27 at 3 07 00 PM" src="https://github.com/user-attachments/assets/7ea920a3-06e2-4002-8f06-426870307e60" />
<img width="338" alt="Screenshot 2025-05-27 at 3 07 05 PM" src="https://github.com/user-attachments/assets/f04f5600-3d3e-400e-8b2f-5db5b4fe8368" />

## Significant changes and points to review

Seems to be result of [1em height on dropdown icon](https://github.com/mozmeao/springfield/pull/190/files#diff-15e61c62c88a86deb6946a53c0175cdb4a9be4a4312e38b4819e9323c4fe4a67R200), so that's been replace with fixed height that allows text height to remain equal between menu titles

## Issue / Bugzilla link



## Testing
http://localhost:8000/en-US/