### PR TITLE
Promote removal of 'unsafe-inlines' for styles

### DIFF
--- a/springfield/settings/__init__.py
+++ b/springfield/settings/__init__.py
@@ -48,6 +48,7 @@ _csp_connect_src = {
     "region1.google-analytics.com",
     "o1069899.sentry.io",
     "o1069899.ingest.sentry.io",
+    "o1069899.ingest.us.sentry.io",
     FXA_ENDPOINT,  # noqa: F405
 }
 _csp_font_src = {


### PR DESCRIPTION
## One-line summary

We have no reports of unsafe-inline style violations other than the wagtail admin, so promoting this to the enforced CSP and adding an override for the admin.

This also removes the `frame-ancestors` change since we are effectively already doing that in the main policy settings via `WAGTAIL_ENABLE_ADMIN`.

