### PR TITLE
Add whatsdeployed view for dev–stage–prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ awesome, and open source as always. Perhaps even a little more.
 
 [firefox]: https://www.firefox.com/
 
+[![What's deployed on dev/stage/prod?](https://img.shields.io/badge/whatsdeployed-dev/stage/prod-teal.svg)](https://whatsdeployed.io/s/gKn/mozmeao/springfield)
+
 Docs
 ----
 


### PR DESCRIPTION
## One-line summary

Created https://whatsdeployed.io/s/gKn/mozmeao/springfield to see what's what.

## Significant changes and points to review

Used origin hostnames to avoid any potential CDN getting in the way to get the newest revision.txt deployed.

Unlike bedrock, this works here as the repo doesn't have pages of tags (yet) so let's enjoy the ride while it lasts (:)

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/pull/16162#issuecomment-2832632415

## Testing

👓 _preview: https://github.com/janbrasna/springfield/tree/whatsdeployed#readme_