### PR TITLE
Propose new desktop page for MVP

### DIFF
--- a/media/css/firefox/browsers/desktop-index.scss
+++ b/media/css/firefox/browsers/desktop-index.scss
@@ -34,14 +34,6 @@ $h-grid-lg: $layout-xl;
     display: none !important; /* stylelint-disable-line declaration-no-important */
 }
 
-.c-main-header {
-    text-align: center;
-
-    .mzp-c-logo {
-        margin: 0 auto $spacing-lg;
-    }
-}
-
 // * -------------------------------------------------------------------------- */
 // Protocol over-rides
 
@@ -71,19 +63,21 @@ main .mzp-l-content {
 }
 
 // * -------------------------------------------------------------------------- */
-// use split component for top banner
+// hero
 
-.c-landing-banner {
+.c-main-header {
+    text-align: center;
+
+    .mzp-c-logo {
+        margin: 0 auto $spacing-lg;
+    }
+
     h1 {
         @include text-title-xl;
     }
 
-    p {
-        @include text-body-lg;
-    }
-
-    &.t-products {
-        padding-top: 0;
+    h2 {
+        margin-bottom: $v-grid-md;
     }
 }
 

--- a/springfield/firefox/templates/firefox/browsers/desktop/index.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/index.html
@@ -50,6 +50,7 @@
       <h2 class="mzp-has-zap-11">
         {{ ftl('firefox-browsers-get-the-browsers-strong-v2') }}
       </h2>
+      {{ download_firefox_thanks(locale_in_transition=True, download_location='desktop card cta', dom_id='firefox-desktop-download') }}
   </header>
 
   <div class="mzp-l-content mzp-t-content-lg c-landing-grid">
@@ -68,9 +69,10 @@
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.download') }}" data-cta-text="Desktop">{{ ftl('firefox-browsers-desktop') }}</a></h2>
       <p>{{ ftl('firefox-browsers-seriously-private-browsing') }}</p>
 
-      {{ download_firefox_thanks(locale_in_transition=True, download_location='desktop card cta', dom_id='firefox-desktop-download') }}
-
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.download') }}" data-cta-text="Desktop Learn More">{{ ftl('ui-learn-more') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.desktop.mac') }}" data-cta-text="Firefox for Mac">Firefox for Mac</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.desktop.linux') }}" data-cta-text="Firefox for Linux">Firefox for Linux</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.desktop.windows') }}" data-cta-text="Firefox for Windows">Firefox for Windows</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ firefox_url('desktop', 'all') }}" data-cta-text="All options">All options</a></p>
     </div>
     <div class="c-landing-grid-item">
       {{ resp_img(


### PR DESCRIPTION
- Avoids looping to home page with Desktop "Learn More" link
- Adds platform specific links and All link
- Moves download button to hero

## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/117
https://github.com/mozmeao/springfield/issues/200


## Testing
http://localhost:8000/en-US/browsers/desktop/