### PR TITLE
(fix) Amend Release Notes links in Nav and Footer to point to Springfield, not www.mozilla.org

### DIFF
--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -56,7 +56,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-resources">
             <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-position="footer" data-link-text="Compare">{{ ftl('footer-compare') }}</a></li>
-            <li><a href="https://www.mozilla.org/firefox/releasenotes/" data-link-position="footer" data-link-text="Release Notes">{{ ftl('footer-release-notes') }}</a></li>
+            <li><a href="{{ url('firefox.notes') }}" data-link-position="footer" data-link-text="Release Notes">{{ ftl('footer-release-notes') }}</a></li>
             <li><a href="https://support.mozilla.org/?{{utm_params}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/?{{utm_params}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
             <li><a href="https://community.mozilla.org/?{{utm_params}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -26,7 +26,7 @@
                 </a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/firefox/notes" data-link-text="Release Notes" data-link-position="topnav - release notes">{{ ftl('navigation-release-notes') }}</a>
+                <a class="m24-c-menu-item-link" href="{{ url('firefox.notes') }}" data-link-text="Release Notes" data-link-position="topnav - release notes">{{ ftl('navigation-release-notes') }}</a>
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}


### PR DESCRIPTION
The content in each site will be the same, so may as well keep people on www.firefox.com


## Issue / Bugzilla link

Resolves #172 - as reported by @janbrasna 

## Testing

Check the nav and footer on any page