### PR TITLE
fix navigation underline bug (fix #195)

### DIFF
--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -26,9 +26,7 @@
                 </a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/firefox/notes" data-link-text="Release Notes" data-link-position="topnav - release notes">
-                 {{ ftl('navigation-release-notes') }}
-                </a>
+                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/firefox/notes" data-link-text="Release Notes" data-link-position="topnav - release notes">{{ ftl('navigation-release-notes') }}</a>
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}


### PR DESCRIPTION
## One-line summary

This PR fixes the extra space in the "Release Notes" link in the "Resource" navigation menu.

## Significant changes and points to review

Navigation

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/195

## Testing

http://localhost:8000/en-US/