### PR TITLE
Fix ftl string and remove globe on no-js lang switcher (fixes #225)

### DIFF
--- a/l10n/en/footer-firefox.ftl
+++ b/l10n/en/footer-firefox.ftl
@@ -64,8 +64,9 @@ footer-websites-cookie-policy = Cookie Policy
 footer-community-participation-guidelines = Community Participation Guidelines
 footer-logo-trademark-licensing = Logo Trademark Licensing
 
-##
+## Language Switcher
 
 footer-language = Language
+footer-go = Go
 
 footer-firefox = { -brand-name-firefox }

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -243,7 +243,7 @@ $image-path: '/media/protocol/img';
         color: m24.$token-color-off-white;
         font-weight: 600;
         font-size: remify(16px);
-        padding-left: 36px;
+        padding-left: 36px; // space for globe icon
         max-width: 100%;
         width: 100%;
         margin: 0;
@@ -262,4 +262,13 @@ $image-path: '/media/protocol/img';
             background-size: 16px 16px;
         }
     }
+}
+
+// No JS: remove globe icon
+.no-js .mzp-c-language-switcher::before {
+    content: none;
+}
+
+.no-js .mzp-js-language-switcher-select {
+    padding-left: $spacing-sm;
 }


### PR DESCRIPTION
## One-line summary


## Significant changes and points to review
Adds missing FTL string and removes globe icon to avoid positioning issues when form height expands with addition of "Go" button


## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/225


## Testing
Disable JS and go to footer on http://localhost:8000/en-US/
<img width="325" alt="Screenshot 2025-06-02 at 11 54 10 AM" src="https://github.com/user-attachments/assets/1b6d65b7-4811-49ad-9539-1c719b7a8a2a" />
