### PR TITLE
Sweep links (fixes #228)

### DIFF
--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -90,6 +90,8 @@
 -brand-name-chrome = Chrome
 -brand-name-edge = Edge
 -brand-name-ie = Internet Explorer
+-brand-name-opera = Opera
+-brand-name-safari = Safari
 
 ## Platforms
 

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -15,6 +15,7 @@
 -brand-name-mozilla = Mozilla
 -brand-name-mozilla-corporation = Mozilla Corporation
 -brand-name-mozilla-foundation = Mozilla Foundation
+-brand-name-netscape = Netscape
 -brand-name-linkedin = LinkedIn
 -brand-name-spotify = Spotify
 

--- a/l10n/en/firefox/features/private-browsing-2023.ftl
+++ b/l10n/en/firefox/features/private-browsing-2023.ftl
@@ -22,5 +22,5 @@ features-private-browsing-what-private-browsing-doesnt-do = What private browsin
 features-private-browsing-private-browsing-mode-will-not = Private browsing mode will not delete any new bookmarks you make from a private browsing window, or protect you from malware or viruses. It also doesn’t prevent the websites you visit from seeing where you are physically located or stop your internet service provider from logging what you do. You’ll need a <a href="{ $vpn }">trustworthy VPN</a> for that.
 
 # Variables:
-#   $chrome (url) = link to https://www.mozilla.org/firefox/browsers/incognito-browser/
+#   $chrome (url) = link to https://www.firefox.com/more/incognito-browser/
 features-private-browsing-compare-firefoxs-private-browsing = Compare { -brand-name-firefox }’s private browsing with <a href="{ $chrome }">Chrome’s incognito mode</a>.

--- a/springfield/firefox/templates/firefox/features/private-browsing.html
+++ b/springfield/firefox/templates/firefox/features/private-browsing.html
@@ -30,5 +30,5 @@
 
 <h2>{{ ftl('features-private-browsing-what-private-browsing-doesnt-do') }}</h2>
 <p>{{ ftl('features-private-browsing-private-browsing-mode-will-not', vpn="https://www.mozilla.org/products/vpn/") }}</p>
-<p>{{ ftl('features-private-browsing-compare-firefoxs-private-browsing', chrome='https://www.mozilla.org/' + LANG + '/firefox/browsers/incognito-browser/') }}</p>
+<p>{{ ftl('features-private-browsing-compare-firefoxs-private-browsing', chrome=url('firefox.more.incognito-browser')) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/includes/desktop-platform-sub-nav.html
+++ b/springfield/firefox/templates/firefox/includes/desktop-platform-sub-nav.html
@@ -34,7 +34,7 @@
   },
   {
     'text': ftl('sub-navigation-chromebook'),
-    'href': 'https://www.mozilla.org/' + LANG + '/firefox/browsers/chromebook/',
+    'href': url('firefox.browsers.desktop.chromebook'),
     'cta_name': "Chromebook"
   },
   {

--- a/springfield/firefox/templates/firefox/includes/sub-nav-firefox.html
+++ b/springfield/firefox/templates/firefox/includes/sub-nav-firefox.html
@@ -35,7 +35,7 @@
     },
     {
       'text': ftl('sub-navigation-more'),
-      'href': 'https://www.mozilla.org/' + LANG + '/firefox/more/',
+      'href': url('firefox.more.index'),
       'cta_name': 'More'
     }
   ]

--- a/springfield/firefox/templates/firefox/more/best-browser.html
+++ b/springfield/firefox/templates/firefox/more/best-browser.html
@@ -74,7 +74,7 @@
         {{ ftl('best-browser-there-are-a-few-ways') }}
       </p>
       <p>
-        {{ ftl('best-browser-the-second-is-not-storing', data=url('privacy.notices.firefox'), privacy=url('privacy.notices.firefox')) }}
+        {{ ftl('best-browser-the-second-is-not-storing', data='https://www.mozilla.org/privacy/firefox/', privacy='https://www.mozilla.org/privacy/firefox/') }}
       </p>
       <p>
         {{ ftl('best-browser-last-but-not-least') }}
@@ -102,7 +102,7 @@
       {{ ftl('best-browser-another-way-to-stop') }}
     </p>
     <p>
-      {{ ftl('best-browser-one-easy-way-to-check', privacy=url('privacy.notices.firefox')) }}
+      {{ ftl('best-browser-one-easy-way-to-check', privacy='https://www.mozilla.org/privacy/firefox/') }}
     </p>
     <p>
       {{ ftl('best-browser-choosing-the-best-browser') }}

--- a/springfield/firefox/templates/firefox/releases/notes.html
+++ b/springfield/firefox/templates/firefox/releases/notes.html
@@ -380,7 +380,7 @@
           <a rel="external" href="https://blog.mozilla.org/press/">Mozilla and Firefox News</a>
           <a href="{{ url('firefox.enterprise.index') }}">Firefox Extended Support Release</a>
           <a href="{{ url('firefox.releases.index') }}">All Firefox for Desktop Releases</a>
-          <a href="https://www.mozilla.org/{{ LANG }}/firefox/more/">Learn more about Firefox</a>
+          <a href="{{ url('firefox.more.index') }}">Learn more about Firefox</a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## One-line summary

Final check on internal links now that we've ported all pages for MVP

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/228



## Testing

Check the updated links on the following pages
- [x] http://localhost:8000/en-US/features/private-browsing/
- [x] http://localhost:8000/en-US/more/best-browser/
- [x] http://localhost:8000/en-US/firefox/138.0.3/releasenotes/

Check Netscape, Opera, and Safari brands are translated
- [x] http://localhost:8000/en-US/more/browser-history/
