### PR TITLE
Add download icon to download button (fixes #205)

### DIFF
--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -292,3 +292,11 @@ ul.download-list {
         margin: 0
     }
 }
+
+// Download Icon
+// Hack to ensure only component authored margin is applied
+// https://github.com/mozmeao/springfield/pull/238#issuecomment-2954261185
+.download-link .mzp-c-button-icon-end img {
+    /* stylelint-disable-next-line declaration-no-important */
+    margin-bottom: 0 !important;
+}

--- a/media/img/icons/m24-small/download-white.svg
+++ b/media/img/icons/m24-small/download-white.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <path fill="#fff" d="M19.5 17.31v2.13H4.72v-2.13h-2.6v4.73H22.1v-4.73h-2.6z"/>
-  <path fill="#fff" d="M21.44 7.09h-8.03V2.06h-2.6v5.03H2.78l9.33 11.09 9.33-11.09Zm-5.59 2.59-3.74 4.46-3.74-4.46h7.48Z"/>
-</svg>
+<svg fill="none" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><clipPath id="a"><path d="m0 0h16v16h-16z"/></clipPath><g clip-path="url(#a)" fill="#fff"><path d="m7.2507 0v10.21l-3.72-3.72-1.06 1.06 5.53 5.53 5.53-5.53-1.06-1.06-3.72 3.72v-10.21z"/><path d="m16 14.5h-16v1.5h16z"/></g></svg>

--- a/springfield/firefox/templates/firefox/all/download.html
+++ b/springfield/firefox/templates/firefox/all/download.html
@@ -6,7 +6,7 @@
 
 {% from "macros.html" import google_play_button, apple_app_store_button, ms_store_button with context %}
 
-{% set icon_download ='<span class="mzp-c-button-icon-end"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 13c.2 0 .4-.1.5-.2l4.4-4.4-1.1-1.1-3.1 3.1V1H7.2v9.4L4.1 7.3l-1 1.1 4.4 4.4c.1.1.3.2.5.2z" /><path d="M13.5 12v2c0 .3-.2.5-.5.5H3c-.3 0-.5-.2-.5-.5v-2H1v2c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2v-2h-1.5z" /></svg></span>' %}
+{% set icon_download ='<span class="mzp-c-button-icon-end"><svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><clipPath id="a"><path d="m0 0h16v16h-16z"/></clipPath><g clip-path="url(#a)" fill="currentColor"><path d="m7.2507 0v10.21l-3.72-3.72-1.06 1.06 5.53 5.53 5.53-5.53-1.06-1.06-3.72 3.72v-10.21z"/><path d="m16 14.5h-16v1.5h16z"/></g></svg></span>' %}
 
 {# Show download #}
 <h2 {% if not (product and platform and locale) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -42,7 +42,13 @@
     </p>
     <div class="cta-container">
       <div class="mzp-c-button-download-container">
-        <a id="primary-download-button" href="#download" class="mzp-c-button mzp-t-product mzp-t-xl">{{ ftl('download-button-download') }}</a>
+        <a id="primary-download-button" href="#download" class="mzp-c-button mzp-t-product mzp-t-xl">
+          {{ ftl('download-button-download') }}
+          <span class="mzp-c-button-icon-end">
+            <!-- TODO: replace with new protocol-assets version -->
+            <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+          </span>
+        </a>
         <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
       </div>
     </div>

--- a/springfield/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/springfield/firefox/templates/firefox/includes/download-button-thanks.html
@@ -16,6 +16,10 @@
     {% else %}
       {{ ftl('download-button-download-firefox') }}
     {% endif %}
+    <span class="mzp-c-button-icon-end">
+      <!-- TODO: replace with new protocol-assets version -->
+      <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+    </span>
   </a>
 
   {# ESR download buttons to display on unsupported systems: issue 13317 #}

--- a/springfield/firefox/templates/firefox/includes/download-button.html
+++ b/springfield/firefox/templates/firefox/includes/download-button.html
@@ -25,7 +25,12 @@
                data-cta-text="Download Firefox for {{ plat.os_arch_pretty or plat.os_pretty }}"
                {% if plat.os == 'android' %}data-cta-type="firefox_mobile"
                {% elif plat.os == 'ios' %}data-cta-type="firefox_mobile"
-               {% else %}data-cta-type="firefox"{% endif %}>{{ plat.os_arch_pretty or plat.os_pretty }}</a>
+               {% else %}data-cta-type="firefox"{% endif %}>{{ plat.os_arch_pretty or plat.os_pretty }}
+              <span class="mzp-c-button-icon-end">
+                <!-- TODO: replace with new protocol-assets version -->
+                <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+              </span>
+              </a>
         </li>
       {%- endfor %}
     </ul>
@@ -101,6 +106,10 @@
               {% endif %}
             {% endif %}
           </strong>
+          <span class="mzp-c-button-icon-end">
+            <!-- TODO: replace with new protocol-assets version -->
+            <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+          </span>
         </a>
       </li>
     {% endfor %}

--- a/springfield/firefox/templates/firefox/includes/macros.html
+++ b/springfield/firefox/templates/firefox/includes/macros.html
@@ -20,6 +20,10 @@
         <strong class="download-title">
           {{ cta_copy }}
         </strong>
+        <span class="mzp-c-button-icon-end">
+          <!-- TODO: replace with new protocol-assets version -->
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+        </span>
       </a>
 
       <small class="mzp-c-button-download-privacy-link">
@@ -50,6 +54,10 @@
         <strong class="download-title">
           {{ cta_copy }}
         </strong>
+        <span class="mzp-c-button-icon-end">
+          <!-- TODO: replace with new protocol-assets version -->
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+        </span>
       </a>
 
       <small class="mzp-c-button-download-privacy-link">
@@ -74,12 +82,20 @@
         <strong class="download-title">
           {{ ftl('download-button-linux-32-v2') }}
         </strong>
+        <span class="mzp-c-button-icon-end">
+          <!-- TODO: replace with new protocol-assets version -->
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+        </span>
       </a>
 
       <a class="download-link os_linux64 mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}-64" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" data-download-version="linux64" data-cta-text="Download for Linux 64-bit" data-cta-position="{{ position }}" data-testid="{{ id }}-64">
         <strong class="download-title">
           {{ ftl('download-button-linux-64-v2') }}
         </strong>
+        <span class="mzp-c-button-icon-end">
+          <!-- TODO: replace with new protocol-assets version -->
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+        </span>
       </a>
 
       <p class="c-linux-debian">{{ ftl('download-button-using-debian', attrs='href="https://support.mozilla.org/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener"


### PR DESCRIPTION
## One-line summary

Adds download icon to all download buttons

## Significant changes and points to review

Did I miss any other inline SVG use? Did I miss other hardcoded buttons?

## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/205


## Testing
- [ ] http://localhost:8000/en-US/browsers/enterprise/
- [ ] http://localhost:8000/en-US/ (nav, mobile nav, hero, last section of page)
- [ ] http://localhost:8000/en-US/browsers/desktop/windows/
- [ ] http://localhost:8000/en-US/browsers/desktop/linux/
- [ ] http://localhost:8000/en-US/channel/desktop/ (Beta, Developer, Nightly)
- [ ] http://localhost:8000/en-US/browsers/desktop/mac/
- [ ] http://localhost:8000/en-US/download/all/desktop-esr/win64/en-US/
- [ ] With and without JS: http://localhost:8000/en-US/firefox/138.0.3/system-requirements/ "Get the latest release" section

Added after review
- [ ] http://localhost:8000/en-US/more/windows-64-bit/ (icon img alignment)
- [ ] http://localhost:8000/en-GB/ (features section: icon img alignment)
- [ ] http://localhost:8000/en-US/channel/desktop/ with MacOS lower than 10.14 and Win lower than 8.1 for ESR buttons (these will have no icon)
<img width="401" alt="esr" src="https://github.com/user-attachments/assets/61939681-0766-49ec-8377-2fd2ad81407a" />
