### PR TITLE
Update bug_report template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "Bug Report \U0001F41B"
 about: Something isn't working as expected? Here is the right place to report.
 title: ''
-labels: 'Bug :bug:'
+labels: 'bug :bug:'
 assignees: ''
 
 ---


### PR DESCRIPTION
## One-line summary

Seems the template minds the case difference in the issue label referenced.

## Significant changes and points to review

Or, the other way around, fixing this by changing the actual issue label itself to Title-case to match bedrock for consistency, in which case this PR is moot.

## Issue / Bugzilla link

Many! ;)

## Testing