### PR TITLE
Fix notes newsletter CTA contrast

### DIFF
--- a/media/css/base/banners/firefox-newsletter.scss
+++ b/media/css/base/banners/firefox-newsletter.scss
@@ -54,6 +54,10 @@
         transition: all 300ms ease-out;
         white-space: nowrap;
 
+        &:link {
+            color: $color-black;
+        }
+
         &:hover,
         &:focus,
         &:active {


### PR DESCRIPTION
## One-line summary

Sets color for the banner CTA to stay readable.

## Significant changes and points to review

Did not look for the difference from bedrock, where this extra specificity comes from; it's a quick hack for now.

## Issue / Bugzilla link

Fixes https://github.com/mozmeao/springfield/issues/172#issue-3086311924

## Testing

/firefox/138.0.1/releasenotes/