### PR TITLE
Fix #244: Update QR mobile redirects

### DIFF
--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -2,7 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import re
+
 from springfield.redirects.util import mobile_app_redirector, platform_redirector, redirect
+
+# matches only ASCII letters (ignoring case), numbers, dashes, periods, and underscores.
+PARAM_VALUES_RE = re.compile(r"[\w.-]+", flags=re.ASCII)
 
 
 def firefox_mobile_faq(request, *args, **kwargs):
@@ -17,6 +22,17 @@ def firefox_channel(*args, **kwargs):
     return platform_redirector("firefox.channel.desktop", "firefox.channel.android", "firefox.channel.ios")
 
 
+def validate_param_value(param: str | None) -> str | None:
+    """
+    Returns the value passed in if it matches the regex `PARAM_VALUES_RE`.
+    Otherwise returns `None`.
+    """
+    if param and PARAM_VALUES_RE.fullmatch(param):
+        return param
+
+    return None
+
+
 def mobile_app(request, *args, **kwargs):
     product = request.GET.get("product")
     campaign = request.GET.get("campaign")
@@ -24,8 +40,7 @@ def mobile_app(request, *args, **kwargs):
     if product not in {"firefox", "focus", "klar"}:
         product = "firefox"
 
-    if campaign not in {"firefox-all"}:
-        campaign = None
+    campaign = validate_param_value(campaign)
 
     return mobile_app_redirector(request, product, campaign)
 

--- a/springfield/firefox/templates/firefox/all/mobile.html
+++ b/springfield/firefox/templates/firefox/all/mobile.html
@@ -16,7 +16,7 @@
   {% set qr_url = android_nightly_url %}
   {% set android_url = android_nightly_url %}
 {% else %}
-  {% set qr_url ="https://www.firefox.com/firefox/browsers/mobile/app/?product=firefox&campaign=firefox-all" %}
+  {% set qr_url ="https://www.firefox.com/browsers/mobile/app/?product=firefox&campaign=firefox-all" %}
 {% endif %}
 
 <div class="c-mobile">

--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -1,0 +1,87 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest.mock import patch
+
+from django.test import RequestFactory
+
+import pytest
+
+from springfield.firefox.redirects import mobile_app, validate_param_value
+
+
+@pytest.mark.parametrize(
+    "test_param, is_valid",
+    (
+        ("firefox-whatsnew", True),
+        ("firefox-welcome-4", True),
+        ("firefox-welcome-6", True),
+        ("firefox-welcome-17-en", True),
+        ("firefox-welcome-17-de", True),
+        ("firefox-welcome-17-fr", True),
+        ("firefox-browsers-mobile-get-app", True),
+        ("firefox-browsers-mobile-focus", True),
+        ("mzaonboardingemail-de", True),
+        ("mzaonboardingemail-fr", True),
+        ("mzaonboardingemail-es", True),
+        ("firefox-all", True),
+        ("fxshare1", True),
+        ("fxshare2", True),
+        ("fxshare3", True),
+        ("fxshare4", True),
+        ("fxshare12", True),
+        ("fxshare14", True),
+        ("fxshare15", True),
+        ("DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_a", True),
+        ("DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_b", True),
+        ("wnp134-de-a", True),
+        ("wnp134-de-b", True),
+        ("wnp134-de-c", True),
+        ("wnp134-en-ca-a", True),
+        ("wnp134-en-ca-b", True),
+        ("smi-marvintsp", True),
+        ("smi-koschtaaa", True),
+        ("smi-bytereview", True),
+        ("pocket-test", True),
+        ("some<nefarious$thing", False),
+        ("ano+h3r=ne", False),
+        ("ǖnicode", False),
+        ("♪♫♬♭♮♯", False),
+        ("", False),
+        (None, False),
+    ),
+)
+def test_param_verification(test_param, is_valid):
+    if is_valid:
+        assert validate_param_value(test_param) == test_param
+    else:
+        assert validate_param_value(test_param) is None
+
+
+def test_mobile_app():
+    rf = RequestFactory()
+
+    # both args exist and have valid values
+    req = rf.get("/firefox/app/?product=focus&campaign=firefox-all")
+    with patch("springfield.firefox.redirects.mobile_app_redirector") as mar:
+        mobile_app(req)
+        mar.assert_called_with(req, "focus", "firefox-all")
+
+    # neither args exist
+    req = rf.get("/firefox/app/")
+    with patch("springfield.firefox.redirects.mobile_app_redirector") as mar:
+        mobile_app(req)
+        mar.assert_called_with(req, "firefox", None)
+
+    # both args exist but invalid values
+    req = rf.get("/firefox/app/?product=dude&campaign=walter$")
+    with patch("springfield.firefox.redirects.mobile_app_redirector") as mar:
+        mobile_app(req)
+        mar.assert_called_with(req, "firefox", None)
+
+    # other args exist
+    req = rf.get("/firefox/app/?bunny=dude&maude=artist")
+    with patch("springfield.firefox.redirects.mobile_app_redirector") as mar:
+        mobile_app(req)
+        mar.assert_called_with(req, "firefox", None)


### PR DESCRIPTION
## One-line summary

- Fix the URL to remove the `/firefox` path.
- Bring over loosened campaign checking for QR code query params.

## Significant changes and points to review

## Issue / Bugzilla link
#244 


## Testing
