### PR TITLE
Add link destination to Resources menu item

### DIFF
--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -7,7 +7,7 @@
  {% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
-   <a class="m24-c-menu-title" href="#TODO" aria-haspopup="true" aria-controls="m24-c-menu-panel-resources" data-testid="m24-navigation-link-resources">
+   <a class="m24-c-menu-title" href="{{ url('firefox.more.index') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-resources" data-testid="m24-navigation-link-resources">
     <h2>{{ ftl('navigation-resources') }}</h2>
   </a>
    <div class="m24-c-menu-panel" id="m24-c-menu-panel-resources" data-testid="m24-navigation-menu-resources">


### PR DESCRIPTION
## One-line summary

Adds some fallback destination href to the menu item.

## Significant changes and points to review

The link is only ever used when context-clicked to be opened in a new tab, or when tapped in expanded mobile menu. Otherwise the anchor acts only as a menu target affordance to open the dropdown panels, and never leads visitors anywhere outside of nonJS situations etc.

If a better content is ported, this can be easily changed. This is to get rid of a visible TODO for now.

## Issue / Bugzilla link

Resolves #189 

## Testing
/