### PR TITLE
Run open-ftl-pr after artifact build+push

### DIFF
--- a/.github/workflows/send_firefox_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_firefox_fluent_strings_to_l10n_org.yml
@@ -4,21 +4,24 @@
 name: Open Fluent PR for Firefox.com
 
 on:
-  push:
-    paths:
-      - "l10n/**/*"
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build and push a Docker image"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
   schedule:
-    - cron: "0 0/3 * * *" # Every 3 hours
+    - cron: "15 5 * * *" # Every 5:15 AM UTC
 
 jobs:
   open_l10n_pr:
     if: github.repository == 'mozmeao/springfield'
     runs-on: ubuntu-latest
+    env:
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.HEAD_SHA }}
       - name: Run PR-opening script
         shell: bash
         run: FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh


### PR DESCRIPTION
## One-line summary

Moves running the l10n PR for a given SHA from push to workflow completion.

## Significant changes and points to review

This will be run for every commit on main, not just those touching l10n files. (That check might be added in cli afterwards but could be a little opaque/fragile.)

Tuning down the cron schedule to compensate for that. (If working as intended the cron will only be once-a-day fallback.)

## Issue / Bugzilla link

#250 

## Testing

[`@janbrasna/springfield` /actions/workflows](https://github.com/janbrasna/springfield/actions/workflows/send_firefox_fluent_strings_to_l10n_org.yml) some demo runs:
- `workflow` triggers checkout passed SHA of the caller event (have empty ref in overview)
- `cron` triggers checkout main HEAD as the implicit actor (have `main` as ref in the list)

Both cases explicitly switch to that SHA in detached HEAD, so no matter if anything new landed in main since the trigger, it should always set HEAD to the expected commit for the shell scripts later to infer the tags, images to pull etc. from the right ref.