### PR TITLE
Eliminate repetitive wordmarks

### DIFF
--- a/l10n/en/firefox/download/desktop.ftl
+++ b/l10n/en/firefox/download/desktop.ftl
@@ -109,7 +109,6 @@ firefox-desktop-download-screenshots = Screenshots
 # Enhanced Tracking Protection is a feature name and so is capitalized in English
 firefox-desktop-download-enhanced-tracking-protection = Enhanced Tracking Protection (ETP)
 firefox-desktop-download-from-watching-a = From watching a web tutorial to keeping an eye on your favorite team, your video follows you while you multitask.
-firefox-desktop-download-firefox-browser = { -brand-name-firefox-browser }
 firefox-desktop-download-get-firefox-android = Get { -brand-name-firefox-browser } for <strong>{ -brand-name-android }</strong>
 firefox-desktop-download-get-firefox-ios = Get { -brand-name-firefox-browser } for <strong>{ -brand-name-ios }</strong>
 firefox-desktop-download-download-the-mobile = Download the { -brand-name-firefox } mobile browser for automatic protection on all your devices.

--- a/media/css/firefox/download/basic/download.scss
+++ b/media/css/firefox/download/basic/download.scss
@@ -7,8 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 
 // notification
 
@@ -19,10 +17,6 @@ $image-path: '/media/protocol/img';
 }
 
 .mzp-c-split-body {
-    .mzp-c-wordmark {
-        margin-bottom: $spacing-2xl;
-    }
-
     .c-download-split-title {
         @include text-title-lg;
     }

--- a/media/css/firefox/download/desktop/download.scss
+++ b/media/css/firefox/download/desktop/download.scss
@@ -8,12 +8,9 @@ $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/components/section-heading';
 @import '~@mozilla-protocol/core/protocol/css/components/zap';
-@import '../../../protocol/components/sub-navigation';
 
 // --------------------------------------------------------------------------
 // Protocol over-rides
@@ -37,6 +34,13 @@ $h-grid-lg: 80px;
 main {
     background-color: $color-white; // for IE6
     color: $color-dark-gray-30;
+
+    h1 {
+        color: var(--body-text-color-secondary);
+        font-family: var(--body-font-family);
+        font-size: var(--text-body-sm);
+        font-weight: normal;
+    }
 
     h2,
     h3,
@@ -612,10 +616,6 @@ button.mzp-c-cta-link {
 
     [lang='ar'] & h2 {
         @include font-size(40px);
-    }
-
-    .mzp-c-wordmark {
-        margin-bottom: $v-grid-md;
     }
 
     // issue 13317

--- a/media/css/firefox/download/desktop/download.scss
+++ b/media/css/firefox/download/desktop/download.scss
@@ -36,7 +36,7 @@ main {
     color: $color-dark-gray-30;
 
     h1 {
-        color: var(--body-text-color-secondary);
+        color: $color-dark-gray-30;
         font-family: var(--body-font-family);
         font-size: var(--text-body-sm);
         font-weight: normal;

--- a/media/css/firefox/home-en-us-ca.scss
+++ b/media/css/firefox/home-en-us-ca.scss
@@ -8,12 +8,9 @@ $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/components/section-heading';
 @import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
-@import '../protocol/components/sub-navigation';
 
 // --------------------------------------------------------------------------
 // Protocol over-rides
@@ -37,6 +34,13 @@ $h-grid-lg: 80px;
 main {
     background-color: $color-white; // for IE6
     color: $color-dark-gray-30;
+
+    h1 {
+        color: $color-dark-gray-30;
+        font-family: var(--body-font-family);
+        font-size: var(--text-body-sm);
+        font-weight: normal;
+    }
 
     h2,
     h3,

--- a/springfield/firefox/templates/firefox/download/basic/base_download.html
+++ b/springfield/firefox/templates/firefox/download/basic/base_download.html
@@ -57,7 +57,6 @@
     image=resp_img(url=hero_img, optional_attributes={ 'class': 'mzp-c-split-media-asset' })
 
   ) %}
-    <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox"></div>
     <h1 class="c-download-split-title">{{ hero_title }}</h1>
     <div class="c-intro-download">
       {% block intro_download_button %}

--- a/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
@@ -50,9 +50,9 @@
    <section id="desktop-banner" class="c-block t-intro show-else mzp-has-media-hide-on-sm">
      <div class="c-block-container">
        <div class="c-block-body">
-         <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox') }}</h1>
-           <h2>Take control of your internet</h2>
-           <p>Go online with fewer distractions, noise and stress. Think of us as bubble wrap for your brain.</p>
+         <h1>{{ ftl('firefox-desktop-download-firefox') }}</h1>
+         <h2>Take control of your internet</h2>
+         <p>Go online with fewer distractions, noise and stress. Think of us as bubble wrap for your brain.</p>
          <div class="c-intro-download">
            {% block primary_cta %}
              {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
@@ -212,7 +212,6 @@
      <div class="c-mobile mzp-t-dark">
        <div class="mzp-l-content">
          <div class="c-mobile-text">
-           <h2 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox-browser') }}</h2>
            <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
            <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
 

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -81,7 +81,7 @@
   <section id="desktop-banner" class="c-block t-intro show-else mzp-has-media-hide-on-sm">
     <div class="c-block-container">
       <div class="c-block-body">
-        <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox') }}</h1>
+        <h1>{{ ftl('firefox-desktop-download-firefox') }}</h1>
           <h2 class="mzp-has-zap-7">{{ ftl('firefox-desktop-download-get-the-browser') }}</h2>
           <p>{{ ftl('firefox-desktop-download-fast-reliable-private', fallback='firefox-desktop-download-no-shady') }}</p>
         <div class="c-intro-download">

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -561,7 +561,6 @@
     <div class="c-mobile mzp-t-dark">
       <div class="mzp-l-content">
         <div class="c-mobile-text">
-          <h2 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox-browser') }}</h2>
           <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
           <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
 


### PR DESCRIPTION
## One-line summary

Turns home h1 into plaintext, removes mobile h2 (there are better h2s right after it) and removes decoration from basic experience.

## Significant changes and points to review

These are the ~6 occurrences, most of which benefit from the shorter hero, however for mobile aside this makes the contained screenshot smaller, so make sure that's ok.

(I haven't removed the one on mobile product pages as that one needs to alternate between Firefox and Focus wordmarks so it's kept for consistency. If there were "Firefox for Android" or "Firefox for iOS" actual wordmarks, these would be a better fit there, to make it immediately obvious it's a mobile product…)

## Issue / Bugzilla link

#180

## Testing

http://localhost:8000/en-US/
http://localhost:8000/en-GB/
http://localhost:8000/en-US/landing/get/
http://localhost:8000/he/landing/get/
http://localhost:8000/skr/
http://localhost:8000/ur/?xv=basic
http://localhost:8000/ro/?xv=basic
(+ the same in mobile /=spoof android UA/ for aside#mobile-banner)