### PR TITLE
Expand list of pages which show the cookie consent banner

### DIFF
--- a/media/js/base/consent/allow-list.es6.js
+++ b/media/js/base/consent/allow-list.es6.js
@@ -4,6 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const MozAllowList = ['/newsletter/'];
+const MozAllowList = [
+    '/newsletter/',
+    // Marketing landing pages
+    '/landing/get/',
+    '/landing/set-as-default/',
+    '/landing/set-as-default/thanks/'
+];
 
 export default MozAllowList;

--- a/tests/unit/spec/base/consent/consent-utils.js
+++ b/tests/unit/spec/base/consent/consent-utils.js
@@ -312,6 +312,9 @@ describe('isURLPermitted()', function () {
     it('should true for pathnames in the allow list irrespective of page locale', function () {
         expect(isURLPermitted('/en-US/newsletter/')).toBeTrue();
         expect(isURLPermitted('/de/newsletter/')).toBeTrue();
+        expect(isURLPermitted('/de/landing/get/')).toBeTrue();
+        expect(isURLPermitted('/de/landing/set-as-default/')).toBeTrue();
+        expect(isURLPermitted('/de/landing/set-as-default/thanks/')).toBeTrue();
     });
 
     it('should still true for allowed pathnames when locale is omitted', function () {


### PR DESCRIPTION
## One-line summary

Expand the set of pages that show cookie consent to be all of the `/landing/` pages, which are product-marketing pages.

Question - should `/landing/set-as-default/thanks/` definitely also show it? I am assuming so

*Please* shout if there are better JS tests to expand related to this changeset


## Issue / Bugzilla link

Resolves #237

## Testing

Ensure you have GPC / DNT disabled in your browser privacy settings.

- [ ] https://www-demo1.springfield.moz.works/en-US/newsletter/?geo=fr - was pre-existing config to show banner; still works
- [ ] https://www-demo1.springfield.moz.works/en-US/newsletter/?geo=us - no consent banner
- [ ] https://www-demo1.springfield.moz.works/en-US/landing/get/?geo=de - shows banner
- [ ] https://www-demo1.springfield.moz.works/en-US/landing/get/?geo=us - no consent banner
- [ ] https://www-demo1.springfield.moz.works/en-US/landing/set-as-default/?geo=de - shows banner
- [ ] https://www-demo1.springfield.moz.works/en-US/landing/set-as-default/?geo=us - no consent banner
- [ ] https://www-demo1.springfield.moz.works/en-US/landing/set-as-default/thanks/?geo=de - shows banner
- [ ] https://www-demo1.springfield.moz.works/en-US/landing/set-as-default/thanks/?geo=us - no consent banner

