### PR TITLE
(fix) Stop creating a redirect loop when a draft page matches a URL path - it should correctly 404

### DIFF
--- a/springfield/cms/middleware.py
+++ b/springfield/cms/middleware.py
@@ -97,7 +97,7 @@ class CMSLocaleFallbackMiddleware:
                 full_url_path = f"{root}/{_url_path}"
                 possible_url_path_patterns.append(full_url_path)
 
-            cms_pages_with_viable_locales = Page.objects.filter(
+            cms_pages_with_viable_locales = Page.objects.live().filter(
                 url_path__in=possible_url_path_patterns,
                 # There's no extra value in filtering with locale__language_code__in=ranked_locales
                 # due to the locale code being embedded in the url_path strings

--- a/springfield/cms/tests/test_middleware.py
+++ b/springfield/cms/tests/test_middleware.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.http import HttpResponse, HttpResponseNotFound
 
 import pytest
+from wagtail.models import Page
 
 from springfield.cms.middleware import CMSLocaleFallbackMiddleware
 
@@ -168,3 +169,23 @@ def test_CMSLocaleFallbackMiddleware_404_with_null_byte_in_url(
     middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
     response = middleware(request)
     assert response.status_code == 404  # rather than a 500 when using postgres
+
+
+def test_CMSLocaleFallbackMiddleware_404_when_no_live_page_exists_only_drafts(
+    rf,
+    tiny_localized_site,
+):
+    # See https://github.com/mozilla/bedrock/issues/16202
+
+    # Unpublish all pages with the matching slug, so only drafts exist - and
+    # we don't expect to be served any of those, of course
+    child_pages = Page.objects.filter(slug="child-page")
+    child_pages.unpublish()
+
+    request = rf.get(
+        "/pt-BR/test-page/child-page/",
+        HTTP_ACCEPT_LANGUAGE="Pt-bR,de-DE,fr;q=0.8,sco;q=0.6",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 404  # rather than a redirect to `child_page`


### PR DESCRIPTION
Prior to this fix, we were looking at all (live and draft) pages to find an alternative to redirect to, which caused a 302 loop

Cross-port of https://github.com/mozilla/bedrock/pull/16205

## Testing

Unit tests passing is enough