### PR TITLE
(fix) Handle edge case in locale-list building when prefer_cms is used but there is nothing yet in the CMS

### DIFF
--- a/springfield/base/templatetags/helpers.py
+++ b/springfield/base/templatetags/helpers.py
@@ -168,8 +168,14 @@ def get_locale_options(request, translations):
     # the locale being requested. In this situation _locales_available_via_cms
     # and _locales_for_django_fallback_view are annotated onto the request.
     # We need to use these to create a more accurate view of what locales are
-    # available
-    if hasattr(request, "_locales_available_via_cms") and hasattr(request, "_locales_for_django_fallback_view"):
+    # available. Also note that being decorated with prefer_cms doesn't guarantee
+    # that the annotated lists of locales contain any values, so we must also count
+    # them to be sure they are viable lists.
+
+    cms_locale_count = len(getattr(request, "_locales_available_via_cms", []))
+    django_fallback_locale_count = len(getattr(request, "_locales_for_django_fallback_view", []))
+
+    if cms_locale_count > 0 and django_fallback_locale_count > 0:
         available_locales = get_translations_native_names(sorted(set(request._locales_available_via_cms + request._locales_for_django_fallback_view)))
 
     return available_locales

--- a/springfield/base/tests/test_helpers.py
+++ b/springfield/base/tests/test_helpers.py
@@ -82,9 +82,24 @@ def test_switch():
             ["de", "pt-BR", "ja-JP", "zh-CN"],
         ),
         (
+            # Just use defaults
             ["en-US", "fr", "sco"],
             [],
             [],
+            ["en-US", "fr", "sco"],
+        ),
+        (
+            # Don't use CMS + Django Fallback
+            ["en-US", "fr", "sco"],
+            ["en-US", "de"],
+            [],
+            ["en-US", "fr", "sco"],
+        ),
+        (
+            # Don't use CMS + Django Fallback
+            ["en-US", "fr", "sco"],
+            [],
+            ["en-US", "de"],
             ["en-US", "fr", "sco"],
         ),
     ),
@@ -92,11 +107,12 @@ def test_switch():
 def test_get_locale_options(rf, translations_locales, cms_locales, django_locales, expected):
     native_translations = get_translations_native_names(translations_locales)
     native_expected = get_translations_native_names(expected)
-
     request = rf.get("/dummy/path/")
 
-    if cms_locales and django_locales:
+    if cms_locales is not None:
         request._locales_available_via_cms = cms_locales
+
+    if django_locales is not None:
         request._locales_for_django_fallback_view = django_locales
 
     assert native_expected == helpers.get_locale_options(


### PR DESCRIPTION
Resolves #268 where we see this bug on the /features/ pages

## Testing

Locally, try some URLs and confirm they show a valid lang picker and that any lang selected is valid (and does not redirect to en-US)

http://localhost:8000/features/
http://localhost:8000/features/fast/
http://localhost:8000/de/features/
http://localhost:8000/de/features/fast/
http://localhost:8000/dsb/features/
http://localhost:8000/dsb/features/fast/
http://localhost:8000/hsb/features/
http://localhost:8000/hsb/features/fast/
http://localhost:8000/rm/features/
http://localhost:8000/rm/features/fast/
