### PR TITLE
update footer to include Mozilla branding (fix #251)

### DIFF
--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -53,6 +53,7 @@ $image-path: '/media/protocol/img';
 @media screen and (min-width: #{$screen-sm}) and (max-width: #{$screen-lg - 1px}) {
     .mzp-c-footer-sections {
         // massive Protocol override
+        border-bottom: transparent;
         column-gap: $spacing-lg;
         display: grid;
         grid-template-areas:
@@ -134,6 +135,12 @@ $image-path: '/media/protocol/img';
     }
 }
 
+@media screen and (min-width: #{$screen-lg}) {
+    .mzp-c-footer-sections {
+        border-color: transparent;
+        padding-bottom: 0;
+    }
+}
 
 /* ----------------------------------------------------------------------------- */
 // Secondary
@@ -177,14 +184,40 @@ $image-path: '/media/protocol/img';
     }
 }
 
+.mzp-c-footer-primary {
+    @media screen and (min-width: #{$screen-lg}) {
+        position: relative;
+    }
+}
+
 .c-footer-logo {
     @extend .mzp-c-footer-primary-logo; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
+    @include footer-line;
+    padding-bottom: $spacing-xl;
+    text-align: center;
+
+    @media screen and (min-width: #{$screen-lg}) {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        text-align: end;
+        width: calc(100% - $layout-lg);
+        @include bidi(((padding-right, $layout-lg, 0), (padding-left, 0, $layout-lg),));
+    }
 
     a {
         background-image: url('/media/img/logos/firefox/logo-word-hor-white.svg');
         background-size: contain;
-        height: 40px;
-        width: 120px;
+        width: 177px;
+        height: 68px;
+    }
+}
+
+.c-footer-branding {
+    margin-bottom: $spacing-xl;
+
+    h2 {
+        padding-top: 0;
     }
 }
 

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -77,6 +77,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <li><a class="podcast" href="https://www.youtube.com/@firefox/podcasts" data-link-position="footer" data-link-text="Podcast" translate="no">Podcast<span></span></a></li>
           </ul>
         </section>
+      </div>
+      <div class="c-footer-logo">
+        <a href="{{ url('firefox') }}" data-link-position="footer" data-link-text="Firefox">{{ ftl('footer-firefox') }}</a>
+      </div>
     </nav>
     <nav class="mzp-c-footer-secondary">
       <div class="mzp-c-footer-legal">
@@ -97,8 +101,9 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       </div>
 
       <div class="c-footer-more">
-        <div class="c-footer-logo">
-          <a href="{{ url('firefox') }}" data-link-position="footer" data-link-text="Firefox">{{ ftl('footer-firefox') }}</a>
+        <div class="c-footer-branding">
+          <h2 class="mzp-c-footer-heading">Powered by Mozilla</h2>
+          <p>Putting people before profits since 1998</p>
         </div>
         <div class="mzp-c-footer-language">
           {% include 'includes/lang-switcher.html' %}


### PR DESCRIPTION
## One-line summary

This PR updates the footer to include Mozilla branding and move Firefox branding.

## Significant changes and points to review

Review footer:
- with various screen sizes
- rtl reading direction

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/251

## Testing

http://localhost:8000/en-US/
