### PR TITLE
Fix link to appropriate version of ESR releasenotes

### DIFF
--- a/springfield/releasenotes/models.py
+++ b/springfield/releasenotes/models.py
@@ -22,6 +22,7 @@ import markdown
 from django_extensions.db.fields.json import JSONField
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
+from product_details import product_details
 from product_details.version_compare import Version
 
 from springfield.base.urlresolvers import reverse
@@ -166,6 +167,13 @@ class ProductReleaseQuerySet(models.QuerySet):
         if product_name.lower() == "firefox extended support release":
             product_name = "firefox"
             channel_name = "esr"
+
+        if channel_name == "esr":
+            # There may be several ESRs in existence at once, so make sure
+            # we get the version declared as the latest in the source of truth.
+            latest_esr = product_details.firefox_versions["FIREFOX_ESR"]
+            version = latest_esr.replace("esr", "")
+
         q = self.filter(product__iexact=product_name)
         if channel_name:
             q = q.filter(channel__iexact=channel_name)

--- a/springfield/releasenotes/tests/test_models.py
+++ b/springfield/releasenotes/tests/test_models.py
@@ -11,6 +11,7 @@ from django.core.cache import caches
 from django.test.utils import override_settings
 
 import markdown
+from product_details import product_details
 
 from springfield.base.tests import TestCase
 from springfield.releasenotes import models
@@ -118,6 +119,18 @@ class TestReleaseModel(TestCase):
         # markdown
         assert note.note.startswith("<p>Firefox Nightly")
         assert note.id == 787203
+
+    def test_product_method_gets_specifically_latest_esr_based_on_product_details(self):
+        _patched_dict = product_details.firefox_versions
+        _patched_dict.update({"FIREFOX_ESR": "999.76"})
+
+        with patch.dict("springfield.releasenotes.models.product_details.firefox_versions", _patched_dict):
+            # See https://github.com/mozilla/bedrock/issues/16289
+            query = models.ProductRelease.objects.product(product_name="firefox", channel_name="esr")
+
+        raw_query_as_str = str(query.query)
+        assert 'AND "releasenotes_productrelease"."channel" LIKE esr' in raw_query_as_str
+        assert 'AND "releasenotes_productrelease"."version" = 999.76' in raw_query_as_str
 
     @override_settings(DEV=False)
     def test_is_public_query(self):


### PR DESCRIPTION
Port of https://github.com/mozilla/bedrock/pull/16328/



This is because we now have more than one ESR available at any one time and the current logic doesn't expect that so just finds the youngest ESR record.

We use the product_details lib as the source of truth for which version we want for the "esr" channel, because we can't depend on the ESR versions being saved/created in a reliable order.

Manually testable by clicking the 'Release notes' link on http://localhost:8000/en-US/download/all/desktop-esr/


