### PR TITLE
(fix) Ensure Send To Device email link is only shown for locales where the form is enabled

### DIFF
--- a/springfield/firefox/templates/firefox/all/mobile.html
+++ b/springfield/firefox/templates/firefox/all/mobile.html
@@ -47,7 +47,9 @@
   {% endif %}
 
   {% if product.slug.startswith('mobile') %}
+    {% if LANG in settings.SEND_TO_DEVICE_LOCALES %}
     <p><a href="{{ url('firefox.browsers.mobile.get-app') }}" class="c-get-app" data-cta-text="Send a link">{{ ftl('firefox-all-product-send-link') }}</a></p>
+    {% endif %}
   {% endif %}
 
 </div>


### PR DESCRIPTION
## Issue / Bugzilla link

Resolves #242 

Also needs to be backported to Bedrock

## Testing

- [ ] http://localhost:8000/en-CA/download/all/mobile-release/ should not show the link to send to device
- [ ] http://localhost:8000/en-GB/download/all/mobile-release/ should show the link - or any locale from "de", "en-GB", "en-US", "es-AR", "es-CL", "es-ES", "es-MX", "fr", "id", "pl", "pt-BR", "ru", "zh-TW"


![Screenshot 2025-06-11 at 15 34 31](https://github.com/user-attachments/assets/c0105f02-62b6-4a75-a188-99ce1e52782a)
![Screenshot 2025-06-11 at 15 34 22](https://github.com/user-attachments/assets/c16c7ed9-886a-4baf-8ad2-c7da1f56efdb)


