### PR TITLE
Only open-ftl-pr after successful image builds

### DIFF
--- a/.github/workflows/send_firefox_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_firefox_fluent_strings_to_l10n_org.yml
@@ -1,7 +1,7 @@
-# Workflow to open a PR on mozilla-l10n/www-l10n with
+# Workflow to open a PR on mozilla-l10n/www-firefox-l10n with
 # new strings that exist in Springfield and need localising
 
-name: Open Fluent PR for Firefox.com
+name: Open Fluent PR in www-firefox-l10n
 
 on:
   workflow_run:
@@ -14,7 +14,9 @@ on:
 
 jobs:
   open_l10n_pr:
-    if: github.repository == 'mozmeao/springfield'
+    if: |
+      github.repository == 'mozmeao/springfield' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run')
     runs-on: ubuntu-latest
     env:
       HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
## One-line summary

Bail early if `workflow_run.conclusion` was not `success`.

## Significant changes and points to review

Chances are the pipeline failed, was cancelled, superseded by another build in the same concurrency group etc., so even the app image might have been skipped. For SHA triggers that never had the container built, pushed, and tagged with that reference, the issue would still be the same, nothing like the HEAD ref available to pull.

I originally didn't want to introduce this, as GH doesn't really have a sane way and everything gets extremely awkward after half a dozen rules you have to consider manually… but this still feels somewhat valuable to actually cancel out the run.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/250#issuecomment-2941088776

## Testing

https://github.com/janbrasna/springfield/actions triggered both by previous checks, and cron.