### PR TITLE
(feat) Add Arabic to list of locales supported by Firefox's Translate feature

### DIFF
--- a/springfield/firefox/templates/firefox/features/translate.html
+++ b/springfield/firefox/templates/firefox/features/translate.html
@@ -23,6 +23,7 @@
 
 <ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
+  <li>Arabic</li>
   <li>Bulgarian</li>
   <li>Catalan</li>
   <li>Chinese (Simplified)</li>

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -682,6 +682,7 @@ class FirefoxFeaturesFreePDFEditor(L10nTemplateView):
 @require_safe
 def firefox_features_translate(request):
     translate_langs = [
+        "ar",
         "bg",
         "ca",
         "zh-CN",


### PR DESCRIPTION
 Ports https://github.com/mozilla/bedrock/issues/16341 from Bedrock

## Testing

## Testing

- [x] http://localhost:8000/en-US/features/translate/
- [x] http://localhost:8000/de/features/translate/ and confirm that Arabic (written in Arabic) 
- [x] Compare with https://www-dev.springfield.moz.works/en-US/features/translate/ which currently does not have Arabic 
