### PR TITLE
Add "Features" menu dropdown

### DIFF
--- a/l10n/en/navigation-firefox.ftl
+++ b/l10n/en/navigation-firefox.ftl
@@ -10,6 +10,13 @@ navigation-landmark-label = Primary
 ## Features
 
 navigation-features = Features
+navigation-close-features-menu = Close Features menu
+navigation-top-features = Top Features
+navigation-fingerprint-blocking = Fingerprint Blocking
+navigation-ad-tracker-blocking = Ad Tracker Blocking
+navigation-private-browsing = Private Browsing Mode
+navigation-password-manager = Free Password Manager
+navigation-features-all = View all Firefox Features
 
 ## Resources
 

--- a/l10n/en/navigation-firefox.ftl
+++ b/l10n/en/navigation-firefox.ftl
@@ -16,7 +16,7 @@ navigation-fingerprint-blocking = Fingerprint Blocking
 navigation-ad-tracker-blocking = Ad Tracker Blocking
 navigation-private-browsing = Private Browsing Mode
 navigation-password-manager = Free Password Manager
-navigation-features-all = View all Firefox Features
+navigation-features-all = View all { -brand-name-firefox } Features
 
 ## Resources
 

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -190,7 +190,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
     a:link,
     a:visited {
-        color: $color-black;
+        color: $token-color-off-black;
         text-decoration: none;
     }
 
@@ -318,15 +318,13 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-menu-category-link {
-    display: flex;
-    font-size: $text-body-md;
-    justify-content: flex-end;
-    margin: $spacer-md 0 0;
-    padding: 0;
-
     a:link,
     a:visited {
         display: flex;
+        justify-content: flex-start;
+        margin: $spacer-md 0 0;
+        padding: $spacer-sm;
+        background: var(--m24-light-orange);
         font-weight: 600;
         position: relative;
         width: fit-content;
@@ -348,15 +346,17 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
         transition-timing-function: $bezier;
         width: auto;
     }
-}
 
-.m24-c-menu-category-link a:hover,
-.m24-c-menu-category-link a:focus {
-    svg {
-        @include bidi((
-            (right, -$spacing-sm, auto),
-            (left, auto, -$spacing-sm),
-        ));
+    a:hover,
+    a:focus {
+        background: var(--m24-orange);
+
+        svg {
+            @include bidi((
+                (right, -$spacing-sm, auto),
+                (left, auto, -$spacing-sm),
+            ));
+        }
     }
 }
 
@@ -432,7 +432,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-menu-subtitle {
-    color: $m24-color-dark-mid-gray;
+    color: $m24-color-black;
     margin: 0;
     padding: $spacing-md 0 $spacing-sm;
 }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -221,16 +221,18 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
         h2::after {
             @include bidi(((margin-left, $spacing-sm, margin-right, 0),));
             content: '';
-            background: url('/media/img/icons/caret-sprite.svg') no-repeat bottom left / auto 12px;
+            background: url('/media/protocol/img/icons/arrow-down.svg') no-repeat center center / auto 16px;
             display: inline-block;
             height: 12px;
             vertical-align: baseline;
             width: 12px;
+            transform-origin: center;
+            transition: transform 0.25s ease;
         }
 
         &.mzp-is-selected {
             h2::after {
-                background-position: bottom right;
+                transform: rotate(-180deg);
             }
         }
     }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -311,9 +311,9 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-menu-category {
-    padding: 8px 16px;
+    padding: $spacing-sm $spacing-md;
     position: relative;
-    width: calc(100% - 32px);
+    width: calc(100% - $spacing-xl);
     z-index: 1000;
 
     @media #{$mq-md} {
@@ -473,7 +473,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
 .m24-c-menu-item-link {
     display: block;
-    padding: 8px 0;
+    padding: $spacing-sm 0;
 
     li:last-child > & {
         padding-bottom: 0;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -305,9 +305,9 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-menu-category {
-    padding: 8px 16px;
+    padding: 8px 16px; // TODO: or spacers to add up calc below?
     position: relative;
-    width: calc(100% - 32px);
+    width: calc(100% - 32px); // TODO: 32px or spacer?
     z-index: 1000;
 
     @media #{$mq-md} {
@@ -350,8 +350,8 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     }
 }
 
-.m24-c-menu-panel .m24-c-menu-category-link a:hover,
-.m24-c-menu-panel .m24-c-menu-category-link a:focus {
+.m24-c-menu-category-link a:hover,
+.m24-c-menu-category-link a:focus {
     svg {
         @include bidi((
             (right, -$spacing-sm, auto),
@@ -409,6 +409,12 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     }
 }
 
+#m24-c-menu-panel-features {
+  @media #{$mq-md} {
+      width: 320px;
+  }
+}
+
 .m24-mzp-is-basic .m24-c-menu-panel {
     display: block;
 
@@ -445,12 +451,15 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     }
 }
 
-.m24-c-menu-panel-content.multi-column {
+.m24-c-menu-panel-content {
     @media #{$mq-md} {
-        display: flex;
         padding: 0 $grid-margin;
-        column-gap: $layout-lg;
         margin: 0 auto;
+
+        &.multi-column {
+            display: flex;
+            column-gap: $layout-lg;
+        }
     }
 }
 

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -354,7 +354,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
     a:hover,
     a:focus {
-        background: var(--m24-orange);
+        background: $token-color-orange;
 
         svg {
             @include bidi((

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -330,7 +330,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
         justify-content: space-between;
         margin: $spacer-md 0 -1em;
         padding: $spacer-sm;
-        background: var(--m24-light-orange);
+        background: $m24-color-light-orange;
         font-weight: 600;
         position: relative;
     }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -321,7 +321,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     display: flex;
     font-size: $text-body-md;
     justify-content: flex-end;
-    margin: $spacer-lg $spacer-lg 0;
+    margin: $spacer-md 0 0;
     padding: 0;
 
     a:link,
@@ -331,7 +331,35 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
         position: relative;
         width: fit-content;
     }
+
+    svg {
+        @include bidi((
+            (left, auto, 0),
+            (margin-left, $spacing-xs, 0),
+            (margin-right, 0, $spacing-xs),
+            (right, 0, auto),
+            (transition-property, right, left),
+            (transform, none, rotate(-180deg)),
+        ));
+        height: 0.8em;
+        position: relative;
+        top: 0.15em;
+        transition-duration: $fast;
+        transition-timing-function: $bezier;
+        width: auto;
+    }
 }
+
+.m24-c-menu-panel .m24-c-menu-category-link a:hover,
+.m24-c-menu-panel .m24-c-menu-category-link a:focus {
+    svg {
+        @include bidi((
+            (right, -$spacing-sm, auto),
+            (left, auto, -$spacing-sm),
+        ));
+    }
+}
+
 
 // * -------------------------------------------------------------------------- */
 // Menu panels

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -321,13 +321,12 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     a:link,
     a:visited {
         display: flex;
-        justify-content: flex-start;
-        margin: $spacer-md 0 0;
+        justify-content: space-between;
+        margin: $spacer-md 0 -1em;
         padding: $spacer-sm;
         background: var(--m24-light-orange);
         font-weight: 600;
         position: relative;
-        width: fit-content;
     }
 
     svg {
@@ -353,8 +352,8 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
         svg {
             @include bidi((
-                (right, -$spacing-sm, auto),
-                (left, auto, -$spacing-sm),
+                (right, -$spacing-xs, auto),
+                (left, auto, -$spacing-xs),
             ));
         }
     }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -311,9 +311,9 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-menu-category {
-    padding: 8px 16px; // TODO: or spacers to add up calc below?
+    padding: 8px 16px;
     position: relative;
-    width: calc(100% - 32px); // TODO: 32px or spacer?
+    width: calc(100% - 32px);
     z-index: 1000;
 
     @media #{$mq-md} {
@@ -473,7 +473,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
 .m24-c-menu-item-link {
     display: block;
-    padding: 8px 0;  // TODO: 8px or token?
+    padding: 8px 0;
 
     li:last-child > & {
         padding-bottom: 0;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -410,7 +410,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
 #m24-c-menu-panel-features {
   @media #{$mq-md} {
-      width: 320px;
+      width: calc($content-md / 2);
   }
 }
 
@@ -444,9 +444,12 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 .m24-c-menu-panel-container {
     margin: 0 auto;
     max-width: $content-max;
+    padding: $spacer-sm $spacer-lg $spacer-lg;
+    background-color: $m24-color-light-gray;
 
     @media #{$mq-md} {
         padding: $spacer-lg 0;
+        background-color: initial;
     }
 }
 
@@ -464,7 +467,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
 .m24-c-menu-item-link {
     display: block;
-    padding: 8px 0;
+    padding: 8px 0;  // TODO: 8px or token?
 
     li:last-child > & {
         padding-bottom: 0;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -227,7 +227,11 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
             vertical-align: baseline;
             width: 12px;
             transform-origin: center;
-            transition: transform 0.25s ease;
+            transition: transform 0.1s ease;
+
+            @media (prefers-reduced-motion: reduce) {
+                transition: none;
+            }
         }
 
         &.mzp-is-selected {

--- a/media/img/icons/caret-sprite.svg
+++ b/media/img/icons/caret-sprite.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" data-name="Ebene 1" viewBox="0 0 34 16">
-  <path d="M14.641 5.299 8 11.939l-6.641-6.64-1.06 1.06L8 14.061l7.701-7.702-1.06-1.06z"/>
-  <path d="M 33.702 13.001 L 26.001 5.3 L 18.3 13.001 L 19.36 14.061 L 26.001 7.422 L 32.642 14.061 L 33.702 13.001 Z" style="stroke-width: 1;"/>
-</svg>

--- a/springfield/base/templates/403_csrf.html
+++ b/springfield/base/templates/403_csrf.html
@@ -1,10 +1,10 @@
 {#
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
- <!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />

--- a/springfield/base/templates/includes/navigation/menus/features.html
+++ b/springfield/base/templates/includes/navigation/menus/features.html
@@ -1,11 +1,61 @@
 {#
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
- #}
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
 
- <li class="m24-c-menu-category">
-  <a class="m24-c-menu-title" href="{{ url('firefox.features.index') }}" data-testid="m24-navigation-link-features">
+<li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="m24-c-menu-title" href="{{ url('firefox.features.index') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-features" data-testid="m24-navigation-link-features">
     <h2>{{ ftl('navigation-features') }}</h2>
   </a>
-</li>
+  <div class="m24-c-menu-panel" id="m24-c-menu-panel-features" data-testid="m24-navigation-menu-features">
+    <div class="m24-c-menu-panel-container">
+      <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-features">{{ ftl('navigation-close-TKTK-menu') }}</button>
+      <div class="m24-c-menu-panel-content multi-column">
+        <div class="m24-mzp-l-content-container">
+          <h3 class="m24-c-menu-subtitle">Secure</h3>
+          <ul class="m24-mzp-l-content">
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.sync') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Sync safely
+              </a>
+            </li>
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.translate') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Translate locally
+              </a>
+            </li>
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.fingerprinting') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Resist fingerprinting
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="m24-mzp-l-content-container">
+          <h3 class="m24-c-menu-subtitle">Customizable</h3>
+          <ul class="m24-mzp-l-content">
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.add-ons') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Extend functionality
+              </a>
+            </li>
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.customize') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Change appearance
+              </a>
+            </li>
+          </ul>
+          <p class="m24-c-menu-category-link">
+            <a href="{{ url('firefox.features.index') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+              Show all
+              <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24" viewBox="0 0 23.4 24" fill="currentColor">
+                <path d="M23.4 12 9.1 0v10.5H0v3h9.1V24l14.3-12zm-11.3-1.5v-4l6.6 5.5-6.6 5.5v-7z"></path>
+              </svg>
+            </a>
+          </p>
+        </div>
+      </div>
+    </div><!-- close .m24-c-menu-panel-container -->
+  </div><!-- close .m24-c-menu-panel -->
+</li><!-- close .m24-c-menu-category -->

--- a/springfield/base/templates/includes/navigation/menus/features.html
+++ b/springfield/base/templates/includes/navigation/menus/features.html
@@ -39,9 +39,7 @@
           <p class="m24-c-menu-category-link">
             <a href="{{ url('firefox.features.index') }}" data-link-text="TKTK" data-link-position="topnav - ???">
               View all Firefox Features
-              <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24" viewBox="0 0 23.4 24" fill="currentColor">
-                <path d="M23.4 12 9.1 0v10.5H0v3h9.1V24l14.3-12zm-11.3-1.5v-4l6.6 5.5-6.6 5.5v-7z"></path>
-              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="m7.24 1.36 5.89 5.89H0v1.5h13.13l-5.89 5.89L8.3 15.7 16 8 8.3.3z"/></svg>
             </a>
           </p>
         </div>

--- a/springfield/base/templates/includes/navigation/menus/features.html
+++ b/springfield/base/templates/includes/navigation/menus/features.html
@@ -11,44 +11,34 @@
   <div class="m24-c-menu-panel" id="m24-c-menu-panel-features" data-testid="m24-navigation-menu-features">
     <div class="m24-c-menu-panel-container">
       <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-features">{{ ftl('navigation-close-TKTK-menu') }}</button>
-      <div class="m24-c-menu-panel-content multi-column">
+      <div class="m24-c-menu-panel-content">
         <div class="m24-mzp-l-content-container">
-          <h3 class="m24-c-menu-subtitle">Secure</h3>
+          <h3 class="m24-c-menu-subtitle">Top Features</h3>
           <ul class="m24-mzp-l-content">
-            <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.sync') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Sync safely
-              </a>
-            </li>
-            <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.translate') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Translate locally
-              </a>
-            </li>
             <li>
               <a class="m24-c-menu-item-link" href="{{ url('firefox.features.fingerprinting') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Resist fingerprinting
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div class="m24-mzp-l-content-container">
-          <h3 class="m24-c-menu-subtitle">Customizable</h3>
-          <ul class="m24-mzp-l-content">
-            <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.add-ons') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Extend functionality
+                Fingerprint Blocking
               </a>
             </li>
             <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.customize') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Change appearance
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.adblocker') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Ad Tracker Blocking
+              </a>
+            </li>
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.private-browsing') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Private Browsing Mode
+              </a>
+            </li>
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.password-manager') }}" data-link-text="TKTK" data-link-position="topnav - ???">
+                Free Password Manager
               </a>
             </li>
           </ul>
           <p class="m24-c-menu-category-link">
             <a href="{{ url('firefox.features.index') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-              Show all
+              View all Firefox Features
               <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24" viewBox="0 0 23.4 24" fill="currentColor">
                 <path d="M23.4 12 9.1 0v10.5H0v3h9.1V24l14.3-12zm-11.3-1.5v-4l6.6 5.5-6.6 5.5v-7z"></path>
               </svg>

--- a/springfield/base/templates/includes/navigation/menus/features.html
+++ b/springfield/base/templates/includes/navigation/menus/features.html
@@ -10,35 +10,35 @@
   </a>
   <div class="m24-c-menu-panel" id="m24-c-menu-panel-features" data-testid="m24-navigation-menu-features">
     <div class="m24-c-menu-panel-container">
-      <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-features">{{ ftl('navigation-close-TKTK-menu') }}</button>
+      <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-features">{{ ftl('navigation-close-features-menu') }}</button>
       <div class="m24-c-menu-panel-content">
         <div class="m24-mzp-l-content-container">
-          <h3 class="m24-c-menu-subtitle">Top Features</h3>
+          <h3 class="m24-c-menu-subtitle">{{ ftl('navigation-top-features') }}</h3>
           <ul class="m24-mzp-l-content">
             <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.fingerprinting') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Fingerprint Blocking
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.fingerprinting') }}" data-link-text="Fingerprint Blocking" data-link-position="topnav - fingerprinting">
+                {{ ftl('navigation-fingerprint-blocking') }}
               </a>
             </li>
             <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.adblocker') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Ad Tracker Blocking
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.adblocker') }}" data-link-text="Ad Tracker Blocking" data-link-position="topnav - antitracking">
+                {{ ftl('navigation-ad-tracker-blocking') }}
               </a>
             </li>
             <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.private-browsing') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Private Browsing Mode
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.private-browsing') }}" data-link-text="Private Browsing Mode" data-link-position="topnav - privatebrowsing">
+                {{ ftl('navigation-private-browsing') }}
               </a>
             </li>
             <li>
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.password-manager') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-                Free Password Manager
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.features.password-manager') }}" data-link-text="Free Password Manager" data-link-position="topnav - passwords">
+                {{ ftl('navigation-password-manager') }}
               </a>
             </li>
           </ul>
           <p class="m24-c-menu-category-link">
-            <a href="{{ url('firefox.features.index') }}" data-link-text="TKTK" data-link-position="topnav - ???">
-              View all Firefox Features
+            <a href="{{ url('firefox.features.index') }}" data-link-text="View all Firefox Features" data-link-position="topnav - all features">
+              {{ ftl('navigation-features-all') }}
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="m7.24 1.36 5.89 5.89H0v1.5h13.13l-5.89 5.89L8.3 15.7 16 8 8.3.3z"/></svg>
             </a>
           </p>

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -1,64 +1,66 @@
 {#
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
- #}
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
 
- {% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
 
- <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
-   <a class="m24-c-menu-title" href="#m24-c-menu-panel-resources" aria-haspopup="true" aria-controls="m24-c-menu-panel-resources" data-testid="m24-navigation-link-resources">
+<li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="m24-c-menu-title" href="#m24-c-menu-panel-resources" aria-haspopup="true" aria-controls="m24-c-menu-panel-resources" data-testid="m24-navigation-link-resources">
     <h2>{{ ftl('navigation-resources') }}</h2>
   </a>
-   <div class="m24-c-menu-panel" id="m24-c-menu-panel-resources" data-testid="m24-navigation-menu-resources">
-     <div class="m24-c-menu-panel-container">
-       <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-resources">{{ ftl('navigation-close-resources-menu') }}</button>
-       <div class="m24-c-menu-panel-content multi-column">
+  <div class="m24-c-menu-panel" id="m24-c-menu-panel-resources" data-testid="m24-navigation-menu-resources">
+    <div class="m24-c-menu-panel-container">
+      <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-resources">{{ ftl('navigation-close-resources-menu') }}</button>
+      <div class="m24-c-menu-panel-content multi-column">
         <div class="m24-mzp-l-content-container">
           <h3 class="m24-c-menu-subtitle">{{ ftl('navigation-product') }}</h3>
           <ul class="m24-mzp-l-content">
             <li>
-                <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.desktop.index') }}" data-link-text="Desktop" data-link-position="topnav - desktop" data-testid="m24-navigation-menu-link-firefox-desktop">
-                 {{ ftl('navigation-desktop') }}
-                </a>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.desktop.index') }}" data-link-text="Desktop" data-link-position="topnav - desktop" data-testid="m24-navigation-menu-link-firefox-desktop">
+                {{ ftl('navigation-desktop') }}
+              </a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.index') }}" data-link-text="Mobile" data-link-position="topnav - mobile">
-                 {{ ftl('navigation-mobile') }}
-                </a>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.index') }}" data-link-text="Mobile" data-link-position="topnav - mobile">
+                {{ ftl('navigation-mobile') }}
+              </a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="{{ url('firefox.notes') }}" data-link-text="Release Notes" data-link-position="topnav - release notes">{{ ftl('navigation-release-notes') }}</a>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.notes') }}" data-link-text="Release Notes" data-link-position="topnav - release notes">
+                {{ ftl('navigation-release-notes') }}
+              </a>
             </li>
             <li>
-                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/{{params}}" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
+              {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+              <a class="m24-c-menu-item-link" href="https://support.mozilla.org/{{params}}" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
             </li>
             <li>
-                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/{{params}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
+              {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+              <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/{{params}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
             </li>
-           </ul>
+          </ul>
         </div>
         <div class="m24-mzp-l-content-container">
           <h3 class="m24-c-menu-subtitle">{{ ftl('navigation-learn') }}</h3>
           <ul class="m24-mzp-l-content">
             <li>
-                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/{{params}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
+              {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+              <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/{{params}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
             </li>
             <li>
-                <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.compare.index') }}" data-link-text="Compare" data-link-position="topnav - compare">
-                 {{ ftl('navigation-compare') }}
-                </a>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.compare.index') }}" data-link-text="Compare" data-link-position="topnav - compare">
+                {{ ftl('navigation-compare') }}
+              </a>
             </li>
             <li>
-                {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts{{params}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
+              {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
+              <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts{{params}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
             </li>
           </ul>
         </div>
-       </div>
-     </div><!-- close .m24-c-menu-panel-container -->
-   </div><!-- close .m24-c-menu-panel -->
- </li><!-- close .m24-c-menu-category -->
+      </div>
+    </div><!-- close .m24-c-menu-panel-container -->
+  </div><!-- close .m24-c-menu-panel -->
+</li><!-- close .m24-c-menu-category -->

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -61,4 +61,4 @@
        </div>
      </div><!-- close .m24-c-menu-panel-container -->
    </div><!-- close .m24-c-menu-panel -->
- </li><!-- close about us -->
+ </li><!-- close .m24-c-menu-category -->

--- a/springfield/base/templates/includes/navigation/navigation.html
+++ b/springfield/base/templates/includes/navigation/navigation.html
@@ -1,11 +1,12 @@
 {#
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
- #}
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
 
- {% include 'includes/banners/pencil-banner.html' %}
- <nav class="m24-navigation m24-mzp-is-sticky" aria-label="{{ ftl('navigation-landmark-label') }}">
+{% include 'includes/banners/pencil-banner.html' %}
+
+<nav class="m24-navigation m24-mzp-is-sticky" aria-label="{{ ftl('navigation-landmark-label') }}">
   <div class="m24-c-navigation-l-content">
     <div class="m24-c-navigation-container">
       <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>


### PR DESCRIPTION
## One-line summary

Add menu items for "Features" navigation item.

## Significant changes and points to review

Some headings and colors were updated with that design.

New treatment was designed for mobile panels.

Q: mobile design calls for grey inset background (only for "Features" or any nav panel?) — not being sure now how to distinguish top nav heading link vs. panel heading without a link both looking the same currently in the mobile nav, I applied the grey background to both panels to make the two heading levels more distinct.

(Fixed some whitespace in surrounding files with it.)

Changed the chevron from sprite to single icon & rotate -180deg on hover.

## Issue / Bugzilla link

#235

## Testing