### PR TITLE
Sweep external mozorg links for UTM params (fixes #232)

### DIFF
--- a/springfield/base/templates/404.html
+++ b/springfield/base/templates/404.html
@@ -6,7 +6,7 @@
 
 {% extends "base-error.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-404&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=404' %}
 
 {% block page_title %}{{ ftl('not-found-page-not-found-page-page-not-found') }}{% endblock %}
 

--- a/springfield/base/templates/404.html
+++ b/springfield/base/templates/404.html
@@ -6,7 +6,7 @@
 
 {% extends "base-error.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=404' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=404' %}
 
 {% block page_title %}{{ ftl('not-found-page-not-found-page-page-not-found') }}{% endblock %}
 
@@ -29,7 +29,7 @@
     <ul class="content-list">
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-        {{ ftl('not-found-page-learn-about-mozilla-the-non', about="https://www.mozilla.org/about/" + referrals) }}
+        {{ ftl('not-found-page-learn-about-mozilla-the-non', about="https://www.mozilla.org/about/" + params) }}
       </li>
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">

--- a/springfield/base/templates/404.html
+++ b/springfield/base/templates/404.html
@@ -6,6 +6,8 @@
 
 {% extends "base-error.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-404&utm_medium=referral' %}
+
 {% block page_title %}{{ ftl('not-found-page-not-found-page-page-not-found') }}{% endblock %}
 
 {% block page_css %}
@@ -27,7 +29,7 @@
     <ul class="content-list">
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-        {{ ftl('not-found-page-learn-about-mozilla-the-non', about="https://www.mozilla.org/about/") }}
+        {{ ftl('not-found-page-learn-about-mozilla-the-non', about="https://www.mozilla.org/about/" + referrals) }}
       </li>
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">

--- a/springfield/base/templates/500.html
+++ b/springfield/base/templates/500.html
@@ -6,7 +6,7 @@
 
 {% extends "base-error.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=500' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=500' %}
 
 {% block page_title %}{{ ftl('error-page-error-page-internal-server-error') }}{% endblock %}
 
@@ -19,7 +19,7 @@
     <h1 class="error-title">{{ ftl('error-page-something-went-wrong') }}</h1>
     <p>
       {{ ftl('error-page-its-probably-just-a-server-error') }}<br>
-      {{ ftl('error-page-you-can-also-try-refreshing', firefox="https://www.firefox.com", mozilla="https://www.mozilla.org/" + referrals) }}
+      {{ ftl('error-page-you-can-also-try-refreshing', firefox="https://www.firefox.com", mozilla="https://www.mozilla.org/" + params) }}
     </p>
   </main>
 {% endblock %}

--- a/springfield/base/templates/500.html
+++ b/springfield/base/templates/500.html
@@ -6,7 +6,7 @@
 
 {% extends "base-error.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-500&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=500' %}
 
 {% block page_title %}{{ ftl('error-page-error-page-internal-server-error') }}{% endblock %}
 

--- a/springfield/base/templates/500.html
+++ b/springfield/base/templates/500.html
@@ -6,6 +6,8 @@
 
 {% extends "base-error.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-500&utm_medium=referral' %}
+
 {% block page_title %}{{ ftl('error-page-error-page-internal-server-error') }}{% endblock %}
 
 {% block page_css %}
@@ -17,7 +19,7 @@
     <h1 class="error-title">{{ ftl('error-page-something-went-wrong') }}</h1>
     <p>
       {{ ftl('error-page-its-probably-just-a-server-error') }}<br>
-      {{ ftl('error-page-you-can-also-try-refreshing', firefox="https://www.firefox.com", mozilla="https://www.mozilla.org/") }}
+      {{ ftl('error-page-you-can-also-try-refreshing', firefox="https://www.firefox.com", mozilla="https://www.mozilla.org/" + referrals) }}
     </p>
   </main>
 {% endblock %}

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -5,7 +5,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=footer' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=footer' %}
 
 
 {% if switch('show-feedback-form') %}
@@ -55,8 +55,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             {{ ftl('footer-community') }}
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-community">
-            <li><a href="https://connect.mozilla.org/{{referrals}}" data-link-position="footer" data-link-text="Connect">{{ ftl('footer-connect') }}</a></li>
-            <li><a href="https://www.mozilla.org/contribute/{{referrals}}" data-link-position="footer" data-link-text="Contribute">{{ ftl('footer-contribute') }}</a></li>
+            <li><a href="https://connect.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Connect">{{ ftl('footer-connect') }}</a></li>
+            <li><a href="https://www.mozilla.org/contribute/{{params}}" data-link-position="footer" data-link-text="Contribute">{{ ftl('footer-contribute') }}</a></li>
             <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Developer">{{ ftl('footer-developer') }}</a></li>
           </ul>
         </section>
@@ -69,10 +69,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-position="footer" data-link-text="Compare">{{ ftl('footer-compare') }}</a></li>
             <li><a href="{{ url('firefox.notes') }}" data-link-position="footer" data-link-text="Release Notes">{{ ftl('footer-release-notes') }}</a></li>
             <li><a href="{{ url('firefox.more.index') }}" data-link-position="footer" data-link-text="Learn">{{ ftl('footer-learn') }}</a></li>
-            <li><a href="https://support.mozilla.org/{{referrals}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
-            <li><a href="https://addons.mozilla.org/firefox/{{referrals}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
-            <li><a href="https://community.mozilla.org/{{referrals}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>
-            <li><a href="https://blog.mozilla.org/en/category/firefox/{{referrals}}" data-link-position="footer" data-link-text="Blog">{{ ftl('footer-blog') }}</a></li>
+            <li><a href="https://support.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
+            <li><a href="https://addons.mozilla.org/firefox/{{params}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
+            <li><a href="https://community.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>
+            <li><a href="https://blog.mozilla.org/en/category/firefox/{{params}}" data-link-position="footer" data-link-text="Blog">{{ ftl('footer-blog') }}</a></li>
           </ul>
         </section>
 
@@ -100,14 +100,14 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             {# Legal requirement in Germany see bedrock issue #14240 #}
             <li><a href="https://www.mozilla.org/de/about/legal/impressum/" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
           {% endif %}
-          <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ referrals }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
-          <li><a href="https://www.mozilla.org/about/legal/terms/firefox/{{ referrals }}" data-link-position="footer" data-link-text="Terms of Use">{{ ftl('footer-terms-of-use') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ params }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
+          <li><a href="https://www.mozilla.org/about/legal/terms/firefox/{{ params }}" data-link-position="footer" data-link-text="Terms of Use">{{ ftl('footer-terms-of-use') }}</a></li>
           <li>
             {# Link to /privacy/websites/cookie-settings/ is a legal requirement and should not be removed. It must be present on every page (bedrock Issue 14213). #}
             <a href="{{ url('privacy.cookie-settings') }}" data-link-position="footer" data-link-text="Cookies">{{ ftl('footer-websites-cookie-policy', fallback='footer-websites-cookies') }}</a>
           </li>
-          <li><a href="https://www.mozilla.org/{{ LANG }}/about/governance/policies/participation/{{ referrals }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
-          <li><a href="https://www.mozilla.org/foundation/trademarks/policy/{{ referrals }}" data-link-position="footer" data-link-text="Logo Trademark Licensing">{{ ftl('footer-logo-trademark-licensing') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/about/governance/policies/participation/{{ params }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
+          <li><a href="https://www.mozilla.org/foundation/trademarks/policy/{{ params }}" data-link-position="footer" data-link-text="Logo Trademark Licensing">{{ ftl('footer-logo-trademark-licensing') }}</a></li>
         </ul>
       </div>
 

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -5,7 +5,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=footer' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=footer' %}
 
 
 {% if switch('show-feedback-form') %}
@@ -55,8 +55,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             {{ ftl('footer-community') }}
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-community">
-            <li><a href="https://connect.mozilla.org/?{{utm_params}}" data-link-position="footer" data-link-text="Connect">{{ ftl('footer-connect') }}</a></li>
-            <li><a href="https://www.mozilla.org/contribute/?{{utm_params}}" data-link-position="footer" data-link-text="Contribute">{{ ftl('footer-contribute') }}</a></li>
+            <li><a href="https://connect.mozilla.org/{{referrals}}" data-link-position="footer" data-link-text="Connect">{{ ftl('footer-connect') }}</a></li>
+            <li><a href="https://www.mozilla.org/contribute/{{referrals}}" data-link-position="footer" data-link-text="Contribute">{{ ftl('footer-contribute') }}</a></li>
             <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Developer">{{ ftl('footer-developer') }}</a></li>
           </ul>
         </section>
@@ -69,10 +69,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-position="footer" data-link-text="Compare">{{ ftl('footer-compare') }}</a></li>
             <li><a href="{{ url('firefox.notes') }}" data-link-position="footer" data-link-text="Release Notes">{{ ftl('footer-release-notes') }}</a></li>
             <li><a href="{{ url('firefox.more.index') }}" data-link-position="footer" data-link-text="Learn">{{ ftl('footer-learn') }}</a></li>
-            <li><a href="https://support.mozilla.org/?{{utm_params}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
-            <li><a href="https://addons.mozilla.org/firefox/?{{utm_params}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
-            <li><a href="https://community.mozilla.org/?{{utm_params}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>
-            <li><a href="https://blog.mozilla.org/en/category/firefox/?{{utm_params}}" data-link-position="footer" data-link-text="Blog">{{ ftl('footer-blog') }}</a></li>
+            <li><a href="https://support.mozilla.org/{{referrals}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
+            <li><a href="https://addons.mozilla.org/firefox/{{referrals}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
+            <li><a href="https://community.mozilla.org/{{referrals}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>
+            <li><a href="https://blog.mozilla.org/en/category/firefox/{{referrals}}" data-link-position="footer" data-link-text="Blog">{{ ftl('footer-blog') }}</a></li>
           </ul>
         </section>
 
@@ -100,14 +100,14 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             {# Legal requirement in Germany see bedrock issue #14240 #}
             <li><a href="https://www.mozilla.org/de/about/legal/impressum/" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
           {% endif %}
-          <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/?{{ utm_params }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
-          <li><a href="https://www.mozilla.org/about/legal/terms/firefox/?{{ utm_params }}" data-link-position="footer" data-link-text="Terms of Use">{{ ftl('footer-terms-of-use') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ referrals }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
+          <li><a href="https://www.mozilla.org/about/legal/terms/firefox/{{ referrals }}" data-link-position="footer" data-link-text="Terms of Use">{{ ftl('footer-terms-of-use') }}</a></li>
           <li>
             {# Link to /privacy/websites/cookie-settings/ is a legal requirement and should not be removed. It must be present on every page (bedrock Issue 14213). #}
             <a href="{{ url('privacy.cookie-settings') }}" data-link-position="footer" data-link-text="Cookies">{{ ftl('footer-websites-cookie-policy', fallback='footer-websites-cookies') }}</a>
           </li>
-          <li><a href="https://www.mozilla.org/{{ LANG }}/about/governance/policies/participation/?{{ utm_params }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
-          <li><a href="https://www.mozilla.org/foundation/trademarks/policy/?{{ utm_params }}" data-link-position="footer" data-link-text="Logo Trademark Licensing">{{ ftl('footer-logo-trademark-licensing') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/about/governance/policies/participation/{{ referrals }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
+          <li><a href="https://www.mozilla.org/foundation/trademarks/policy/{{ referrals }}" data-link-position="footer" data-link-text="Logo Trademark Licensing">{{ ftl('footer-logo-trademark-licensing') }}</a></li>
         </ul>
       </div>
 

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
+ {% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
    <a class="m24-c-menu-title" href="#m24-c-menu-panel-resources" aria-haspopup="true" aria-controls="m24-c-menu-panel-resources" data-testid="m24-navigation-link-resources">
@@ -32,11 +32,11 @@
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
+                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/{{referrals}}" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/?{{utm_params}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
+                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/{{referrals}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
             </li>
            </ul>
         </div>
@@ -45,7 +45,7 @@
           <ul class="m24-mzp-l-content">
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/?{{utm_params}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
+                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/{{referrals}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
             </li>
             <li>
                 <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.compare.index') }}" data-link-text="Compare" data-link-position="topnav - compare">
@@ -54,7 +54,7 @@
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts?{{utm_params}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
+                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts{{referrals}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
             </li>
           </ul>
         </div>

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
+ {% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=resources' %}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
    <a class="m24-c-menu-title" href="#m24-c-menu-panel-resources" aria-haspopup="true" aria-controls="m24-c-menu-panel-resources" data-testid="m24-navigation-link-resources">
@@ -32,11 +32,11 @@
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/{{referrals}}" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
+                <a class="m24-c-menu-item-link" href="https://support.mozilla.org/{{params}}" data-link-text="Support" data-link-position="topnav - support">{{ ftl('navigation-support') }}</a>
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/{{referrals}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
+                <a class="m24-c-menu-item-link" href="https://addons.mozilla.org/firefox/{{params}}" data-link-text="Add-Ons" data-link-position="topnav - addons">{{ ftl('navigation-add-ons') }}</a>
             </li>
            </ul>
         </div>
@@ -45,7 +45,7 @@
           <ul class="m24-mzp-l-content">
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/{{referrals}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
+                <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/en/category/firefox/{{params}}" data-link-text="Blog" data-link-position="topnav - blog">{{ ftl('navigation-blog') }}</a>
             </li>
             <li>
                 <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.compare.index') }}" data-link-text="Compare" data-link-position="topnav - compare">
@@ -54,7 +54,7 @@
             </li>
             <li>
                 {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
-                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts{{referrals}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
+                <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts{{params}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
             </li>
           </ul>
         </div>

--- a/springfield/base/templates/includes/navigation/nav-cta.html
+++ b/springfield/base/templates/includes/navigation/nav-cta.html
@@ -4,8 +4,6 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=cta' %}
-
 {% if not hide_nav_cta %}
     {% if not custom_nav_cta %}
       {% if not hide_nav_download_button %}

--- a/springfield/firefox/templates/firefox/all/base.html
+++ b/springfield/firefox/templates/firefox/all/base.html
@@ -74,7 +74,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{ params }">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-nightly" %}

--- a/springfield/firefox/templates/firefox/all/base.html
+++ b/springfield/firefox/templates/firefox/all/base.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% set campaign = "firefox-all" %}
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=' + campaign %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=' + campaign %}
 
 
 {% if product and platform %}
@@ -58,7 +58,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-beta" %}
@@ -66,7 +66,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-developer" %}
@@ -74,7 +74,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{ referrals }">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{ params }">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-nightly" %}
@@ -82,7 +82,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-esr" %}
@@ -90,7 +90,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "android-beta" %}
@@ -121,8 +121,8 @@
         {% endif %}
         <div class="c-support-links">
           <ul>
-            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/{{ referrals }}&utm_content=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
+            <li><a href="https://support.mozilla.org/products/{{ params }}&utm_content=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
           </ul>
         </div>
       </div>

--- a/springfield/firefox/templates/firefox/all/base.html
+++ b/springfield/firefox/templates/firefox/all/base.html
@@ -3,6 +3,7 @@
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
+
 {% extends "base-protocol.html" %}
 
 {%- block page_title -%}
@@ -33,6 +34,8 @@
 {% endblock %}
 
 {% set campaign = "firefox-all" %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=' + campaign %}
+
 
 {% if product and platform %}
   {% set current_step = ftl('firefox-all-choose-language') %}
@@ -55,7 +58,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-beta" %}
@@ -63,7 +66,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-developer" %}
@@ -71,7 +74,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{ referrals }">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-nightly" %}
@@ -79,7 +82,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "desktop-esr" %}
@@ -87,7 +90,7 @@
               <ul>
                 <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
                 <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ referrals }}">{{ ftl('firefox-all-source-code') }}</a></li>
               </ul>
             </div>
           {% elif product.slug == "android-beta" %}
@@ -118,8 +121,8 @@
         {% endif %}
         <div class="c-support-links">
           <ul>
-            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
+            <li><a href="https://support.mozilla.org/products/{{ referrals }}&utm_content=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
           </ul>
         </div>
       </div>

--- a/springfield/firefox/templates/firefox/browsers/compare/base-article.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/base-article.html
@@ -13,7 +13,7 @@
   {{ css_bundle('firefox-compare-article') }}
 {% endblock page_css %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=browser-comparison' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=browser-comparison' %}
 
 {% block article_title %}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/browsers/compare/base-article.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/base-article.html
@@ -13,7 +13,7 @@
   {{ css_bundle('firefox-compare-article') }}
 {% endblock page_css %}
 
-{% set utm_params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=browser-comparison' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=browser-comparison' %}
 
 {% block article_title %}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/browsers/compare/brave.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/brave.html
@@ -16,7 +16,7 @@
 
 <p>{{ ftl('compare-brave-firefox-makes-it-easy-for-you') }}</p>
 
-<p>{{ ftl('compare-brave-firefox-gives-you-the-option', primary='href="https://support.mozilla.org/kb/use-primary-password-protect-stored-logins%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
+<p>{{ ftl('compare-brave-firefox-gives-you-the-option', primary='href="https://support.mozilla.org/kb/use-primary-password-protect-stored-logins%s" rel="external noopener" target="_blank"'|safe|format(params)) }}</p>
 
 <p>{{ ftl('compare-shared-we-also-offer-easy') }}</p>
 <ul class="mzp-u-list-styled">
@@ -26,5 +26,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-brave-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
+<p>{{ ftl('compare-brave-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(params)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/brave.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/brave.html
@@ -16,7 +16,7 @@
 
 <p>{{ ftl('compare-brave-firefox-makes-it-easy-for-you') }}</p>
 
-<p>{{ ftl('compare-brave-firefox-gives-you-the-option', primary='href="https://support.mozilla.org/kb/use-primary-password-protect-stored-logins%s" rel="external noopener" target="_blank"'|safe|format(utm_params)) }}</p>
+<p>{{ ftl('compare-brave-firefox-gives-you-the-option', primary='href="https://support.mozilla.org/kb/use-primary-password-protect-stored-logins%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
 
 <p>{{ ftl('compare-shared-we-also-offer-easy') }}</p>
 <ul class="mzp-u-list-styled">
@@ -26,5 +26,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-brave-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(utm_params)) }}</p>
+<p>{{ ftl('compare-brave-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/chrome.html
@@ -26,5 +26,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-chrome-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/switching-chrome-firefox%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
+<p>{{ ftl('compare-chrome-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/switching-chrome-firefox%s" rel="external noopener" target="_blank"'|safe|format(params)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/chrome.html
@@ -26,5 +26,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-chrome-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/switching-chrome-firefox%s" rel="external noopener" target="_blank"'|safe|format(utm_params)) }}</p>
+<p>{{ ftl('compare-chrome-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/switching-chrome-firefox%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/edge.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/edge.html
@@ -28,5 +28,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-edge-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-bookmarks-and-other-data-microsoft-edge%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
+<p>{{ ftl('compare-edge-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-bookmarks-and-other-data-microsoft-edge%s" rel="external noopener" target="_blank"'|safe|format(params)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/edge.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/edge.html
@@ -28,5 +28,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-edge-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-bookmarks-and-other-data-microsoft-edge%s" rel="external noopener" target="_blank"'|safe|format(utm_params)) }}</p>
+<p>{{ ftl('compare-edge-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-bookmarks-and-other-data-microsoft-edge%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/opera.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/opera.html
@@ -26,6 +26,6 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-opera-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
+<p>{{ ftl('compare-opera-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(params)) }}</p>
 
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/opera.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/opera.html
@@ -26,6 +26,6 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-opera-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(utm_params)) }}</p>
+<p>{{ ftl('compare-opera-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/import-data-another-browser%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
 
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/safari.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/safari.html
@@ -27,5 +27,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-safari-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/importing-safari-data-firefox%s" rel="external noopener" target="_blank"'|safe|format(utm_params)) }}</p>
+<p>{{ ftl('compare-safari-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/importing-safari-data-firefox%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/compare/safari.html
+++ b/springfield/firefox/templates/firefox/browsers/compare/safari.html
@@ -27,5 +27,5 @@
 
 <h2>{{ ftl('compare-shared-its-easy-to-switch') }}</h2>
 
-<p>{{ ftl('compare-safari-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/importing-safari-data-firefox%s" rel="external noopener" target="_blank"'|safe|format(referrals)) }}</p>
+<p>{{ ftl('compare-safari-switching-to-firefox-is-easy', howto='href="https://support.mozilla.org/kb/importing-safari-data-firefox%s" rel="external noopener" target="_blank"'|safe|format(params)) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/browsers/desktop/base.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/base.html
@@ -20,7 +20,7 @@
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 
-{% set referrals = link_referrals or '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
+{% set params = link_params or '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
 
 {# meta #}
 {% set meta_title_prefix = meta_title_prefix or ftl('firefox-new-download-browser', fallback='firefox-new-download-firefox') %}
@@ -96,7 +96,7 @@
         <li><a href="{{ firefox_url('desktop', 'all') }}">{{ small_advanced }}</a></li>
         <li><a href="{{ firefox_url('desktop', 'all') }}">{{ small_lang }}</a></li>
         {% endif %}
-        <li><a href="https://support.mozilla.org/products/firefox{{ referrals }}&utm_content=need-help-link">{{ small_help }}</a></li>
+        <li><a href="https://support.mozilla.org/products/firefox{{ params }}&utm_content=need-help-link">{{ small_help }}</a></li>
       </ul>
     </div>
     {% endblock %}

--- a/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source==www.firefox.com&utm_medium=referral&utm_campaign=desktop-browsers-chromebook&utm_content=seo' %}
+{% set params = '?utm_source==www.firefox.com&utm_medium=referral&utm_campaign=desktop-browsers-chromebook&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('browsers-chromebook-get-firefox-browser') }}{% endblock %}
 
@@ -57,7 +57,7 @@
         </a>
       </li>
       <li class="mzp-c-menu-list-item t-sumo">
-        <a href="https://support.mozilla.org/kb/run-firefox-chromeos{{ referrals }}" rel="external noopener" data-cta-text="Install Firefox for Chromebook">
+        <a href="https://support.mozilla.org/kb/run-firefox-chromeos{{ params }}" rel="external noopener" data-cta-text="Install Firefox for Chromebook">
           {{ ftl('browsers-chromebook-get-firefox-desktop') }}
         </a>
       </li>
@@ -117,7 +117,7 @@
           }
         ) }}
 
-        <p>{{ ftl('browsers-chromebook-install-firefox-as', url='href="https://support.mozilla.org/kb/run-firefox-chromeos%s" rel="external noopener" data-cta-text="Install Firefox for Chromebook" '|safe|format(referrals)) }}</p>
+        <p>{{ ftl('browsers-chromebook-install-firefox-as', url='href="https://support.mozilla.org/kb/run-firefox-chromeos%s" rel="external noopener" data-cta-text="Install Firefox for Chromebook" '|safe|format(params)) }}</p>
       </div>
     </div>
   </section>

--- a/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
@@ -9,6 +9,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% set referrals = '?utm_source==www.firefox.com-desktop-browsers-chromebook&utm_medium=referral&utm_campaign=seo' %}
+
 {% block page_title %}{{ ftl('browsers-chromebook-get-firefox-browser') }}{% endblock %}
 
 {% block page_desc %} {{ ftl('browsers-chromebook-so-youve-got') }} {% endblock %}
@@ -55,7 +57,7 @@
         </a>
       </li>
       <li class="mzp-c-menu-list-item t-sumo">
-        <a href="https://support.mozilla.org/kb/run-firefox-chromeos?utm_source=www.firefox.com-desktop-browsers-chromebook&amp;utm_medium=referral&amp;utm_campaign=seo" rel="external noopener" data-cta-text="Install Firefox for Chromebook">
+        <a href="https://support.mozilla.org/kb/run-firefox-chromeos{{ referrals }}" rel="external noopener" data-cta-text="Install Firefox for Chromebook">
           {{ ftl('browsers-chromebook-get-firefox-desktop') }}
         </a>
       </li>
@@ -115,7 +117,7 @@
           }
         ) }}
 
-        <p>{{ ftl('browsers-chromebook-install-firefox-as', url='href="https://support.mozilla.org/kb/run-firefox-chromeos?utm_source=www.firefox.com-browsers-desktop-chromebook&amp;utm_medium=referral&amp;utm_campaign=seo" rel="external noopener" data-cta-text="Install Firefox for Chromebook" '|safe) }}</p>
+        <p>{{ ftl('browsers-chromebook-install-firefox-as', url='href="https://support.mozilla.org/kb/run-firefox-chromeos%s" rel="external noopener" data-cta-text="Install Firefox for Chromebook" '|safe|format(referrals)) }}</p>
       </div>
     </div>
   </section>

--- a/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set params = '?utm_source==www.firefox.com&utm_medium=referral&utm_campaign=desktop-browsers-chromebook&utm_content=seo' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=desktop-browsers-chromebook&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('browsers-chromebook-get-firefox-browser') }}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/chromebook.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source==www.firefox.com-desktop-browsers-chromebook&utm_medium=referral&utm_campaign=seo' %}
+{% set referrals = '?utm_source==www.firefox.com&utm_medium=referral&utm_campaign=desktop-browsers-chromebook&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('browsers-chromebook-get-firefox-browser') }}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/browsers/desktop/index.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/index.html
@@ -39,7 +39,7 @@
 
 {% set android_url = play_store_url('firefox', 'firefox-desktop') %}
 {% set ios_url = app_store_url('firefox', 'firefox-desktop') %}
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
 {% set _entrypoint = 'firefox.com-firefox-desktop' %}
 
 {% block content %}

--- a/springfield/firefox/templates/firefox/browsers/mobile/index.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/index.html
@@ -12,7 +12,7 @@
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 {% set android_url = play_store_url('firefox', 'firefox-browsers-mobile') %}
 {% set ios_url = app_store_url('firefox', 'firefox-browsers-mobile') %}
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-mobile' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-mobile' %}
 {% set _entrypoint = 'www.firefox.com-firefox-mobile' %}
 
 {% block page_title %}{{ ftl('browsers-mobile-firefox-mobile-browsers-put') }}{% endblock %}

--- a/springfield/firefox/templates/firefox/channel/android.html
+++ b/springfield/firefox/templates/firefox/channel/android.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/channel/base.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-channel-android&utm_medium=referral' %}
+
 {% block page_title_suffix %}{% endblock %}
 
 {% block page_title %}
@@ -43,10 +45,10 @@
     </ul>
     <p>
       {% if ftl_has_messages('firefox-channel-beta-is-an-unstable-testing') %}
-        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/#pre-release') }}
+        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
       {% else %}
         {{ ftl('firefox-channel-firefox-beta-automatically') }}
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/#pre-release">{{ ftl('ui-learn-more') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>
@@ -75,10 +77,10 @@
     </ul>
     <p>
     {% if ftl_has_messages('firefox-channel-nightly-is-an-unstable-testing') %}
-      {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/#pre-release') }}
+      {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
     {% else %}
       {{ ftl('firefox-channel-firefox-nightly-automatically') }}
-      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/#pre-release">{{ ftl('ui-learn-more') }}</a>
+      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
     </p>
     <p>{{ ftl('firefox-channel-nightly-update-one-or-more-times') }}</p>

--- a/springfield/firefox/templates/firefox/channel/android.html
+++ b/springfield/firefox/templates/firefox/channel/android.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/channel/base.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=channel-android' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=channel-android' %}
 
 {% block page_title_suffix %}{% endblock %}
 
@@ -45,10 +45,10 @@
     </ul>
     <p>
       {% if ftl_has_messages('firefox-channel-beta-is-an-unstable-testing') %}
-        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
+        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + params + '#pre-release') }}
       {% else %}
         {{ ftl('firefox-channel-firefox-beta-automatically') }}
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}#pre-release">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>
@@ -77,10 +77,10 @@
     </ul>
     <p>
     {% if ftl_has_messages('firefox-channel-nightly-is-an-unstable-testing') %}
-      {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
+      {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + params + '#pre-release') }}
     {% else %}
       {{ ftl('firefox-channel-firefox-nightly-automatically') }}
-      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
+      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}#pre-release">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
     </p>
     <p>{{ ftl('firefox-channel-nightly-update-one-or-more-times') }}</p>

--- a/springfield/firefox/templates/firefox/channel/android.html
+++ b/springfield/firefox/templates/firefox/channel/android.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/channel/base.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-channel-android&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=channel-android' %}
 
 {% block page_title_suffix %}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/channel/desktop.html
+++ b/springfield/firefox/templates/firefox/channel/desktop.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/channel/base.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-channel-desktop&utm_medium=referral' %}
+
 {% block page_title %}
   {{ ftl('firefox-channel-download-and-test-future') }}
 {% endblock %}
@@ -41,10 +43,10 @@
     </ul>
     <p>
       {% if ftl_has_messages('firefox-channel-beta-is-an-unstable-testing') %}
-        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/#pre-release') }}
+        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
       {% else %}
         {{ ftl('firefox-channel-firefox-beta-automatically') }}
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/#pre-release">{{ ftl('ui-learn-more') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>
@@ -79,10 +81,10 @@
     </ul>
     <p>
     {% if ftl_has_messages('firefox-channel-developer-edition-is-an') %}
-      {{ ftl('firefox-channel-developer-edition-is-an', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/#pre-release') }}
+      {{ ftl('firefox-channel-developer-edition-is-an', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
     {% else %}
       {{ ftl('firefox-channel-firefox-developer-edition') }}
-      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/#pre-release">{{ ftl('ui-learn-more') }}</a>
+      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
     </p>
   </div>
@@ -117,10 +119,10 @@
     </ul>
     <p>
       {% if ftl_has_messages('firefox-channel-nightly-is-an-unstable-testing') %}
-        {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/#pre-release')}}
+        {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release')}}
       {% else %}
         {{ ftl('firefox-channel-firefox-nightly-automatically') }}
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/#pre-release">{{ ftl('ui-learn-more') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>{{ ftl('firefox-channel-nightly-update-one-or-more-times') }}</p>

--- a/springfield/firefox/templates/firefox/channel/desktop.html
+++ b/springfield/firefox/templates/firefox/channel/desktop.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/channel/base.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=channel-desktop' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=channel-desktop' %}
 
 {% block page_title %}
   {{ ftl('firefox-channel-download-and-test-future') }}
@@ -43,10 +43,10 @@
     </ul>
     <p>
       {% if ftl_has_messages('firefox-channel-beta-is-an-unstable-testing') %}
-        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
+        {{ ftl('firefox-channel-beta-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + params + '#pre-release') }}
       {% else %}
         {{ ftl('firefox-channel-firefox-beta-automatically') }}
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}#pre-release">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>
@@ -81,10 +81,10 @@
     </ul>
     <p>
     {% if ftl_has_messages('firefox-channel-developer-edition-is-an') %}
-      {{ ftl('firefox-channel-developer-edition-is-an', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release') }}
+      {{ ftl('firefox-channel-developer-edition-is-an', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + params + '#pre-release') }}
     {% else %}
       {{ ftl('firefox-channel-firefox-developer-edition') }}
-      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
+      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}#pre-release">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
     </p>
   </div>
@@ -119,10 +119,10 @@
     </ul>
     <p>
       {% if ftl_has_messages('firefox-channel-nightly-is-an-unstable-testing') %}
-        {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals + '#pre-release')}}
+        {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + params + '#pre-release')}}
       {% else %}
         {{ ftl('firefox-channel-firefox-nightly-automatically') }}
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release">{{ ftl('ui-learn-more') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}#pre-release">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>{{ ftl('firefox-channel-nightly-update-one-or-more-times') }}</p>

--- a/springfield/firefox/templates/firefox/channel/desktop.html
+++ b/springfield/firefox/templates/firefox/channel/desktop.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/channel/base.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-channel-desktop&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=channel-desktop' %}
 
 {% block page_title %}
   {{ ftl('firefox-channel-download-and-test-future') }}

--- a/springfield/firefox/templates/firefox/default/thanks.html
+++ b/springfield/firefox/templates/firefox/default/thanks.html
@@ -18,7 +18,7 @@
   {{ css_bundle('firefox-default-thanks') }}
 {% endblock %}
 
-{% set referrals = '?utm_source=www.firefox.com-default-thanks&utm_medium=referral&utm_campaign=default-thanks&entrypoint=www.firefox.com-default-thanks' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=default-thanks&entrypoint=www.firefox.com-default-thanks' %}
 
 
 {% block content %}

--- a/springfield/firefox/templates/firefox/default/thanks.html
+++ b/springfield/firefox/templates/firefox/default/thanks.html
@@ -18,7 +18,8 @@
   {{ css_bundle('firefox-default-thanks') }}
 {% endblock %}
 
-{% set utms = '?utm_source=www.firefox.com-default-thanks&utm_medium=referral&utm_campaign=default-thanks&entrypoint=www.firefox.com-default-thanks' %}
+{% set referrals = '?utm_source=www.firefox.com-default-thanks&utm_medium=referral&utm_campaign=default-thanks&entrypoint=www.firefox.com-default-thanks' %}
+
 
 {% block content %}
 <main>
@@ -48,18 +49,18 @@
       <p>{{ ftl('set-as-default-thanks-youre-almost-done-just-change') }}</p>
 
       <p class="thanks-help-text">
-        <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser{{ utms }}">
+        <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser{{ referrals }}">
           {{ ftl('set-as-default-thanks-having-trouble-setting-your') }}
         </a>
       </p>
     </div>
     <p class="mzp-c-callout-desc thanks-state-not-default-android hide-from-legacy-ie">
     {{ ftl('set-as-default-thanks-heres-everything-you-need-android',
-           android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ utms) }}
+           android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ referrals) }}
     </p>
     <p class="mzp-c-callout-desc thanks-state-not-default-ios hide-from-legacy-ie">
     {{ ftl('set-as-default-thanks-heres-everything-you-need-ios',
-           ios='https://support.mozilla.org/en-US/kb/unable-set-firefox-default-browser-ios' ~ utms) }}
+           ios='https://support.mozilla.org/en-US/kb/unable-set-firefox-default-browser-ios' ~ referrals) }}
     </p>
     <p class="mzp-c-callout-desc thanks-state-is-default hide-from-legacy-ie">
       {{ ftl('set-as-default-thanks-youre-all-set') }}
@@ -81,7 +82,7 @@
           {{ ftl('set-as-default-create-an-account') }}
         </h2>
         <p>{{ ftl('set-as-default-thanks-sign-up-for-a-free-account-v2') }}</p>
-        <a href="https://www.mozilla.org/{{ LANG }}/account/">{{ ftl('set-as-default-thanks-get-an-account') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/account/{{ referrals }}">{{ ftl('set-as-default-thanks-get-an-account') }}</a>
       </section>
 
       <section class="thanks-extra-links-item help">
@@ -90,8 +91,8 @@
         </h2>
         <p>
         {{ ftl('set-as-default-thanks-heres-everything-you-need-android-desktop',
-               android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ utms,
-               desktop='https://support.mozilla.org/kb/make-firefox-your-default-browser' ~ utms) }}
+               android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ referrals,
+               desktop='https://support.mozilla.org/kb/make-firefox-your-default-browser' ~ referrals) }}
         </p>
       </section>
     </div>

--- a/springfield/firefox/templates/firefox/default/thanks.html
+++ b/springfield/firefox/templates/firefox/default/thanks.html
@@ -18,7 +18,7 @@
   {{ css_bundle('firefox-default-thanks') }}
 {% endblock %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=default-thanks&entrypoint=www.firefox.com-default-thanks' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=default-thanks&entrypoint=www.firefox.com-default-thanks' %}
 
 
 {% block content %}
@@ -49,18 +49,18 @@
       <p>{{ ftl('set-as-default-thanks-youre-almost-done-just-change') }}</p>
 
       <p class="thanks-help-text">
-        <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser{{ referrals }}">
+        <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser{{ params }}">
           {{ ftl('set-as-default-thanks-having-trouble-setting-your') }}
         </a>
       </p>
     </div>
     <p class="mzp-c-callout-desc thanks-state-not-default-android hide-from-legacy-ie">
     {{ ftl('set-as-default-thanks-heres-everything-you-need-android',
-           android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ referrals) }}
+           android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ params) }}
     </p>
     <p class="mzp-c-callout-desc thanks-state-not-default-ios hide-from-legacy-ie">
     {{ ftl('set-as-default-thanks-heres-everything-you-need-ios',
-           ios='https://support.mozilla.org/en-US/kb/unable-set-firefox-default-browser-ios' ~ referrals) }}
+           ios='https://support.mozilla.org/en-US/kb/unable-set-firefox-default-browser-ios' ~ params) }}
     </p>
     <p class="mzp-c-callout-desc thanks-state-is-default hide-from-legacy-ie">
       {{ ftl('set-as-default-thanks-youre-all-set') }}
@@ -82,7 +82,7 @@
           {{ ftl('set-as-default-create-an-account') }}
         </h2>
         <p>{{ ftl('set-as-default-thanks-sign-up-for-a-free-account-v2') }}</p>
-        <a href="https://www.mozilla.org/{{ LANG }}/account/{{ referrals }}">{{ ftl('set-as-default-thanks-get-an-account') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/account/{{ params }}">{{ ftl('set-as-default-thanks-get-an-account') }}</a>
       </section>
 
       <section class="thanks-extra-links-item help">
@@ -91,8 +91,8 @@
         </h2>
         <p>
         {{ ftl('set-as-default-thanks-heres-everything-you-need-android-desktop',
-               android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ referrals,
-               desktop='https://support.mozilla.org/kb/make-firefox-your-default-browser' ~ referrals) }}
+               android='https://support.mozilla.org/kb/make-firefox-default-browser-android' ~ params,
+               desktop='https://support.mozilla.org/kb/make-firefox-your-default-browser' ~ params) }}
         </p>
       </section>
     </div>

--- a/springfield/firefox/templates/firefox/developer/index.html
+++ b/springfield/firefox/templates/firefox/developer/index.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-developer&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=developer' %}
 
 {% block page_title %}{{ ftl('firefox-developer-page-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}

--- a/springfield/firefox/templates/firefox/developer/index.html
+++ b/springfield/firefox/templates/firefox/developer/index.html
@@ -9,6 +9,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-developer&utm_medium=referral' %}
+
 {% block page_title %}{{ ftl('firefox-developer-page-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}
 {% block page_image %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endblock %}
@@ -45,7 +47,7 @@
      data-cta-text="Get help with your installation"')}}</p>
     <p class="intro-feedback-note">
       {{ ftl('firefox-developer-firefox-developer-edition-sends') }}
-      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/#pre-release" class="more">{{ ftl('ui-learn-more') }}</a>
+      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release" class="more">{{ ftl('ui-learn-more') }}</a>
     </p>
   </div>
 

--- a/springfield/firefox/templates/firefox/developer/index.html
+++ b/springfield/firefox/templates/firefox/developer/index.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=developer' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=developer' %}
 
 {% block page_title %}{{ ftl('firefox-developer-page-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}
@@ -47,7 +47,7 @@
      data-cta-text="Get help with your installation"')}}</p>
     <p class="intro-feedback-note">
       {{ ftl('firefox-developer-firefox-developer-edition-sends') }}
-      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}#pre-release" class="more">{{ ftl('ui-learn-more') }}</a>
+      <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}#pre-release" class="more">{{ ftl('ui-learn-more') }}</a>
     </p>
   </div>
 

--- a/springfield/firefox/templates/firefox/download/basic/base_download.html
+++ b/springfield/firefox/templates/firefox/download/basic/base_download.html
@@ -11,7 +11,7 @@
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 
-{% set referrals = link_referrals or '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
+{% set params = link_params or '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
 
 {# meta #}
 {% set meta_title_prefix = meta_title_prefix or ftl('firefox-new-download-browser', fallback='firefox-new-download-firefox') %}
@@ -71,7 +71,7 @@
         <li><a href="{{ firefox_url('desktop', 'all') }}">{{ small_advanced }}</a></li>
         <li><a href="{{ firefox_url('desktop', 'all') }}">{{ small_lang }}</a></li>
         {% endif %}
-        <li><a href="https://support.mozilla.org/products/firefox{{ referrals }}&utm_content=need-help-link">{{ small_help }}</a></li>
+        <li><a href="https://support.mozilla.org/products/firefox{{ params }}&utm_content=need-help-link">{{ small_help }}</a></li>
       </ul>
     </div>
     {% endblock %}

--- a/springfield/firefox/templates/firefox/download/basic/thanks.html
+++ b/springfield/firefox/templates/firefox/download/basic/thanks.html
@@ -25,7 +25,7 @@
   {% endwith %}
 {% endblock %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-download-thanks' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-download-thanks' %}
 
 {% block content %}
 <main>
@@ -51,9 +51,9 @@
     {% if ftl_has_messages('firefox-new-if-you-see-a-prompt', 'firefox-new-visit-support-for-more') %}
       <aside class="c-windows-disclaimer mzp-c-emphasis-box show-windows-10-plus">
         <img class="c-windows-disclaimer-logo" src="{{ static('img/logos/windows/logo-windows-black.svg') }}" alt="{{ ftl('firefox-new-windows') }}" width="132" height="28">
-        <p>{{ ftl('firefox-new-if-you-see-a-prompt', attrs='href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(referrals)) }}</p>
+        <p>{{ ftl('firefox-new-if-you-see-a-prompt', attrs='href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params)) }}</p>
 
-        <p><a href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app{{ referrals }}" rel="external noopener" data-cta-text="Visit Support for More Details">{{ ftl('firefox-new-visit-support-for-more') }}</a></p>
+        <p><a href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app{{ params }}" rel="external noopener" data-cta-text="Visit Support for More Details">{{ ftl('firefox-new-visit-support-for-more') }}</a></p>
       </aside>
     {% endif %}
 
@@ -66,7 +66,7 @@
               class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-64-v2') }}</a>
           </div>
           {% set attrs = 'href="https://support.mozilla.org/kb/install-firefox-linux%s#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener"
-           data-cta-text="You can set up our APT repository instead"'|safe|format(referrals) %}
+           data-cta-text="You can set up our APT repository instead"'|safe|format(params) %}
           <p class="linux-deb-text">{{ ftl('download-button-using-debian', attrs=attrs) }}</p>
         </div>
         {# Edge-case platform support messaging #}

--- a/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
@@ -21,7 +21,7 @@ Set Firefox as your default browser.
 
 {% extends "firefox/download/desktop/base.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-home' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-home' %}
 {% set ios_url = app_store_url('firefox', 'firefox-home') %}
 
 {% block string_data %}{% endblock %}
@@ -47,7 +47,7 @@ Set Firefox as your default browser.
 
 {% if outdated %}
 
-  {% set update_url = 'href="%s" data-cta-text="Update to the latest version"'|safe|format(('https://support.mozilla.org/kb/update-firefox-latest-release' + referrals)) %}
+  {% set update_url = 'href="%s" data-cta-text="Update to the latest version"'|safe|format(('https://support.mozilla.org/kb/update-firefox-latest-release' + params)) %}
 
   {% if ftl_has_messages('firefox-desktop-out-of-date') %}
     <aside class="c-page-header-notification">
@@ -74,7 +74,7 @@ Set Firefox as your default browser.
 
           <div class="c-intro-download-alt"><a href="{{ url('firefox.all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 
-          <div class="c-intro-download-alt"><a href="https://support.mozilla.org/products/firefox{{ referrals }}&utm_content=browser-support" rel="external noopener" data-cta-text="Firefox browser support">{{ ftl('firefox-desktop-download-browser-support') }}</a></div>
+          <div class="c-intro-download-alt"><a href="https://support.mozilla.org/products/firefox{{ params }}&utm_content=browser-support" rel="external noopener" data-cta-text="Firefox browser support">{{ ftl('firefox-desktop-download-browser-support') }}</a></div>
         </div>
       </div>
       <div class="c-block-media l-v-center">
@@ -219,7 +219,7 @@ Set Firefox as your default browser.
   </section>
 
   <section class="c-support">
-    {% set questions_attrs = 'href="https://support.mozilla.org/products/firefox%s&utm_content=mozilla-support" rel="external noopener" data-cta-text="Mozilla support"'|safe|format(referrals) %}
+    {% set questions_attrs = 'href="https://support.mozilla.org/products/firefox%s&utm_content=mozilla-support" rel="external noopener" data-cta-text="Mozilla support"'|safe|format(params) %}
     {{ ftl('firefox-desktop-download-questions', attrs=questions_attrs) }}
   </section>
 

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -21,7 +21,7 @@
 
 {% extends "firefox/download/desktop/base.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
 {% set ios_url = app_store_url('firefox', 'firefox-com-download') %}
 
 {% block string_data %}{% endblock %}
@@ -76,7 +76,7 @@
 
 {% if outdated %}
 
-  {% set update_url = 'href="%s" data-cta-text="Update to the latest version"'|safe|format(('https://support.mozilla.org/kb/update-firefox-latest-release' + referrals)) %}
+  {% set update_url = 'href="%s" data-cta-text="Update to the latest version"'|safe|format(('https://support.mozilla.org/kb/update-firefox-latest-release' + params)) %}
 
   {% if ftl_has_messages('firefox-desktop-out-of-date') %}
     <aside class="c-page-header-notification">
@@ -103,7 +103,7 @@
 
           <div class="c-intro-download-alt"><a href="{{ firefox_url('desktop', 'all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 
-          <div class="c-intro-download-alt"><a href="https://support.mozilla.org/products/firefox{{ referrals }}&utm_content=browser-support" rel="external noopener" data-cta-text="Firefox browser support">{{ ftl('firefox-desktop-download-browser-support') }}</a></div>
+          <div class="c-intro-download-alt"><a href="https://support.mozilla.org/products/firefox{{ params }}&utm_content=browser-support" rel="external noopener" data-cta-text="Firefox browser support">{{ ftl('firefox-desktop-download-browser-support') }}</a></div>
         </div>
       </div>
       <div class="c-block-media l-v-center">
@@ -426,7 +426,7 @@
     <ul class="c-trio">
       <li>
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-extensions-for-every') }}</h3>
-        {% set extensions_attrs = 'href="https://addons.mozilla.org/firefox/extensions/%s" rel="external noopener" data-cta-text="extension for everyone"'|safe|format(referrals) %}
+        {% set extensions_attrs = 'href="https://addons.mozilla.org/firefox/extensions/%s" rel="external noopener" data-cta-text="extension for everyone"'|safe|format(params) %}
         <p>{{ ftl('firefox-desktop-download-from-security-to', attrs=extensions_attrs) }}</p>
       </li>
 
@@ -459,7 +459,7 @@
           }
         ) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-challenging-the-status') }}</h3>
-        {% set mozorg_about_href = 'https://www.mozilla.org/' + LANG + '/about/' + referrals %}
+        {% set mozorg_about_href = 'https://www.mozilla.org/' + LANG + '/about/' + params %}
         {% set created_attrs = 'href="%s" data-cta-text="created by Mozilla"'|safe|format(mozorg_about_href) %}
         <p>{{ ftl('firefox-desktop-download-firefox-was-created', attrs=created_attrs) }}</p>
       </div>
@@ -477,7 +477,7 @@
           }
         ) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-your-privacy-comes') }}</h3>
-        {% set privacy_href = 'https://www.mozilla.org/' + LANG + '/privacy/' + referrals %}
+        {% set privacy_href = 'https://www.mozilla.org/' + LANG + '/privacy/' + params %}
         {% set internet_attrs = 'href="%s" data-cta-text="Personal Data Promise"'|safe|format(privacy_href) %}
         <p>{{ ftl('firefox-desktop-download-as-the-internet-v2', fallback='firefox-desktop-download-as-the-internet', attrs=internet_attrs) }}</p>
       </div>
@@ -498,7 +498,7 @@
       <div class="mzp-c-card js-animate">
         {{ download_picture('contain-mr1', '131', 138) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-facebook-container') }}</h3>
-        {% set addon_attrs = 'href="https://addons.mozilla.org/firefox/addon/facebook-container/%s" rel="external noopener" data-cta-text="Download this browser extension"'|safe|format(referrals) %}
+        {% set addon_attrs = 'href="https://addons.mozilla.org/firefox/addon/facebook-container/%s" rel="external noopener" data-cta-text="Download this browser extension"'|safe|format(params) %}
         <p>{{ ftl('firefox-desktop-download-download-this-browser', attrs=addon_attrs) }}</p>
       </div>
 
@@ -513,14 +513,14 @@
       <div class="mzp-c-card js-animate">
         {{ download_picture('screenshots-mr1', '131', 138) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-screenshots') }}</h3>
-        {% set screenshot_attrs = 'href="https://support.mozilla.org/kb/firefox-screenshots%s" rel="external noopener" data-cta-text="screenshot"'|safe|format(referrals) %}
+        {% set screenshot_attrs = 'href="https://support.mozilla.org/kb/firefox-screenshots%s" rel="external noopener" data-cta-text="screenshot"'|safe|format(params) %}
         <p>{{ ftl('firefox-desktop-download-grab-a-high', attrs=screenshot_attrs) }}</p>
       </div>
 
       <div class="mzp-c-card js-animate">
         {{ download_picture('etp', '134', 138) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-enhanced-tracking-protection') }}</h3>
-        {% set automatically_attrs = 'href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop%s" rel="external noopener" data-cta-text="block many trackers"'|safe|format(referrals) %}
+        {% set automatically_attrs = 'href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop%s" rel="external noopener" data-cta-text="block many trackers"'|safe|format(params) %}
         <p>{{ ftl('firefox-desktop-download-firefox-automatically', attrs=automatically_attrs) }}</p>
       </div>
 
@@ -537,7 +537,7 @@
   </section>
 
   <section class="c-support">
-    {% set questions_attrs = 'href="https://support.mozilla.org/products/firefox%s&utm_content=mozilla-support" rel="external noopener" data-cta-text="Mozilla support"'|safe|format(referrals) %}
+    {% set questions_attrs = 'href="https://support.mozilla.org/products/firefox%s&utm_content=mozilla-support" rel="external noopener" data-cta-text="Mozilla support"'|safe|format(params) %}
     {{ ftl('firefox-desktop-download-questions', attrs=questions_attrs) }}
   </section>
 

--- a/springfield/firefox/templates/firefox/download/desktop/thanks.html
+++ b/springfield/firefox/templates/firefox/download/desktop/thanks.html
@@ -28,7 +28,7 @@
   {% endwith %}
 {% endblock %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-download-thanks' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-download-thanks' %}
 
 {% block content %}
 <main>
@@ -57,19 +57,19 @@
   {% if ftl_has_messages('firefox-desktop-download-if-you-see-a-prompt', 'firefox-desktop-download-visit-support-for-more') %}
     <aside class="c-windows-disclaimer mzp-c-emphasis-box show-windows-10-plus">
       <img class="c-windows-disclaimer-logo" src="{{ static('img/logos/windows/logo-windows-black.svg') }}" alt="{{ ftl('firefox-desktop-download-windows') }}" width="132" height="28">
-      <p>{{ ftl('firefox-desktop-download-if-you-see-a-prompt', attrs='href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(referrals)) }}</p>
+      <p>{{ ftl('firefox-desktop-download-if-you-see-a-prompt', attrs='href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params)) }}</p>
 
-      <p><a href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app{{ referrals }}" rel="external noopener" data-cta-text="Visit Support for More Details">{{ ftl('firefox-desktop-download-visit-support-for-more') }}</a></p>
+      <p><a href="https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app{{ params }}" rel="external noopener" data-cta-text="Visit Support for More Details">{{ ftl('firefox-desktop-download-visit-support-for-more') }}</a></p>
     </aside>
   {% endif %}
 
     <div class="c-support-install">
       <p class="show-mac">
-        {% set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
+        {% set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) %}
         {{ ftl('firefox-desktop-download-get-help', attrs=support_mac_attrs) }}
       </p>
       <p class="show-windows">
-        {% set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-windows%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
+        {% set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-windows%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) %}
         {{ ftl('firefox-desktop-download-get-help', attrs=support_windows_attrs) }}
       </p>
       <div class="show-linux">
@@ -77,11 +77,11 @@
           <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" class="mzp-c-button mzp-t-product" data-testid="thanks-download-button-linux-32">{{ ftl('download-button-linux-32-v2') }}</a>
           <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" class="mzp-c-button mzp-t-product" data-testid="thanks-download-button-linux-64">{{ ftl('download-button-linux-64-v2') }}</a>
         </div>
-        {% set attrs = 'href="https://support.mozilla.org/kb/install-firefox-linux%s#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener" data-cta-text="You can set up our APT repository instead"'|safe|format(referrals) %}
+        {% set attrs = 'href="https://support.mozilla.org/kb/install-firefox-linux%s#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener" data-cta-text="You can set up our APT repository instead"'|safe|format(params) %}
         <p class="linux-deb-text">{{ ftl('download-button-using-debian', attrs=attrs) }}</p>
       </div>
       <p class="show-else">
-        {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
+        {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) %}
         {{ ftl('firefox-desktop-download-get-help', attrs=support_else_attrs) }}
       </p>
 

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -17,7 +17,7 @@
   {{ css_bundle('firefox-enterprise') }}
 {% endblock %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=enterprise' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=enterprise' %}
 
 {% block body_id %}firefox{% endblock %}
 
@@ -49,7 +49,7 @@
             <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
           </span>
         </a>
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/?{{ referrals }}" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/?{{ params }}" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
       </div>
     </div>
   {% endcall %}
@@ -152,13 +152,13 @@
           <div class="enterprise-download-support">
             <h4 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-support') }}</h4>
             <ul class="mzp-u-list-styled">
-              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ referrals }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ referrals }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ referrals }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ params }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ params }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ params }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
               <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ ftl('firefox-enterprise-deployment-guide') }}</a></li>
               <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ ftl('firefox-enterprise-policy-documentation') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
-              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
             </ul>
           </div>
         </section>
@@ -186,11 +186,11 @@
             <h4 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-support') }}</h4>
             <ul class="mzp-u-list-styled">
               <li>{{ ftl('firefox-enterprise-sample-plist-for-configuration', url='https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
-              <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf/{{ referrals }}">{{ ftl('firefox-enterprise-pkg-installer') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf/{{ params }}">{{ ftl('firefox-enterprise-pkg-installer') }}</a></li>
               <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ ftl('firefox-enterprise-deployment-guide') }}</a></li>
               <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ ftl('firefox-enterprise-policy-documentation') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
-              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
             </ul>
           </div>
         </section>
@@ -227,13 +227,13 @@
           <div class="enterprise-download-support">
             <h4 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-support') }}</h4>
             <ul class="mzp-u-list-styled">
-              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ referrals }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ referrals }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ referrals }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ params }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ params }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ params }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
               <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ ftl('firefox-enterprise-deployment-guide') }}</a></li>
               <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ ftl('firefox-enterprise-policy-documentation') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
-              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
             </ul>
           </div>
         </section>

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -17,7 +17,7 @@
   {{ css_bundle('firefox-enterprise') }}
 {% endblock %}
 
-{% set utm_params = '?utm_source=www.firefox.com-enterprise&utm_campaign=enterprise&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com-enterprise&utm_medium=referral&utm_campaign=enterprise' %}
 
 {% block body_id %}firefox{% endblock %}
 
@@ -49,7 +49,7 @@
             <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
           </span>
         </a>
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/?{{ referrals }}" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
       </div>
     </div>
   {% endcall %}
@@ -152,13 +152,13 @@
           <div class="enterprise-download-support">
             <h4 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-support') }}</h4>
             <ul class="mzp-u-list-styled">
-              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ utm_params }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ utm_params }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ utm_params }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ referrals }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ referrals }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ referrals }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
               <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ ftl('firefox-enterprise-deployment-guide') }}</a></li>
               <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ ftl('firefox-enterprise-policy-documentation') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
-              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
             </ul>
           </div>
         </section>
@@ -186,11 +186,11 @@
             <h4 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-support') }}</h4>
             <ul class="mzp-u-list-styled">
               <li>{{ ftl('firefox-enterprise-sample-plist-for-configuration', url='https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
-              <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf/{{ utm_params }}">{{ ftl('firefox-enterprise-pkg-installer') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf/{{ referrals }}">{{ ftl('firefox-enterprise-pkg-installer') }}</a></li>
               <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ ftl('firefox-enterprise-deployment-guide') }}</a></li>
               <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ ftl('firefox-enterprise-policy-documentation') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
-              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
             </ul>
           </div>
         </section>
@@ -227,13 +227,13 @@
           <div class="enterprise-download-support">
             <h4 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-support') }}</h4>
             <ul class="mzp-u-list-styled">
-              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ utm_params }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ utm_params }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ utm_params }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ referrals }}">{{ ftl('firefox-enterprise-msi-installers') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ referrals }}">{{ ftl('firefox-enterprise-legacy-browser-support') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ referrals }}">{{ ftl('firefox-enterprise-admx-templates') }}</a></li>
               <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ ftl('firefox-enterprise-deployment-guide') }}</a></li>
               <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ ftl('firefox-enterprise-policy-documentation') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
-              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-release-notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ referrals }}">{{ ftl('firefox-enterprise-documentation-and-community') }}</a></li>
             </ul>
           </div>
         </section>

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -17,7 +17,7 @@
   {{ css_bundle('firefox-enterprise') }}
 {% endblock %}
 
-{% set referrals = '?utm_source=www.firefox.com-enterprise&utm_medium=referral&utm_campaign=enterprise' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=enterprise' %}
 
 {% block body_id %}firefox{% endblock %}
 

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -49,7 +49,7 @@
             <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
           </span>
         </a>
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/?{{ params }}" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}" class="mzp-c-button-download-privacy-link">{{ ftl('download-button-firefox-privacy-notice') }}</a>
       </div>
     </div>
   {% endcall %}

--- a/springfield/firefox/templates/firefox/features/add-ons.html
+++ b/springfield/firefox/templates/firefox/features/add-ons.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
 
 {% block article_title_short %}{{ ftl('features-add-ons-firefox-add-ons') }}{% endblock %}
 {% block article_title %}{{ ftl('features-add-ons-firefox-add-ons-and-browser-extensions') }}{% endblock %}
@@ -29,11 +29,11 @@
 
 <p>
   {{ ftl('features-add-ons-there-are-firefox-add-ons-that',
-    fbcontainer='href="%s"'|safe|format('https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + referrals),
-    translate='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/addon/simple-translate/' + referrals),
-    language='href="%s"'|safe|format('https://addons.mozilla.org/firefox/addon/languagetool/' + referrals),
+    fbcontainer='href="%s"'|safe|format('https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + params),
+    translate='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/addon/simple-translate/' + params),
+    language='href="%s"'|safe|format('https://addons.mozilla.org/firefox/addon/languagetool/' + params),
     customize='href="%s" rel="external noopener"'|safe|format(url('firefox.features.customize')),
-    amo='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/' + referrals),
+    amo='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/' + params),
   ) }}
 </p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/add-ons.html
+++ b/springfield/firefox/templates/firefox/features/add-ons.html
@@ -29,7 +29,7 @@
 
 <p>
   {{ ftl('features-add-ons-there-are-firefox-add-ons-that',
-    fbcontainer='href="%s"'|safe|format('https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + params),
+    fbcontainer='href="%s"'|safe|format('https://addons.mozilla.org/firefox/addon/facebook-container/ ' + params),
     translate='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/addon/simple-translate/' + params),
     language='href="%s"'|safe|format('https://addons.mozilla.org/firefox/addon/languagetool/' + params),
     customize='href="%s" rel="external noopener"'|safe|format(url('firefox.features.customize')),

--- a/springfield/firefox/templates/firefox/features/add-ons.html
+++ b/springfield/firefox/templates/firefox/features/add-ons.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/features/base-article.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+
 {% block article_title_short %}{{ ftl('features-add-ons-firefox-add-ons') }}{% endblock %}
 {% block article_title %}{{ ftl('features-add-ons-firefox-add-ons-and-browser-extensions') }}{% endblock %}
 
@@ -27,11 +29,11 @@
 
 <p>
   {{ ftl('features-add-ons-there-are-firefox-add-ons-that',
-    fbcontainer='href="%s"'|safe|format('https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/'),
-    translate='href="https://addons.mozilla.org/firefox/addon/simple-translate/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    language='href="https://addons.mozilla.org/firefox/addon/languagetool/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    customize='href="%s"'|safe|format(url('firefox.features.customize')),
-    amo='href="https://addons.mozilla.org/firefox/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
+    fbcontainer='href="%s"'|safe|format('https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + referrals),
+    translate='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/addon/simple-translate/' + referrals),
+    language='href="%s"'|safe|format('https://addons.mozilla.org/firefox/addon/languagetool/' + referrals),
+    customize='href="%s" rel="external noopener"'|safe|format(url('firefox.features.customize')),
+    amo='href="%s" rel="external noopener"'|safe|format('https://addons.mozilla.org/firefox/' + referrals),
   ) }}
 </p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/customize.html
+++ b/springfield/firefox/templates/firefox/features/customize.html
@@ -7,7 +7,7 @@
 {% extends "firefox/features/base-article.html" %}
 
 {% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
-{% set referrals = '?' + utm_params %}
+{% set params = '?' + utm_params %}
 
 {% block article_title %}{{ ftl('features-customize-customize-your-firefox') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-customize-choose-how-your-browser-looks') }}{% endblock %}
@@ -36,10 +36,10 @@
     top='href="https://addons.mozilla.org/firefox/search/?sort=rating&type=statictheme&%s" rel="external noopener"'|format(utm_params),
     trending='href="https://addons.mozilla.org/firefox/search/?sort=hotness&type=statictheme&%s" rel="external noopener"'|format(utm_params),
     recommended='href="https://addons.mozilla.org/firefox/search/?promoted=recommended&sort=random&type=statictheme&%s" rel="external noopener"'|format(utm_params),
-    music='href="https://addons.mozilla.org/firefox/themes/category/music/%s" rel="external noopener"'|format(referrals),
-    seasonal='href="https://addons.mozilla.org/firefox/themes/category/seasonal/%s" rel="external noopener"'|format(referrals),
-    sports='href="https://addons.mozilla.org/firefox/themes/category/sports/%s" rel="external noopener"'|format(referrals),
-    nature='href="https://addons.mozilla.org/firefox/themes/category/nature/%s" rel="external noopener"'|format(referrals)
+    music='href="https://addons.mozilla.org/firefox/themes/category/music/%s" rel="external noopener"'|format(params),
+    seasonal='href="https://addons.mozilla.org/firefox/themes/category/seasonal/%s" rel="external noopener"'|format(params),
+    sports='href="https://addons.mozilla.org/firefox/themes/category/sports/%s" rel="external noopener"'|format(params),
+    nature='href="https://addons.mozilla.org/firefox/themes/category/nature/%s" rel="external noopener"'|format(params)
   ) }}
 </p>
 

--- a/springfield/firefox/templates/firefox/features/customize.html
+++ b/springfield/firefox/templates/firefox/features/customize.html
@@ -6,7 +6,8 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set referrals = '?' + utm_params %}
 
 {% block article_title %}{{ ftl('features-customize-customize-your-firefox') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-customize-choose-how-your-browser-looks') }}{% endblock %}
@@ -31,14 +32,14 @@
 
 <p>
   {{ ftl('features-customize-you-can-find-more-free-custom-v2',
-    amo='href="https://addons.mozilla.org/firefox/themes/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    top='href="https://addons.mozilla.org/firefox/search/?sort=rating&type=statictheme&utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    trending='href="https://addons.mozilla.org/firefox/search/?sort=hotness&type=statictheme&utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    recommended='href="https://addons.mozilla.org/firefox/search/?promoted=recommended&sort=random&type=statictheme&utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    music='href="https://addons.mozilla.org/firefox/themes/category/music/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    seasonal='href="https://addons.mozilla.org/firefox/themes/category/seasonal/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    sports='href="https://addons.mozilla.org/firefox/themes/category/sports/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"',
-    nature='href="https://addons.mozilla.org/firefox/themes/category/nature/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"'
+    amo='href="https://addons.mozilla.org/firefox/themes/" rel="external noopener"',
+    top='href="https://addons.mozilla.org/firefox/search/?sort=rating&type=statictheme&%s" rel="external noopener"'|format(utm_params),
+    trending='href="https://addons.mozilla.org/firefox/search/?sort=hotness&type=statictheme&%s" rel="external noopener"'|format(utm_params),
+    recommended='href="https://addons.mozilla.org/firefox/search/?promoted=recommended&sort=random&type=statictheme&%s" rel="external noopener"'|format(utm_params),
+    music='href="https://addons.mozilla.org/firefox/themes/category/music/%s" rel="external noopener"'|format(referrals),
+    seasonal='href="https://addons.mozilla.org/firefox/themes/category/seasonal/%s" rel="external noopener"'|format(referrals),
+    sports='href="https://addons.mozilla.org/firefox/themes/category/sports/%s" rel="external noopener"'|format(referrals),
+    nature='href="https://addons.mozilla.org/firefox/themes/category/nature/%s" rel="external noopener"'|format(referrals)
   ) }}
 </p>
 

--- a/springfield/firefox/templates/firefox/features/customize.html
+++ b/springfield/firefox/templates/firefox/features/customize.html
@@ -32,7 +32,7 @@
 
 <p>
   {{ ftl('features-customize-you-can-find-more-free-custom-v2',
-    amo='href="https://addons.mozilla.org/firefox/themes/" rel="external noopener"',
+    amo='href="https://addons.mozilla.org/firefox/themes/%s" rel="external noopener"'|format(params),
     top='href="https://addons.mozilla.org/firefox/search/?sort=rating&type=statictheme&%s" rel="external noopener"'|format(utm_params),
     trending='href="https://addons.mozilla.org/firefox/search/?sort=hotness&type=statictheme&%s" rel="external noopener"'|format(utm_params),
     recommended='href="https://addons.mozilla.org/firefox/search/?promoted=recommended&sort=random&type=statictheme&%s" rel="external noopener"'|format(utm_params),

--- a/springfield/firefox/templates/firefox/features/fast-2024.html
+++ b/springfield/firefox/templates/firefox/features/fast-2024.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=features-fast' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=features-fast' %}
 
 {% block page_image %}{{ static('img/firefox/features/fast-high-res.png') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-fast-firefox-is-faster-than-ever') }}{% endblock %}
@@ -20,8 +20,8 @@
 
 <h2>{{ ftl('features-fast-faster-every-day') }}</h2>
 <p>{{ ftl('features-fast-firefox-is-powered-by-the-world') }}</p>
-<p>{{ ftl('features-fast-all-browsers-had-to-make', link='href="https://hacks.mozilla.org/2023/10/down-and-to-the-right-firefox-got-faster-for-real-users-in-2023/%s" rel="external noopener"'|format(referrals)) }}</p>
+<p>{{ ftl('features-fast-all-browsers-had-to-make', link='href="https://hacks.mozilla.org/2023/10/down-and-to-the-right-firefox-got-faster-for-real-users-in-2023/%s" rel="external noopener"'|format(params)) }}</p>
 
 <h2>{{ ftl('features-fast-towards-a-faster-web') }}</h2>
-<p>{{ ftl('features-fast-theres-been-an-encouraging', link='href="https://www.mozilla.org/en-US/about/webvision/full/%s#performance"'|format(referrals)|safe) }}</p>
+<p>{{ ftl('features-fast-theres-been-an-encouraging', link='href="https://www.mozilla.org/en-US/about/webvision/full/%s#performance"'|format(params)|safe) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/fast-2024.html
+++ b/springfield/firefox/templates/firefox/features/fast-2024.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/features/base-article.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=features-fast' %}
+
 {% block page_image %}{{ static('img/firefox/features/fast-high-res.png') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-fast-firefox-is-faster-than-ever') }}{% endblock %}
 
@@ -18,8 +20,8 @@
 
 <h2>{{ ftl('features-fast-faster-every-day') }}</h2>
 <p>{{ ftl('features-fast-firefox-is-powered-by-the-world') }}</p>
-<p>{{ ftl('features-fast-all-browsers-had-to-make', link='href="https://hacks.mozilla.org/2023/10/down-and-to-the-right-firefox-got-faster-for-real-users-in-2023/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"') }}</p>
+<p>{{ ftl('features-fast-all-browsers-had-to-make', link='href="https://hacks.mozilla.org/2023/10/down-and-to-the-right-firefox-got-faster-for-real-users-in-2023/%s" rel="external noopener"'|format(referrals)) }}</p>
 
 <h2>{{ ftl('features-fast-towards-a-faster-web') }}</h2>
-<p>{{ ftl('features-fast-theres-been-an-encouraging', link='href="https://www.mozilla.org/en-US/about/webvision/full/#performance"'|safe) }}</p>
+<p>{{ ftl('features-fast-theres-been-an-encouraging', link='href="https://www.mozilla.org/en-US/about/webvision/full/%s#performance"'|format(referrals)|safe) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/password-manager.html
+++ b/springfield/firefox/templates/firefox/features/password-manager.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
 
 {% block article_title %}{{ ftl('password-manager-free-password-manager') }}{% endblock %}
 {% block page_desc %}{{ ftl('password-manager-firefox-password-manager-saves-all') }}{% endblock %}
@@ -14,7 +14,7 @@
 {% block article_content %}
 <p>{{ ftl('password-manager-firefox-securely-stores-your') }}</p>
 
-{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/" + referrals) %}
+{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/" + params) %}
 <p>{{ ftl('password-manager-with-a-free-mozilla-account-v2', fxa=fxa) }}</p>
 
 <h2>{{ ftl('password-manager-password-autofill-for-easy-logins') }}</h2>
@@ -50,7 +50,7 @@
 </figure>
 
 <h2>{{ ftl('password-manager-no-more-reusing-your-passwords') }}</h2>
-<p>{{ ftl('password-manager-have-firefox-create-a-strong-unique', attrs='href="https://support.mozilla.org/kb/how-generate-secure-password-firefox" + referrals rel="external noopener"') }}</p>
+<p>{{ ftl('password-manager-have-firefox-create-a-strong-unique', attrs='href="https://support.mozilla.org/kb/how-generate-secure-password-firefox" + params rel="external noopener"') }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(
@@ -66,7 +66,7 @@
 </figure>
 
 <h2>{{ ftl('password-manager-password-security-alerts') }}</h2>
-<p>{{ ftl('password-manager-firefox-alerts-you-if-a-password-has', attrs='href="https://support.mozilla.org/kb/firefox-password-manager-alerts-breached-websites" + referrals rel="external noopener"') }}</p>
+<p>{{ ftl('password-manager-firefox-alerts-you-if-a-password-has', attrs='href="https://support.mozilla.org/kb/firefox-password-manager-alerts-breached-websites" + params rel="external noopener"') }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/springfield/firefox/templates/firefox/features/password-manager.html
+++ b/springfield/firefox/templates/firefox/features/password-manager.html
@@ -6,13 +6,15 @@
 
 {% extends "firefox/features/base-article.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+
 {% block article_title %}{{ ftl('password-manager-free-password-manager') }}{% endblock %}
 {% block page_desc %}{{ ftl('password-manager-firefox-password-manager-saves-all') }}{% endblock %}
 
 {% block article_content %}
 <p>{{ ftl('password-manager-firefox-securely-stores-your') }}</p>
 
-{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/") %}
+{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/" + referrals) %}
 <p>{{ ftl('password-manager-with-a-free-mozilla-account-v2', fxa=fxa) }}</p>
 
 <h2>{{ ftl('password-manager-password-autofill-for-easy-logins') }}</h2>
@@ -48,7 +50,7 @@
 </figure>
 
 <h2>{{ ftl('password-manager-no-more-reusing-your-passwords') }}</h2>
-<p>{{ ftl('password-manager-have-firefox-create-a-strong-unique', attrs='href="https://support.mozilla.org/kb/how-generate-secure-password-firefox?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"') }}</p>
+<p>{{ ftl('password-manager-have-firefox-create-a-strong-unique', attrs='href="https://support.mozilla.org/kb/how-generate-secure-password-firefox" + referrals rel="external noopener"') }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(
@@ -64,7 +66,7 @@
 </figure>
 
 <h2>{{ ftl('password-manager-password-security-alerts') }}</h2>
-<p>{{ ftl('password-manager-firefox-alerts-you-if-a-password-has', attrs='href="https://support.mozilla.org/kb/firefox-password-manager-alerts-breached-websites?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features" rel="external noopener"') }}</p>
+<p>{{ ftl('password-manager-firefox-alerts-you-if-a-password-has', attrs='href="https://support.mozilla.org/kb/firefox-password-manager-alerts-breached-websites" + referrals rel="external noopener"') }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/springfield/firefox/templates/firefox/features/private-browsing.html
+++ b/springfield/firefox/templates/firefox/features/private-browsing.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
 
 {% block article_title_short %}{{ ftl('features-private-browsing-private-browsing-mode') }}{% endblock %}
 {% block article_title %}{{ ftl('features-private-browsing-firefox-private-browsing-mode') }}{% endblock %}
@@ -31,6 +31,6 @@
 </figure>
 
 <h2>{{ ftl('features-private-browsing-what-private-browsing-doesnt-do') }}</h2>
-<p>{{ ftl('features-private-browsing-private-browsing-mode-will-not', vpn="https://www.mozilla.org/products/vpn/" + referrals) }}</p>
+<p>{{ ftl('features-private-browsing-private-browsing-mode-will-not', vpn="https://www.mozilla.org/products/vpn/" + params) }}</p>
 <p>{{ ftl('features-private-browsing-compare-firefoxs-private-browsing', chrome=url('firefox.more.incognito-browser')) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/private-browsing.html
+++ b/springfield/firefox/templates/firefox/features/private-browsing.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/features/base-article.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+
 {% block article_title_short %}{{ ftl('features-private-browsing-private-browsing-mode') }}{% endblock %}
 {% block article_title %}{{ ftl('features-private-browsing-firefox-private-browsing-mode') }}{% endblock %}
 
@@ -29,6 +31,6 @@
 </figure>
 
 <h2>{{ ftl('features-private-browsing-what-private-browsing-doesnt-do') }}</h2>
-<p>{{ ftl('features-private-browsing-private-browsing-mode-will-not', vpn="https://www.mozilla.org/products/vpn/") }}</p>
+<p>{{ ftl('features-private-browsing-private-browsing-mode-will-not', vpn="https://www.mozilla.org/products/vpn/" + referrals) }}</p>
 <p>{{ ftl('features-private-browsing-compare-firefoxs-private-browsing', chrome=url('firefox.more.incognito-browser')) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/private.html
+++ b/springfield/firefox/templates/firefox/features/private.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/features/base-article.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+
 {% block page_image %}{{ static('img/firefox/features/private-high-res.png') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-private-were-focused-on-your-right-to') }}{% endblock %}
 
@@ -13,7 +15,7 @@
 
 {% block article_content %}
 <p>{{ ftl('features-private-yes-firefox-protects-your', url=url('firefox.features.private-browsing')) }}</p>
-<p>{{ ftl('features-private-firefox-also-protects-your', url='https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features') }}</p>
+<p>{{ ftl('features-private-firefox-also-protects-your', url='https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop' + referrals) }}</p>
 <p>{{ ftl('features-private-sidenote-we-are-not-big-tech') }}</p>
 
 {% if LANG in ['fr', 'de'] %}
@@ -24,6 +26,6 @@
 {% endif %}
 
 <h2>{{ ftl('features-private-what-information-does-firefox') }}</h2>
-<p>{{ ftl('features-private-mozilla-the-maker-of-firefox', url='https://www.mozilla.org/' + LANG + '/privacy/') }}</p>
-<p>{{ ftl('features-private-read-firefoxs-privacy-notice', url='https://www.mozilla.org/' + LANG + '/privacy/firefox/') }}</p>
+<p>{{ ftl('features-private-mozilla-the-maker-of-firefox', url='https://www.mozilla.org/' + LANG + '/privacy/' + referrals) }}</p>
+<p>{{ ftl('features-private-read-firefoxs-privacy-notice', url='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/private.html
+++ b/springfield/firefox/templates/firefox/features/private.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
 
 {% block page_image %}{{ static('img/firefox/features/private-high-res.png') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-private-were-focused-on-your-right-to') }}{% endblock %}
@@ -15,7 +15,7 @@
 
 {% block article_content %}
 <p>{{ ftl('features-private-yes-firefox-protects-your', url=url('firefox.features.private-browsing')) }}</p>
-<p>{{ ftl('features-private-firefox-also-protects-your', url='https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop' + referrals) }}</p>
+<p>{{ ftl('features-private-firefox-also-protects-your', url='https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop' + params) }}</p>
 <p>{{ ftl('features-private-sidenote-we-are-not-big-tech') }}</p>
 
 {% if LANG in ['fr', 'de'] %}
@@ -26,6 +26,6 @@
 {% endif %}
 
 <h2>{{ ftl('features-private-what-information-does-firefox') }}</h2>
-<p>{{ ftl('features-private-mozilla-the-maker-of-firefox', url='https://www.mozilla.org/' + LANG + '/privacy/' + referrals) }}</p>
-<p>{{ ftl('features-private-read-firefoxs-privacy-notice', url='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + referrals) }}</p>
+<p>{{ ftl('features-private-mozilla-the-maker-of-firefox', url='https://www.mozilla.org/' + LANG + '/privacy/' + params) }}</p>
+<p>{{ ftl('features-private-read-firefoxs-privacy-notice', url='https://www.mozilla.org/' + LANG + '/privacy/firefox/' + params) }}</p>
 {% endblock article_content %}

--- a/springfield/firefox/templates/firefox/features/sync.html
+++ b/springfield/firefox/templates/firefox/features/sync.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
 
 {% block article_title %}{{ ftl('features-sync-firefox-browser-sync') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-sync-access-your-firefox-bookmarks') }}{% endblock %}
@@ -14,7 +14,7 @@
 {% block article_content %}
 <p>{{ ftl('features-sync-with-firefox-you-can-pick-up-where') }}</p>
 
-{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/" + referrals) %}
+{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/" + params) %}
 <p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account-v3', fxa=fxa) }}</p>
 
 <figure class="c-article-figure">
@@ -30,7 +30,7 @@
   ) }}
 </figure>
 
-<p>{{ ftl('features-sync-all-your-data-is-encrypted-on-our', privacy='https://www.mozilla.org/' + LANG + '/privacy/' + referrals) }}</p>
+<p>{{ ftl('features-sync-all-your-data-is-encrypted-on-our', privacy='https://www.mozilla.org/' + LANG + '/privacy/' + params) }}</p>
 
 <h2>{{ ftl('features-sync-send-tabs-from-one-device-to-another') }}</h2>
 <p>{{ ftl('features-sync-the-send-tab-feature-in-firefox') }}</p>

--- a/springfield/firefox/templates/firefox/features/sync.html
+++ b/springfield/firefox/templates/firefox/features/sync.html
@@ -6,13 +6,15 @@
 
 {% extends "firefox/features/base-article.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+
 {% block article_title %}{{ ftl('features-sync-firefox-browser-sync') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-sync-access-your-firefox-bookmarks') }}{% endblock %}
 
 {% block article_content %}
 <p>{{ ftl('features-sync-with-firefox-you-can-pick-up-where') }}</p>
 
-{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/") %}
+{% set fxa = 'href="%s"'|safe|format("https://www.mozilla.org/" + LANG + "/account/" + referrals) %}
 <p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account-v3', fxa=fxa) }}</p>
 
 <figure class="c-article-figure">
@@ -28,7 +30,7 @@
   ) }}
 </figure>
 
-<p>{{ ftl('features-sync-all-your-data-is-encrypted-on-our', privacy='https://www.mozilla.org/' + LANG + '/privacy/') }}</p>
+<p>{{ ftl('features-sync-all-your-data-is-encrypted-on-our', privacy='https://www.mozilla.org/' + LANG + '/privacy/' + referrals) }}</p>
 
 <h2>{{ ftl('features-sync-send-tabs-from-one-device-to-another') }}</h2>
 <p>{{ ftl('features-sync-the-send-tab-feature-in-firefox') }}</p>

--- a/springfield/firefox/templates/firefox/features/tips/tips.html
+++ b/springfield/firefox/templates/firefox/features/tips/tips.html
@@ -149,7 +149,7 @@
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='M9DK-taZsrw',
         image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_facebook-steve.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-        link_url='https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + params
+        link_url='https://addons.mozilla.org/firefox/addon/facebook-container/' + params
       )}}
 
       <!-- password manager -->

--- a/springfield/firefox/templates/firefox/features/tips/tips.html
+++ b/springfield/firefox/templates/firefox/features/tips/tips.html
@@ -6,6 +6,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+
 {% block page_image %}{{ static('img/firefox/features/tips/tips-and-tools.png') }}{% endblock %}
 
 {% from "macros-protocol.html" import split, callout, zap, card, callout_compact with context %}
@@ -84,7 +86,7 @@
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='-Rv5MKSBNUM',
         image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_screenshot_mj.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-        link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#screenshots'
+        link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/' + referrals + '#screenshots'
       )}}
 
        <!-- HTTps -->
@@ -147,7 +149,7 @@
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='M9DK-taZsrw',
         image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_facebook-steve.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-        link_url='https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/'
+        link_url='https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + referrals
       )}}
 
       <!-- password manager -->
@@ -236,7 +238,7 @@
       brand_product='mozilla',
       brand_size='lg'
     ) %}
-    <a href="https://www.mozilla.org/{{ LANG }}/account/" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
+    <a href="https://www.mozilla.org/{{ LANG }}/account/{{ referrals }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
   {% endcall %}
   </main>
 {% endblock %}

--- a/springfield/firefox/templates/firefox/features/tips/tips.html
+++ b/springfield/firefox/templates/firefox/features/tips/tips.html
@@ -6,7 +6,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-features' %}
 
 {% block page_image %}{{ static('img/firefox/features/tips/tips-and-tools.png') }}{% endblock %}
 
@@ -86,7 +86,7 @@
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='-Rv5MKSBNUM',
         image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_screenshot_mj.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-        link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/' + referrals + '#screenshots'
+        link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/' + params + '#screenshots'
       )}}
 
        <!-- HTTps -->
@@ -149,7 +149,7 @@
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='M9DK-taZsrw',
         image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_facebook-steve.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-        link_url='https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + referrals
+        link_url='https://www.mozilla.org/' + LANG + '/firefox/facebookcontainer/' + params
       )}}
 
       <!-- password manager -->
@@ -238,7 +238,7 @@
       brand_product='mozilla',
       brand_size='lg'
     ) %}
-    <a href="https://www.mozilla.org/{{ LANG }}/account/{{ referrals }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
+    <a href="https://www.mozilla.org/{{ LANG }}/account/{{ params }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
   {% endcall %}
   </main>
 {% endblock %}

--- a/springfield/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/springfield/firefox/templates/firefox/includes/download-button-thanks.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download-button-thanks' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download-button-thanks' %}
 
 <div id="{{ id }}" class="mzp-c-button-download-container c-button-download-thanks">
   <a href="{{ transition_url }}"
@@ -28,7 +28,7 @@
   {% include 'firefox/includes/download-unsupported.html' %}
 
   <small class="mzp-c-button-download-privacy-link">
-    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
+    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">
       {{ ftl('download-button-firefox-privacy-notice') }}
     </a>
   </small>

--- a/springfield/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/springfield/firefox/templates/firefox/includes/download-button-thanks.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button-thanks' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download-button-thanks' %}
 
 <div id="{{ id }}" class="mzp-c-button-download-container c-button-download-thanks">
   <a href="{{ transition_url }}"

--- a/springfield/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/springfield/firefox/templates/firefox/includes/download-button-thanks.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button-thanks' %}
+
 <div id="{{ id }}" class="mzp-c-button-download-container c-button-download-thanks">
   <a href="{{ transition_url }}"
      class="download-link c-button-download-thanks-link mzp-c-button mzp-t-product {% if button_class %}{{ button_class }}{% else %}mzp-t-xl{% endif %}"
@@ -26,7 +28,7 @@
   {% include 'firefox/includes/download-unsupported.html' %}
 
   <small class="mzp-c-button-download-privacy-link">
-    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/">
+    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
       {{ ftl('download-button-firefox-privacy-notice') }}
     </a>
   </small>

--- a/springfield/firefox/templates/firefox/includes/download-button.html
+++ b/springfield/firefox/templates/firefox/includes/download-button.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button' %}
+
 {% macro alt_buttons(builds) %}
   <div class="download download-dumb">
     <p role="heading" class="download-heading">
@@ -115,7 +117,7 @@
     {% endfor %}
   </ul>
   <small class="fx-privacy-link mzp-c-button-download-privacy-link">
-    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/">
+    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
       {{ ftl('download-button-firefox-privacy-notice', fallback='download-button-firefox-privacy') }}
     </a>
   </small>

--- a/springfield/firefox/templates/firefox/includes/download-button.html
+++ b/springfield/firefox/templates/firefox/includes/download-button.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button' %}
 
 {% macro alt_buttons(builds) %}
   <div class="download download-dumb">
@@ -117,7 +117,7 @@
     {% endfor %}
   </ul>
   <small class="fx-privacy-link mzp-c-button-download-privacy-link">
-    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
+    <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">
       {{ ftl('download-button-firefox-privacy-notice', fallback='download-button-firefox-privacy') }}
     </a>
   </small>

--- a/springfield/firefox/templates/firefox/includes/macros.html
+++ b/springfield/firefox/templates/firefox/includes/macros.html
@@ -4,6 +4,8 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button' %}
+
 {% macro firefox_download_desktop_button_windows(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-win', build='32', position='primary cta') -%}
   {% set class_name = 'os_win' if build == '32' else 'os_win64' %}
   {% set os = 'win' if build == '32' else 'win64' %}
@@ -27,7 +29,7 @@
       </a>
 
       <small class="mzp-c-button-download-privacy-link">
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
           {{ ftl('download-button-firefox-privacy-notice') }}
         </a>
       </small>
@@ -63,7 +65,7 @@
       </a>
 
       <small class="mzp-c-button-download-privacy-link">
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
           {{ ftl('download-button-firefox-privacy-notice') }}
         </a>
       </small>
@@ -104,7 +106,7 @@
       data-cta-text="You can set up our APT repository instead"')}}</p>
 
       <small class="mzp-c-button-download-privacy-link">
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
           {{ ftl('download-button-firefox-privacy-notice') }}
         </a>
       </small>

--- a/springfield/firefox/templates/firefox/includes/macros.html
+++ b/springfield/firefox/templates/firefox/includes/macros.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=download-button' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download-button' %}
 
 {% macro firefox_download_desktop_button_windows(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-win', build='32', position='primary cta') -%}
   {% set class_name = 'os_win' if build == '32' else 'os_win64' %}

--- a/springfield/firefox/templates/firefox/includes/macros.html
+++ b/springfield/firefox/templates/firefox/includes/macros.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download-button' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download-button' %}
 
 {% macro firefox_download_desktop_button_windows(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-win', build='32', position='primary cta') -%}
   {% set class_name = 'os_win' if build == '32' else 'os_win64' %}
@@ -29,7 +29,7 @@
       </a>
 
       <small class="mzp-c-button-download-privacy-link">
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">
           {{ ftl('download-button-firefox-privacy-notice') }}
         </a>
       </small>
@@ -65,7 +65,7 @@
       </a>
 
       <small class="mzp-c-button-download-privacy-link">
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">
           {{ ftl('download-button-firefox-privacy-notice') }}
         </a>
       </small>
@@ -106,7 +106,7 @@
       data-cta-text="You can set up our APT repository instead"')}}</p>
 
       <small class="mzp-c-button-download-privacy-link">
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ referrals }}">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">
           {{ ftl('download-button-firefox-privacy-notice') }}
         </a>
       </small>

--- a/springfield/firefox/templates/firefox/includes/mozilla-account-promo.html
+++ b/springfield/firefox/templates/firefox/includes/mozilla-account-promo.html
@@ -4,6 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=account-promo' %}
 
 <div class="mzp-l-content is-js-dependent">
 
@@ -48,7 +49,7 @@
       <p class="accounts-signin">
         {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin') %}
         {% set sign_in_url = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-text="Accounts Learn More"'|safe %}
-        {% set learn_more_url = 'href="'|safe ~ 'https://www.mozilla.org/' ~ LANG ~ '/account/' ~ '"'|safe %}
+        {% set learn_more_url = 'href="https://www.mozilla.org/{}/account/{}"'.format(LANG, referrals) %}
         {{ ftl('moz-account-already-have-v2', sign_in_url=sign_in_url, learn_more_url=learn_more_url) }}
       </p>
     </div>

--- a/springfield/firefox/templates/firefox/includes/mozilla-account-promo.html
+++ b/springfield/firefox/templates/firefox/includes/mozilla-account-promo.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=account-promo' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=account-promo' %}
 
 <div class="mzp-l-content is-js-dependent">
 

--- a/springfield/firefox/templates/firefox/includes/mozilla-account-promo.html
+++ b/springfield/firefox/templates/firefox/includes/mozilla-account-promo.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=account-promo' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=account-promo' %}
 
 <div class="mzp-l-content is-js-dependent">
 
@@ -49,7 +49,7 @@
       <p class="accounts-signin">
         {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin') %}
         {% set sign_in_url = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-text="Accounts Learn More"'|safe %}
-        {% set learn_more_url = 'href="https://www.mozilla.org/{}/account/{}"'.format(LANG, referrals) %}
+        {% set learn_more_url = 'href="https://www.mozilla.org/{}/account/{}"'.format(LANG, params) %}
         {{ ftl('moz-account-already-have-v2', sign_in_url=sign_in_url, learn_more_url=learn_more_url) }}
       </p>
     </div>

--- a/springfield/firefox/templates/firefox/includes/send-to-device.html
+++ b/springfield/firefox/templates/firefox/includes/send-to-device.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=send-to-device' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=send-to-device' %}
 
 <section id="{{ dom_id }}" class="send-to-device {{ class_name }}" data-testid="send-to-device-form">
   <div class="form-container">

--- a/springfield/firefox/templates/firefox/includes/send-to-device.html
+++ b/springfield/firefox/templates/firefox/includes/send-to-device.html
@@ -4,6 +4,8 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=send-to-device' %}
+
 <section id="{{ dom_id }}" class="send-to-device {{ class_name }}" data-testid="send-to-device-form">
   <div class="form-container">
     {% if include_title %}
@@ -54,7 +56,7 @@
           {% else %}
             {{ ftl('send-to-device-intended-recipient-email') }}
           {% endif %}
-          <a href="https://www.mozilla.org/privacy/websites/#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
+          <a href="https://www.mozilla.org/privacy/websites/{{ referrals }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
         </p>
       </div>
       <div class="thank-you hidden" data-testid="send-to-device-form-thanks">

--- a/springfield/firefox/templates/firefox/includes/send-to-device.html
+++ b/springfield/firefox/templates/firefox/includes/send-to-device.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=send-to-device' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=send-to-device' %}
 
 <section id="{{ dom_id }}" class="send-to-device {{ class_name }}" data-testid="send-to-device-form">
   <div class="form-container">
@@ -56,7 +56,7 @@
           {% else %}
             {{ ftl('send-to-device-intended-recipient-email') }}
           {% endif %}
-          <a href="https://www.mozilla.org/privacy/websites/{{ referrals }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
+          <a href="https://www.mozilla.org/privacy/websites/{{ params }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
         </p>
       </div>
       <div class="thank-you hidden" data-testid="send-to-device-form-thanks">

--- a/springfield/firefox/templates/firefox/more/best-browser.html
+++ b/springfield/firefox/templates/firefox/more/best-browser.html
@@ -8,7 +8,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=best-browser&utm_content=seo' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=best-browser&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('best-browser-find-your-best-browser') }}{% endblock %}
 
@@ -76,13 +76,13 @@
         {{ ftl('best-browser-there-are-a-few-ways') }}
       </p>
       <p>
-        {{ ftl('best-browser-the-second-is-not-storing', data='https://www.mozilla.org/privacy/firefox/' + referrals, privacy='https://www.mozilla.org/privacy/firefox/' + referrals) }}
+        {{ ftl('best-browser-the-second-is-not-storing', data='https://www.mozilla.org/privacy/firefox/' + params, privacy='https://www.mozilla.org/privacy/firefox/' + params) }}
       </p>
       <p>
         {{ ftl('best-browser-last-but-not-least') }}
       </p>
       <p>
-        {{ ftl('best-browser-firefox-is-offering-v2', monitor='href="https://monitor.mozilla.org/{}"'.format(referrals)) }}
+        {{ ftl('best-browser-firefox-is-offering-v2', monitor='href="https://monitor.mozilla.org/{}"'.format(params)) }}
       </p>
       <blockquote aria-hidden="true" role="presentation">
       <p>
@@ -104,7 +104,7 @@
       {{ ftl('best-browser-another-way-to-stop') }}
     </p>
     <p>
-      {{ ftl('best-browser-one-easy-way-to-check', privacy='https://www.mozilla.org/privacy/firefox/' + referrals) }}
+      {{ ftl('best-browser-one-easy-way-to-check', privacy='https://www.mozilla.org/privacy/firefox/' + params) }}
     </p>
     <p>
       {{ ftl('best-browser-choosing-the-best-browser') }}

--- a/springfield/firefox/templates/firefox/more/best-browser.html
+++ b/springfield/firefox/templates/firefox/more/best-browser.html
@@ -8,7 +8,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=best-browser&utm_content=seo' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=best-browser' %}
 
 {% block page_title %}{{ ftl('best-browser-find-your-best-browser') }}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/more/best-browser.html
+++ b/springfield/firefox/templates/firefox/more/best-browser.html
@@ -8,7 +8,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-best-browser&utm_medium=referral&utm_campaign=seo' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=best-browser&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('best-browser-find-your-best-browser') }}{% endblock %}
 

--- a/springfield/firefox/templates/firefox/more/best-browser.html
+++ b/springfield/firefox/templates/firefox/more/best-browser.html
@@ -8,6 +8,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-best-browser&utm_medium=referral&utm_campaign=seo' %}
+
 {% block page_title %}{{ ftl('best-browser-find-your-best-browser') }}{% endblock %}
 
 {% block page_desc %}
@@ -74,13 +76,13 @@
         {{ ftl('best-browser-there-are-a-few-ways') }}
       </p>
       <p>
-        {{ ftl('best-browser-the-second-is-not-storing', data='https://www.mozilla.org/privacy/firefox/', privacy='https://www.mozilla.org/privacy/firefox/') }}
+        {{ ftl('best-browser-the-second-is-not-storing', data='https://www.mozilla.org/privacy/firefox/' + referrals, privacy='https://www.mozilla.org/privacy/firefox/' + referrals) }}
       </p>
       <p>
         {{ ftl('best-browser-last-but-not-least') }}
       </p>
       <p>
-        {{ ftl('best-browser-firefox-is-offering-v2', monitor='href="https://monitor.mozilla.org/"') }}
+        {{ ftl('best-browser-firefox-is-offering-v2', monitor='href="https://monitor.mozilla.org/{}"'.format(referrals)) }}
       </p>
       <blockquote aria-hidden="true" role="presentation">
       <p>
@@ -102,7 +104,7 @@
       {{ ftl('best-browser-another-way-to-stop') }}
     </p>
     <p>
-      {{ ftl('best-browser-one-easy-way-to-check', privacy='https://www.mozilla.org/privacy/firefox/') }}
+      {{ ftl('best-browser-one-easy-way-to-check', privacy='https://www.mozilla.org/privacy/firefox/' + referrals) }}
     </p>
     <p>
       {{ ftl('best-browser-choosing-the-best-browser') }}

--- a/springfield/firefox/templates/firefox/more/faq.html
+++ b/springfield/firefox/templates/firefox/more/faq.html
@@ -9,6 +9,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-faq&utm_medium=referral&utm_campaign=seo' %}
+
 {% block page_title %}{{ ftl('firefox-faq') }}{% endblock %}
 {% block page_desc %}{{ ftl('whether-you-searched-privacy') }}{% endblock %}
 
@@ -45,7 +47,7 @@
         <h2>{{ ftl('what-is-firefox') }}</h2>
         <p>{{ ftl('the-firefox-browser-the-only',
           url='/',
-          url2='https://www.mozilla.org/en-US/products/') }}</p>
+          url2='https://www.mozilla.org/en-US/products/' + referrals) }}</p>
       </li>
       <li>
         <h2>{{ ftl('how-do-i') }}</h2>
@@ -88,19 +90,19 @@
       <li>
         <h2>{{ ftl('does-firefox-use') }}</h2>
         <p>{{ ftl('firefoxs-default-search',
-              url='https://support.mozilla.org/kb/change-your-default-search-settings-firefox/?utm_source=www.firefox.com-faq&amp;utm_medium=referral&amp;utm_campaign=seo') }}</p>
+              url='https://support.mozilla.org/kb/change-your-default-search-settings-firefox/' + referrals) }}</p>
       </li>
       {% if ftl_has_messages('firefox-does-not-v2') %}
       <li>
         <h2>{{ ftl('does-firefox-have') }}</h2>
         <p>{{ ftl('firefox-does-not-v2',
-              url='https://www.mozilla.org/en-US/products/vpn/?utm_source=www.firefox.com-faq&amp;utm_medium=referral&amp;utm_campaign=seo') }}</p>
+              url='https://www.mozilla.org/en-US/products/vpn/' + referrals) }}</p>
         <small>{{ ftl('related-questions-ip') }}</small>
       </li>
       {% endif %}
       <li>
         <h2>{{ ftl('who-owns-firefox') }}</h2>
-        <p>{{ ftl('firefox-is-made', url='https://foundation.mozilla.org/?utm_source=www.firefox.com-faq&amp;utm_medium=referral&amp;utm_campaign=seo', url2='https://www.mozilla.org/en-US/foundation/moco/') }}</p>
+        <p>{{ ftl('firefox-is-made', url='https://foundation.mozilla.org/' + referrals, url2='https://www.mozilla.org/en-US/foundation/moco/' + referrals) }}</p>
         <small>{{ ftl('related-questions-who') }}</small>
       </li>
     </ul>

--- a/springfield/firefox/templates/firefox/more/faq.html
+++ b/springfield/firefox/templates/firefox/more/faq.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=faq&utm_content=seo' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=faq&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('firefox-faq') }}{% endblock %}
 {% block page_desc %}{{ ftl('whether-you-searched-privacy') }}{% endblock %}
@@ -47,7 +47,7 @@
         <h2>{{ ftl('what-is-firefox') }}</h2>
         <p>{{ ftl('the-firefox-browser-the-only',
           url='/',
-          url2='https://www.mozilla.org/en-US/products/' + referrals) }}</p>
+          url2='https://www.mozilla.org/en-US/products/' + params) }}</p>
       </li>
       <li>
         <h2>{{ ftl('how-do-i') }}</h2>
@@ -90,19 +90,19 @@
       <li>
         <h2>{{ ftl('does-firefox-use') }}</h2>
         <p>{{ ftl('firefoxs-default-search',
-              url='https://support.mozilla.org/kb/change-your-default-search-settings-firefox/' + referrals) }}</p>
+              url='https://support.mozilla.org/kb/change-your-default-search-settings-firefox/' + params) }}</p>
       </li>
       {% if ftl_has_messages('firefox-does-not-v2') %}
       <li>
         <h2>{{ ftl('does-firefox-have') }}</h2>
         <p>{{ ftl('firefox-does-not-v2',
-              url='https://www.mozilla.org/en-US/products/vpn/' + referrals) }}</p>
+              url='https://www.mozilla.org/en-US/products/vpn/' + params) }}</p>
         <small>{{ ftl('related-questions-ip') }}</small>
       </li>
       {% endif %}
       <li>
         <h2>{{ ftl('who-owns-firefox') }}</h2>
-        <p>{{ ftl('firefox-is-made', url='https://foundation.mozilla.org/' + referrals, url2='https://www.mozilla.org/en-US/foundation/moco/' + referrals) }}</p>
+        <p>{{ ftl('firefox-is-made', url='https://foundation.mozilla.org/' + params, url2='https://www.mozilla.org/en-US/foundation/moco/' + params) }}</p>
         <small>{{ ftl('related-questions-who') }}</small>
       </li>
     </ul>

--- a/springfield/firefox/templates/firefox/more/faq.html
+++ b/springfield/firefox/templates/firefox/more/faq.html
@@ -9,7 +9,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-faq&utm_medium=referral&utm_campaign=seo' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=faq&utm_content=seo' %}
 
 {% block page_title %}{{ ftl('firefox-faq') }}{% endblock %}
 {% block page_desc %}{{ ftl('whether-you-searched-privacy') }}{% endblock %}

--- a/springfield/firefox/templates/firefox/testflight.html
+++ b/springfield/firefox/templates/firefox/testflight.html
@@ -8,7 +8,7 @@
 
 {% from "macros-protocol.html" import callout with context %}
 
-{% set referrals = '?utm_source=www.firefox.com-testflight&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=testflight' %}
 
 {% block page_title_full %}Firefox for iOS Beta — TestFlight{% endblock %}
 

--- a/springfield/firefox/templates/firefox/testflight.html
+++ b/springfield/firefox/templates/firefox/testflight.html
@@ -8,7 +8,7 @@
 
 {% from "macros-protocol.html" import callout with context %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=testflight' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=testflight' %}
 
 {% block page_title_full %}Firefox for iOS Beta — TestFlight{% endblock %}
 
@@ -118,7 +118,7 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
           {% endwith %}
 
           When Mozilla receives data from you or TestFlight, we handle it in
-          accordance with our <a href="https://www.mozilla.org/{{ LANG }}/privacy/{{ referrals }}">Privacy Policy</a>.
+          accordance with our <a href="https://www.mozilla.org/{{ LANG }}/privacy/{{ params }}">Privacy Policy</a>.
         </p>
       </li>
       <li>

--- a/springfield/firefox/templates/firefox/testflight.html
+++ b/springfield/firefox/templates/firefox/testflight.html
@@ -8,6 +8,8 @@
 
 {% from "macros-protocol.html" import callout with context %}
 
+{% set referrals = '?utm_source=www.firefox.com-testflight&utm_medium=referral' %}
+
 {% block page_title_full %}Firefox for iOS Beta — TestFlight{% endblock %}
 
 {% block page_desc %}
@@ -116,7 +118,7 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
           {% endwith %}
 
           When Mozilla receives data from you or TestFlight, we handle it in
-          accordance with our <a href="https://www.mozilla.org/{{ LANG }}/privacy/">Privacy Policy</a>.
+          accordance with our <a href="https://www.mozilla.org/{{ LANG }}/privacy/{{ referrals }}">Privacy Policy</a>.
         </p>
       </li>
       <li>

--- a/springfield/newsletter/templates/newsletter/includes/form.html
+++ b/springfield/newsletter/templates/newsletter/includes/form.html
@@ -6,7 +6,7 @@
 
 {% from "newsletter/includes/macros.html" import email_form_thankyou with context %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=newsletter-form' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=newsletter-form' %}
 
 {% if not success %}
   <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post" data-testid="newsletter-form">

--- a/springfield/newsletter/templates/newsletter/includes/form.html
+++ b/springfield/newsletter/templates/newsletter/includes/form.html
@@ -6,6 +6,8 @@
 
 {% from "newsletter/includes/macros.html" import email_form_thankyou with context %}
 
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_content=newsletter-form' %}
+
 {% if not success %}
   <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post" data-testid="newsletter-form">
     {% if not is_multi_newsletter_form %}
@@ -94,7 +96,7 @@
 
         <p>
           <label for="privacy" class="mzp-u-inline">
-            <input type="checkbox" id="privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox"> {{ ftl('newsletter-form-im-okay-with-mozilla', url='https://www.mozilla.org/' + LANG + '/privacy/websites/') }}
+            <input type="checkbox" id="privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox"> {{ ftl('newsletter-form-im-okay-with-mozilla', url='https://www.mozilla.org/' + LANG + '/privacy/websites/' + referrals) }}
           </label>
         </p>
         </div>

--- a/springfield/newsletter/templates/newsletter/includes/form.html
+++ b/springfield/newsletter/templates/newsletter/includes/form.html
@@ -6,7 +6,7 @@
 
 {% from "newsletter/includes/macros.html" import email_form_thankyou with context %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=newsletter-form' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=newsletter-form' %}
 
 {% if not success %}
   <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post" data-testid="newsletter-form">
@@ -96,7 +96,7 @@
 
         <p>
           <label for="privacy" class="mzp-u-inline">
-            <input type="checkbox" id="privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox"> {{ ftl('newsletter-form-im-okay-with-mozilla', url='https://www.mozilla.org/' + LANG + '/privacy/websites/' + referrals) }}
+            <input type="checkbox" id="privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox"> {{ ftl('newsletter-form-im-okay-with-mozilla', url='https://www.mozilla.org/' + LANG + '/privacy/websites/' + params) }}
           </label>
         </p>
         </div>

--- a/springfield/privacy/templates/privacy/cookie-settings.html
+++ b/springfield/privacy/templates/privacy/cookie-settings.html
@@ -8,7 +8,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=cookie-settings' %}
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=cookie-settings' %}
 
 {% block page_title %}{{ ftl('cookie-settings-page-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('cookie-settings-page-desc') }}{% endblock %}
@@ -168,7 +168,7 @@
       <p>{{ ftl('cookie-settings-privacy-desc') }}</p>
 
       <p>
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ referrals }}">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ params }}">
           {{ ftl('cookie-settings-privacy-policy-link') }}
         </a>
       </p>

--- a/springfield/privacy/templates/privacy/cookie-settings.html
+++ b/springfield/privacy/templates/privacy/cookie-settings.html
@@ -8,7 +8,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% set referrals = '?utm_source=www.firefox.com-cookie-settings&utm_medium=referral' %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=cookie-settings' %}
 
 {% block page_title %}{{ ftl('cookie-settings-page-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('cookie-settings-page-desc') }}{% endblock %}

--- a/springfield/privacy/templates/privacy/cookie-settings.html
+++ b/springfield/privacy/templates/privacy/cookie-settings.html
@@ -8,6 +8,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% set referrals = '?utm_source=www.firefox.com-cookie-settings&utm_medium=referral' %}
+
 {% block page_title %}{{ ftl('cookie-settings-page-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('cookie-settings-page-desc') }}{% endblock %}
 
@@ -166,7 +168,7 @@
       <p>{{ ftl('cookie-settings-privacy-desc') }}</p>
 
       <p>
-        <a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/">
+        <a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ referrals }}">
           {{ ftl('cookie-settings-privacy-policy-link') }}
         </a>
       </p>


### PR DESCRIPTION
- Vars containing UTM links are called params and start with "?" (when needed, we can break the UTMs off away from the question mark)
- All* external links include referrals
- No internal links should include referrals

*All is particularly focused on links over to mozorg. Any missing external mozorg links can be considered blocking. Other external links might be worth adding but are not blocking.

## One-line summary


## Significant changes and points to review

Relevant UTM docs
- https://mozilla.github.io/bedrock/attribution/0002-firefox-desktop/#attribution-data
- https://mozilla.github.io/bedrock/attribution/0004-mozilla-accounts/#how-does-attribution-work


## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/232


## Testing
- [x] http://localhost:8000/en-US/ (check nav and footer)
- [x] http://localhost:8000/en-US/404
- [x] http://localhost:8000/en-US/500
- [x] http://localhost:8000/en-US/download/all/
- [x] http://localhost:8000/en-US/compare/chrome/
- [x] http://localhost:8000/en-US/compare/edge/
- [x] http://localhost:8000/en-US/compare/safari/
- [x] http://localhost:8000/en-US/compare/brave/
- [x] http://localhost:8000/en-US/compare/opera/
- [x] http://localhost:8000/en-US/browsers/desktop/chromebook/
- [x] http://localhost:8000/en-US/channel/android/
- [x] http://localhost:8000/en-US/channel/desktop/
- [x] http://localhost:8000/en-US/thanks/
- [x] http://localhost:8000/en-US/channel/desktop/developer/
- [x] http://localhost:8000/en-US/features/add-ons/
- [x] http://localhost:8000/en-US/features/customize/
- [x] http://localhost:8000/en-US/features/fast/
- [x] http://localhost:8000/en-US/features/private-browsing/
- [x] http://localhost:8000/en-US/features/private/
- [x] http://localhost:8000/en-US/features/sync/
- [x] http://localhost:8000/en-US/features/tips/
- [x] http://localhost:8000/en-US/more/best-browser/
- [x] http://localhost:8000/en-US/more/faq/
- [x] http://localhost:8000/en-US/channel/ios/testflight/
- [x] http://localhost:8000/en-US/newsletter/ (click into email input to see privacy link appear)
- [x] http://localhost:8000/en-US/privacy/websites/cookie-settings/
- [ ] Check privacy notice links under download buttons (they should have `utm_content` instead of `utm_campaign`
- [x] http://localhost:8000/en-US/browsers/desktop/ (check account promo "learn more" link at bottom)
- [x] http://localhost:8000/en-US/browsers/mobile/android/ "learn more" link on email