### PR TITLE
Fix site details on global root and locale page

### DIFF
--- a/springfield/base/templates/404-locale.html
+++ b/springfield/base/templates/404-locale.html
@@ -8,19 +8,19 @@
 
 {%- block page_title -%}
   {%- if is_root -%}
-    Internet for people, not profit
+    Get Firefox for desktop and mobile.
   {%- else -%}
-    404 - Choose your language or locale to browse Mozilla.org
+    404 — Choose your language or locale to browse
   {%- endif -%}
 {%- endblock -%}
 
 {%- block page_title_suffix -%}
-  {% if is_root %} — Mozilla Global{% else %} — Mozilla{% endif %}
+  {% if is_root %} — Firefox.com Global{% else %} — Firefox.com{% endif %}
 {%- endblock -%}
 
 {%- block page_desc -%}
   {%- if is_root -%}
-    Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.
+    Firefox is a free web browser backed by Mozilla, a non-profit dedicated to internet health and privacy.
   {%- else -%}
     Select your country or region to indicate your preferred language.
   {%- endif -%}
@@ -44,7 +44,7 @@
   <header class="c-simple-header">
     <h1 class="c-simple-header-title">
       {%- if is_root -%}
-        Choose your language or locale to browse Mozilla.org
+        Choose your language or locale to browse Firefox.com
       {%- else -%}
         Page is not yet translated
       {%- endif -%}
@@ -57,7 +57,7 @@
   <section class="c-block-list">
     <ul>
       {% for locale in available_locales if locale in languages %}
-        <li lang="{{ locale }}"><a href="/{{ locale }}{{ request.path_info }}" title="{{ 'Browse {0} in the {1} language'|f(request.path_info, languages[locale]["native"]) }}">{{ languages[locale]['native'] }}</a></li>
+        <li lang="{{ locale }}"><a href="/{{ locale }}{{ request.path_info }}" title="{{ 'Browse {0} in the {1} language'|f(request.path_info, languages[locale]["English"]) }}">{{ languages[locale]['native'] }}</a></li>
       {% endfor %}
     </ul>
   </section>

--- a/springfield/base/templates/base/locales.html
+++ b/springfield/base/templates/base/locales.html
@@ -6,10 +6,10 @@
 
 {% extends "base-protocol.html" %}
 
-{% block page_title %}Choose your language or locale to browse Mozilla.org{% endblock %}
+{% block page_title %}Choose your language or locale to browse Firefox.com{% endblock %}
 
 {% block page_desc %}
-  Select your country or region to indicate your preferred language. Learn how Mozilla puts people before profit, making products designed to keep the internet open to all.
+  Select your country or region to indicate your preferred language. Firefox is a free web browser backed by Mozilla, a non-profit dedicated to internet health and privacy.
 {% endblock %}
 
 {% block canonical_urls %}
@@ -31,7 +31,7 @@
       <h2 class="c-block-list-title">{{ region }}</h2>
       <ul>
         {% for loc in locales %}
-          <li lang="{{ loc }}"><a href="/{{ loc }}/" title="Browse Mozilla.org in the {{ languages[loc]['English'] }} language">{{ languages[loc]["native"] }}</a></li>
+          <li lang="{{ loc }}"><a href="/{{ loc }}/" title="Browse Firefox.com in the {{ languages[loc]['English'] }} language">{{ languages[loc]["native"] }}</a></li>
         {% endfor %}
       </ul>
     </section>


### PR DESCRIPTION
## One-line summary

Removing WMO references, taglines and meta from locale pages.

## Significant changes and points to review

Wording repurposed from other places.
The change on L60 key from native to English is intentional (for consistency)
Title truncated on L13 as it gets the same in suffix just below.

## Issue / Bugzilla link

#292

## Testing

http://localhost:8000/en-US/404-locale/
http://localhost:8000/locales/
http://localhost:8000/ (in prod mode, and with Accept-Language empty)