### PR TITLE
remove pencil banner site link (fix #296)

### DIFF
--- a/l10n/en/banners/m24-pencil-banner.ftl
+++ b/l10n/en/banners/m24-pencil-banner.ftl
@@ -5,3 +5,4 @@
 # Variables:
 # $link (url) - link to https://www.firefox.com
 m24-pencil-banner-firefox-has-moved = { -brand-name-firefox } has moved – Same mission. Same values. Welcome to <a { $link }>firefox.com</a>
+m24-pencil-banner-firefox-has-moved-v2 = { -brand-name-firefox } has moved – Same mission. Same values. Welcome to firefox.com.

--- a/springfield/base/templates/includes/banners/pencil-banner.html
+++ b/springfield/base/templates/includes/banners/pencil-banner.html
@@ -9,7 +9,7 @@
   {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
   <aside class="m24-pencil-banner" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
     <div class="m24-pencil-banner-copy">
-      {{ ftl('m24-pencil-banner-firefox-has-moved', link='href="https://www.firefox.com/"') }}
+      {{ ftl('m24-pencil-banner-firefox-has-moved-v2') }}
     </div>
     <button class="m24-pencil-banner-close" type="button">{{ ftl('ui-close') }}</button>
   </aside>


### PR DESCRIPTION
## One-line summary

This PR removes the firefox.com link from the pencil banner.

## Significant changes and points to review

Home page pencil banner.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/296

## Testing

http://localhost:8000/en-US/