### PR TITLE
Add feedback link above footer (#297)

### DIFF
--- a/l10n/en/footer-firefox.ftl
+++ b/l10n/en/footer-firefox.ftl
@@ -82,6 +82,6 @@ footer-putting-people = Putting people before profits since 1998
 
 ## Feedback
 
-footer-feedback-find-a-bug = Find a bug with our new website?
+footer-feedback-found-a-bug = Found a bug with our new website?
 # links to a Google Form that is English only
 footer-feedback-let-us-know = Let us know.

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -12,7 +12,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
   <aside class="m24-pencil-banner" aria-label="Feedback" data-nosnippet="true">
     <div class="m24-pencil-banner-copy">
-      {{ ftl('footer-feedback-find-a-bug') }} <a href="https://forms.gle/oEkxTrQQthys19qG9" rel="external noopener" target="_blank">{{ ftl('footer-feedback-let-us-know') }}</a>
+      {{ ftl('footer-feedback-found-a-bug') }} <a href="https://forms.gle/oEkxTrQQthys19qG9" rel="external noopener" target="_blank">{{ ftl('footer-feedback-let-us-know') }}</a>
     </div>
   </aside>
 {% endif %}


### PR DESCRIPTION
## One-line summary

Add feedback link above footer

## Significant changes and points to review

- Adds a little banner and link behind a switch
- Translatable but will display without translation
- Google form does not require login.

## Issue / Bugzilla link

Fix #297 

## Testing

Should appear in the footer of all pages. Make sure the link works.

![Screenshot 2025-06-17 at 08 49 14](https://github.com/user-attachments/assets/d0faee4f-8292-4590-aa14-29f8382b1eba)
