### PR TITLE
Port Download-as-Default work from Bedrock #294

### DIFF
--- a/l10n/en/firefox/download/desktop.ftl
+++ b/l10n/en/firefox/download/desktop.ftl
@@ -24,7 +24,9 @@ firefox-desktop-download-get-the-browser = Get the browser that protects what’
 
 firefox-desktop-download-fast-reliable-private = Fast, reliable and private — for peace of mind online.
 
-# Obsolete string
+firefox-desktop-set-as-default = Set { -brand-name-firefox } as your default browser.
+
+# Obsolete string (expires: 2025-04-17)
 firefox-desktop-download-no-shady = No shady privacy policies or back doors for advertisers. Just a lightning fast browser that doesn’t sell you out.
 
 firefox-desktop-download-download-options = Download options and other languages
@@ -33,7 +35,7 @@ firefox-desktop-download-browser-support = { -brand-name-firefox-browser } suppo
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
 firefox-desktop-download-do-what-you-do-v2 = Do what you do online.<br> { -brand-name-firefox-browser } has got you <strong>covered</strong>.
 
-# Obsolete string
+# Obsolete string (expires: 2025-04-17)
 firefox-desktop-download-do-what-you-do = Do what you do online.<br> { -brand-name-firefox-browser } <strong>isn’t</strong> watching.
 
 firefox-desktop-download-we-block-the-ad = We block the ad trackers. You explore the internet faster.

--- a/media/css/firefox/download/desktop/download.scss
+++ b/media/css/firefox/download/desktop/download.scss
@@ -1324,3 +1324,27 @@ button.mzp-c-cta-link {
         }
     }
 }
+
+// --------------------------------------------------------------------------
+// download as default checkbox
+
+.default-browser-label {
+    display: block;
+    font-weight: normal;
+    margin: 0 auto $spacing-lg;
+    padding-bottom: 0;
+    width: max-content;
+
+    &.hidden {
+        display: none;
+    }
+
+    input[type="checkbox"] {
+        margin-right: $spacing-sm;
+        vertical-align: top;
+    }
+
+    .c-intro-download & {
+        margin: 0 0 $spacing-lg;
+    }
+}

--- a/media/css/firefox/home-en-us-ca.scss
+++ b/media/css/firefox/home-en-us-ca.scss
@@ -731,3 +731,27 @@ button.mzp-c-cta-link {
         }
     }
 }
+
+// --------------------------------------------------------------------------
+// download as default checkbox
+
+.default-browser-label {
+    display: block;
+    font-weight: normal;
+    margin: 0 auto $spacing-lg;
+    padding-bottom: 0;
+    width: max-content;
+
+    &.hidden {
+        display: none;
+    }
+
+    input[type="checkbox"] {
+        margin-right: $spacing-sm;
+        vertical-align: top;
+    }
+
+    .c-intro-download & {
+        margin: 0 0 $spacing-lg;
+    }
+}

--- a/media/js/firefox/download/desktop/download-as-default-init.es6.js
+++ b/media/js/firefox/download/desktop/download-as-default-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import DownloadAsDefault from './download-as-default.es6.js';
+
+DownloadAsDefault.init();

--- a/media/js/firefox/download/desktop/download-as-default.es6.js
+++ b/media/js/firefox/download/desktop/download-as-default.es6.js
@@ -1,0 +1,237 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    hasConsentCookie,
+    getConsentCookie,
+    consentRequired,
+    dntEnabled,
+    gpcEnabled
+} from '../../../base/consent/utils.es6';
+
+const DownloadAsDefault = {};
+
+window.Mozilla.DownloadAsDefault = DownloadAsDefault;
+
+/**
+ * Removes UTM parameters from a given URL, preserving
+ * all other parameters and URL information.
+ * @param {String} href
+ * @returns {String} href
+ */
+DownloadAsDefault.removeUTMParams = (href) => {
+    const url = new URL(href);
+    const searchParams = new URLSearchParams(url.search);
+
+    // List of UTM parameters to remove
+    const utmParams = [
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+        'experiment',
+        'variation'
+    ];
+
+    // Remove UTM parameters
+    utmParams.forEach((param) => searchParams.delete(param));
+
+    // Construct new URL without UTM parameters
+    const newUrl =
+        url.origin +
+        url.pathname +
+        (searchParams.toString() ? '?' + searchParams.toString() : '') +
+        url.hash;
+
+    return newUrl;
+};
+
+/**
+ * Adds UTM parameters to a given URL that are needed to trigger
+ * the set-as-default functionality when Firefox is installed.
+ * @param {String} href
+ * @returns {String} href
+ */
+DownloadAsDefault.addUTMParams = (href) => {
+    // sanitize URL so we don't pile on UTMs
+    const url = new URL(DownloadAsDefault.removeUTMParams(href));
+    const searchParams = new URLSearchParams(url.search);
+
+    searchParams.append('utm_campaign', 'SET_DEFAULT_BROWSER');
+
+    // Construct new URL with UTM parameters
+    const newUrl =
+        url.origin +
+        url.pathname +
+        (searchParams.toString() ? '?' + searchParams.toString() : '') +
+        url.hash;
+
+    return newUrl;
+};
+
+/**
+ * Processes attribution changes depending on checkbox state.
+ * @param {Boolean} checked - checkbox target value.
+ */
+DownloadAsDefault.processAttributionRequest = (checked) => {
+    let url = window.location.href;
+
+    // First remove all existing attribution data.
+    window.Mozilla.StubAttribution.removeAttributionData();
+
+    /**
+     * If the checkbox has been unchecked, remove UTM parameters
+     * from the page URL (`utm_campaign=SET_DEFAULT_BROWSER` is
+     * what triggers the browser default functionality).
+     */
+    if (!checked) {
+        url = DownloadAsDefault.removeUTMParams(url);
+    } else {
+        url = DownloadAsDefault.addUTMParams(url);
+    }
+
+    // Update the browser's URL without reloading
+    window.history.replaceState({}, document.title, url);
+
+    /**
+     * Finally, re-initiate attribution based on the new URL
+     * parameters. Only rebind events after attribution
+     * request has been successful.
+     */
+    window.Mozilla.StubAttribution.init(() => {
+        DownloadAsDefault.bindEvents();
+    });
+};
+
+/**
+ * Handles checkbox change event. Because checkbox state must be
+ * synced between all checkboxes on the page, we must temporarily
+ * unbind event listeners to avoid triggering multiple change
+ * events at once.
+ * @param {Object} e - change event object.
+ */
+DownloadAsDefault.handleChangeEvent = (e) => {
+    DownloadAsDefault.unbindEvents();
+    DownloadAsDefault.setCheckboxState(e.target.checked);
+    DownloadAsDefault.processAttributionRequest(e.target.checked);
+};
+
+/**
+ * Unbinds checkbox change event listeners and disables
+ * inputs when unbound.
+ */
+DownloadAsDefault.unbindEvents = () => {
+    const checkboxes = document.querySelectorAll('.default-browser-checkbox');
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].removeEventListener(
+            'change',
+            DownloadAsDefault.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = true;
+    }
+};
+
+/**
+ * Binds checkbox change event listeners and removes
+ * disabled states on inputs when bound.
+ */
+DownloadAsDefault.bindEvents = () => {
+    const checkboxes = document.querySelectorAll('.default-browser-checkbox');
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].addEventListener(
+            'change',
+            DownloadAsDefault.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = false;
+    }
+};
+
+/**
+ * Sets the checked state of all checkbox inputs.
+ * @param {Boolean} checked state
+ */
+DownloadAsDefault.setCheckboxState = (checked) => {
+    const checkboxes = document.querySelectorAll('.default-browser-checkbox');
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].checked = checked;
+    }
+};
+
+/**
+ * Displays checkboxes via CSS by removing the `hidden`
+ * class on their corresponding `<label>` parent elements.
+ */
+DownloadAsDefault.showCheckbox = () => {
+    const labels = document.querySelectorAll('.default-browser-label');
+    for (let i = 0; i < labels.length; i++) {
+        labels[i].classList.remove('hidden');
+        labels[i].querySelector('.default-browser-checkbox').checked = true;
+    }
+};
+
+/**
+ * Determines if set-as-default checkbox should display.
+ * @returns {Boolean}
+ */
+DownloadAsDefault.meetsRequirements = () => {
+    if (
+        typeof window.URL !== 'function' ||
+        typeof window.URLSearchParams !== 'function' ||
+        !window.history.replaceState
+    ) {
+        return false;
+    } else if (window.site.platform !== 'windows') {
+        // Ensure the visitor is on Windows OS
+        return false;
+    } else if (!window.site.fxSupported) {
+        // Ensure the visitor is on a supported version
+        return false;
+    } else if (dntEnabled() || gpcEnabled()) {
+        // Has the visitor set a browser-level privacy flag?
+        return false;
+    } else if (hasConsentCookie()) {
+        // Does the visitor have an existing analytics consent cookie?
+        const cookie = getConsentCookie();
+        if (cookie && !cookie.analytics) {
+            return false;
+        }
+    } else if (consentRequired()) {
+        // Is the visitor in EU/EAA?
+        return false;
+    } else if (
+        // Are requirements for stub attribution met?
+        typeof window.Mozilla.StubAttribution === 'undefined' ||
+        !window.Mozilla.StubAttribution.meetsRequirements()
+    ) {
+        return false;
+    }
+
+    return true;
+};
+
+/**
+ * Init Firefox set-as-default opt-out flow.
+ * @returns {Boolean}.
+ */
+DownloadAsDefault.init = () => {
+    if (!DownloadAsDefault.meetsRequirements()) {
+        return false;
+    }
+
+    DownloadAsDefault.showCheckbox();
+    DownloadAsDefault.processAttributionRequest(true);
+    // processAttributionRequest will bind the events
+
+    return true;
+};
+
+export default DownloadAsDefault;

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -375,6 +375,19 @@
     },
     {
       "files": [
+        "js/firefox/home-en-us-ca.js"
+      ],
+      "name": "firefox-home-en-us-ca"
+    },
+    {
+      "files": [
+        "js/firefox/download/desktop/download-as-default.es6.js",
+        "js/firefox/download/desktop/download-as-default-init.es6.js"
+      ],
+      "name": "download_as_default"
+    },
+    {
+      "files": [
         "js/firefox/browsers/desktop/chromebook.js"
       ],
       "name": "chromebook"
@@ -448,12 +461,6 @@
         "js/base/banners/firefox-newsletter-banner-check.js"
       ],
       "name": "firefox-newsletter-banner"
-    },
-    {
-      "files": [
-        "js/firefox/home-en-us-ca.js"
-      ],
-      "name": "firefox-home-en-us-ca"
     },
     {
       "files": [

--- a/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
@@ -4,239 +4,259 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 
- {% extends "firefox/download/desktop/base.html" %}
+{% if switch('download_as_default') and not needs_data_consent(country_code) %}
+{% set download_as_default_enabled = true %}
+{% else %}
+{% set download_as_default_enabled = false %}
+{% endif %}
 
- {% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-home' %}
- {% set ios_url = app_store_url('firefox', 'firefox-home') %}
+{% macro default_browser_checkbox(id='default-browser-checkbox') -%}
+<label for="{{ id }}" class="default-browser-label hidden">
+<input type="checkbox" id="{{ id }}" class="default-browser-checkbox">
+Set Firefox as your default browser.
+</label>
+{%- endmacro %}
 
- {% block string_data %}{% endblock %}
+{% extends "firefox/download/desktop/base.html" %}
 
- {% block page_image %}
-    {{ static('img/firefox/download/desktop/meta-img-en.png') }}
- {% endblock %}
+{% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-home' %}
+{% set ios_url = app_store_url('firefox', 'firefox-home') %}
 
- {% block extrahead %}
-   {{ super() }}
-   {{ css_bundle('firefox-home-en-us-ca') }}
+{% block string_data %}{% endblock %}
 
-   <!--[if IE 9]>
-     {{ css_bundle('firefox-home-en-us-ca-ie9') }}
-   <![endif]-->
+{% block page_image %}
+  {{ static('img/firefox/download/desktop/meta-img-en.png') }}
+{% endblock %}
 
-   <!--[if lt IE 9]>
-     {{ css_bundle('firefox-home-en-us-ca-ie8') }}
-   <![endif]-->
- {% endblock %}
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox-home-en-us-ca') }}
 
- {% block content %}
+  <!--[if IE 9]>
+    {{ css_bundle('firefox-home-en-us-ca-ie9') }}
+  <![endif]-->
 
- {% if outdated %}
+  <!--[if lt IE 9]>
+    {{ css_bundle('firefox-home-en-us-ca-ie8') }}
+  <![endif]-->
+{% endblock %}
 
-   {% set update_url = 'href="%s" data-cta-text="Update to the latest version"'|safe|format(('https://support.mozilla.org/kb/update-firefox-latest-release' + referrals)) %}
+{% block content %}
 
-   {% if ftl_has_messages('firefox-desktop-out-of-date') %}
-     <aside class="c-page-header-notification">
-       <div class="mzp-c-notification-bar mzp-t-warning">
-         {{ ftl('firefox-desktop-out-of-date', update_url=update_url) }}
-       </div>
-     </aside>
-   {% endif %}
+{% if outdated %}
 
- {% endif %}
+  {% set update_url = 'href="%s" data-cta-text="Update to the latest version"'|safe|format(('https://support.mozilla.org/kb/update-firefox-latest-release' + referrals)) %}
 
- <main class="main-download" {% if variation %}data-variation="{{ variation }}"{% endif %}>
-   <section id="desktop-banner" class="c-block t-intro show-else mzp-has-media-hide-on-sm">
-     <div class="c-block-container">
-       <div class="c-block-body">
-         <h1>{{ ftl('firefox-desktop-download-firefox') }}</h1>
-         <h2>Take control of your internet</h2>
-         <p>Go online with fewer distractions, noise and stress. Think of us as bubble wrap for your brain.</p>
-         <div class="c-intro-download">
-           {% block primary_cta %}
-             {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
-           {% endblock %}
+  {% if ftl_has_messages('firefox-desktop-out-of-date') %}
+    <aside class="c-page-header-notification">
+      <div class="mzp-c-notification-bar mzp-t-warning">
+        {{ ftl('firefox-desktop-out-of-date', update_url=update_url) }}
+      </div>
+    </aside>
+  {% endif %}
 
-           <div class="c-intro-download-alt"><a href="{{ url('firefox.all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
+{% endif %}
 
-           <div class="c-intro-download-alt"><a href="https://support.mozilla.org/products/firefox{{ referrals }}&utm_content=browser-support" rel="external noopener" data-cta-text="Firefox browser support">{{ ftl('firefox-desktop-download-browser-support') }}</a></div>
-         </div>
-       </div>
-       <div class="c-block-media l-v-center">
-        {{ resp_img(
-          url='img/firefox/home/hero.png',
-          srcset={
-            'img/firefox/home/hero-high-res.png': '2x'
-          },
-          optional_attributes={
-            'class': 'c-block-media-img',
-            'alt': 'Firefox on desktop and mobile.',
-            'width': '768'
-          }
-        ) }}
-       </div>
-     </div>
-   </section>
+<main class="main-download" {% if variation %}data-variation="{{ variation }}"{% endif %}>
+  <section id="desktop-banner" class="c-block t-intro show-else mzp-has-media-hide-on-sm">
+    <div class="c-block-container">
+      <div class="c-block-body">
+        <h1>{{ ftl('firefox-desktop-download-firefox') }}</h1>
+        <h2>Take control of your internet</h2>
+        <p>Go online with fewer distractions, noise and stress. Think of us as bubble wrap for your brain.</p>
+        <div class="c-intro-download">
+          {% block primary_cta %}
+            {{ default_browser_checkbox(id='default-browser-checkbox-primary') }}
+            {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+          {% endblock %}
 
+          <div class="c-intro-download-alt"><a href="{{ url('firefox.all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 
-  <section class="mzp-l-content t-releases">
-    <div class="mzp-c-emphasis-box js-animate">
-      <h2 class="mzp-c-section-heading">Latest Firefox features</h2>
-      <ul class="c-trio">
-        <li>
-          <img alt="Happy toggle." src="{{ static('img/firefox/home/toggle.svg') }}" width="90" height="54">
-          <h3>Dial down the noise</h3>
-          <p>Block ads and enhance your privacy with customizable settings and tons of downloadable extensions.</p>
-        </li>
-        <li class="t-cursor">
-          <img alt="Multiple cursors." src="{{ static('img/firefox/home/multi.svg') }}" width="134" height="38">
-          <h3>Multi-task or mono-task</h3>
-          <p>Go into reading mode, pop out videos and get more organized with the new sidebar layout.</p>
-        </li>
-        <li>
-          <img alt="Lots of open tabs." src="{{ static('img/firefox/home/tabs.svg') }}" width="72" height="54">
-          <h3>Keep tabs on all your tabs</h3>
-          <p>Close duplicates, search and pin open tabs — there are almost infinite possibilities for the almost infinite number of tabs you have open.</p>
-        </li>
-      </ul>
-
-      <p class="c-notes"><a class="mzp-c-cta-link" href="{{ url('firefox.notes') }}" data-cta-text="See Release Notes">See Release Notes</a></p>
+          <div class="c-intro-download-alt"><a href="https://support.mozilla.org/products/firefox{{ referrals }}&utm_content=browser-support" rel="external noopener" data-cta-text="Firefox browser support">{{ ftl('firefox-desktop-download-browser-support') }}</a></div>
+        </div>
+      </div>
+      <div class="c-block-media l-v-center">
+      {{ resp_img(
+        url='img/firefox/home/hero.png',
+        srcset={
+          'img/firefox/home/hero-high-res.png': '2x'
+        },
+        optional_attributes={
+          'class': 'c-block-media-img',
+          'alt': 'Firefox on desktop and mobile.',
+          'width': '768'
+        }
+      ) }}
+      </div>
     </div>
   </section>
 
 
-   <section class="t-highlights">
-     <h2 class="mzp-c-section-heading">Get the browser that helps you get sh*t done</h2>
+<section class="mzp-l-content t-releases">
+  <div class="mzp-c-emphasis-box js-animate">
+    <h2 class="mzp-c-section-heading">Latest Firefox features</h2>
+    <ul class="c-trio">
+      <li>
+        <img alt="Happy toggle." src="{{ static('img/firefox/home/toggle.svg') }}" width="90" height="54">
+        <h3>Dial down the noise</h3>
+        <p>Block ads and enhance your privacy with customizable settings and tons of downloadable extensions.</p>
+      </li>
+      <li class="t-cursor">
+        <img alt="Multiple cursors." src="{{ static('img/firefox/home/multi.svg') }}" width="134" height="38">
+        <h3>Multi-task or mono-task</h3>
+        <p>Go into reading mode, pop out videos and get more organized with the new sidebar layout.</p>
+      </li>
+      <li>
+        <img alt="Lots of open tabs." src="{{ static('img/firefox/home/tabs.svg') }}" width="72" height="54">
+        <h3>Keep tabs on all your tabs</h3>
+        <p>Close duplicates, search and pin open tabs — there are almost infinite possibilities for the almost infinite number of tabs you have open.</p>
+      </li>
+    </ul>
 
-     <div class="t-block c-block l-reversed">
-       <div class="c-block-container">
-         <div class="c-block-body l-v-center l-h-start">
-           <h3 class="mzp-u-title-sm">Block ad trackers without lifting a paw</h3>
-           <p>Not-fun fact: Ad trackers make web pages load slower. Fun fact: You won’t have to dig around in settings to fix that because Firefox automatically blocks most trackers.</p>
-           <button id="protection-report" type="button" class="mzp-c-cta-link">{{ ftl('firefox-desktop-download-see-your-report') }}</button>
-         </div>
-         <div class="c-block-media l-v-end l-h-end l-media-constrain-on-sm">
-          <img alt="Shield and hand protecting a browser tab." class="c-block-media-img" src="{{ static('img/firefox/home/block.svg') }}" width="220">
-         </div>
-       </div>
-     </div>
-
-     <div class="t-think c-block">
-       <div class="c-block-container">
-         <div class="c-block-body l-v-center l-h-end">
-           <h3 class="mzp-u-title-sm">Swear off staring into the abyss</h3>
-           <p>Stay focused with extensions like <a href="https://addons.mozilla.org/firefox/addon/tomato-clock/">Tomato Clock</a> and <a href="http://addons.mozilla.org/firefox/addon/turn-off-the-lights">Turn Off the Lights</a> — they’re Recommended, which is like our gold star for having exceptional security and functionality.</p>
-         </div>
-         <div class="c-block-media l-v-center l-h-start l-media-constrain-on-sm">
-          <img alt="A human brain connected to the world." class="c-block-media-img" src="{{ static('img/firefox/home/think.svg') }}" width="260">
-         </div>
-       </div>
-     </div>
-
-     <div class="t-devices c-block l-reversed">
-       <div class="c-block-container">
-         <div class="c-block-body l-v-center">
-           <h3 class="mzp-u-title-sm">Your stuff, on all your screens</h3>
-           <p>Get Firefox mobile so your passwords, tabs and history — and the privacy and security you rely on — go with you wherever you go.</p>
-           <div class="mobile-download-buttons-wrapper">
-             {% block mobile_secondary_cta %}
-               <ul class="mobile-download-buttons">
-                 <li class="android">
-                   {{ google_play_button() }}
-                 </li>
-                 <li class="ios">
-                   {{ apple_app_store_button(href=ios_url) }}
-                 </li>
-               </ul>
-             {% endblock %}
-           </div>
-         </div>
-         <div class="c-block-media l-v-end l-h-end l-media-constrain-on-sm">
-          <img alt="Desktop, laptop, and phone. " class="c-block-media-img" src="{{ static('img/firefox/home/screens.svg') }}" width="350">
-         </div>
-       </div>
-     </div>
-   </section>
-
-   <div class="t-custom">
-    <section class="mzp-l-content mzp-t-content-md">
-      <h2 class="mzp-c-section-heading">*Really* make it yours</h2>
-
-      <div class="c-screen">
-        <div class="c-screenshot">
-          <img alt="Firefox in dark mode." src="{{ static('img/firefox/home/dark.svg') }}" width="1000">
-        </div>
-      </div>
-
-      <ul class="mzp-l-columns mzp-t-columns-two">
-        <li>
-          <h3>Work smarter, play harder</h3>
-          <p>Explore the possibilities for research, shopping and more in <a href="https://addons.mozilla.org/firefox/extensions/">extensions</a>.</p>
-        </li>
-
-        <li>
-          <h3>Bye, boring browser</h3>
-          <p>The internet can be all kittens and rainbows — with the right add-on <a href="https://addons.mozilla.org/firefox/themes/">theme</a>.</p>
-        </li>
-      </ul>
-    </section>
+    <p class="c-notes"><a class="mzp-c-cta-link" href="{{ url('firefox.notes') }}" data-cta-text="See Release Notes">See Release Notes</a></p>
   </div>
+</section>
 
-   <section class="mzp-l-content t-free">
-    <div class="mzp-c-emphasis-box js-animate">
-      <div class="c-free">
-        <div class="c-free-img">
-          <img alt="Firefox on a desktop." src="{{ static('img/firefox/home/free.svg') }}" width="300">
+
+  <section class="t-highlights">
+    <h2 class="mzp-c-section-heading">Get the browser that helps you get sh*t done</h2>
+
+    <div class="t-block c-block l-reversed">
+      <div class="c-block-container">
+        <div class="c-block-body l-v-center l-h-start">
+          <h3 class="mzp-u-title-sm">Block ad trackers without lifting a paw</h3>
+          <p>Not-fun fact: Ad trackers make web pages load slower. Fun fact: You won’t have to dig around in settings to fix that because Firefox automatically blocks most trackers.</p>
+          <button id="protection-report" type="button" class="mzp-c-cta-link">{{ ftl('firefox-desktop-download-see-your-report') }}</button>
         </div>
-        <div class="c-free-body">
-          <h2>Billionaire-free for 20+ years</h2>
-          <p>Firefox was created in 2004 by Mozilla as a faster, more private, and customizable alternative to browsers like Internet Explorer. Today, we are still not-for-profit, still not owned by any billionaires and still working to make the internet — and the time you spend on it — better.</p>
+        <div class="c-block-media l-v-end l-h-end l-media-constrain-on-sm">
+        <img alt="Shield and hand protecting a browser tab." class="c-block-media-img" src="{{ static('img/firefox/home/block.svg') }}" width="220">
+        </div>
+      </div>
+    </div>
+
+    <div class="t-think c-block">
+      <div class="c-block-container">
+        <div class="c-block-body l-v-center l-h-end">
+          <h3 class="mzp-u-title-sm">Swear off staring into the abyss</h3>
+          <p>Stay focused with extensions like <a href="https://addons.mozilla.org/firefox/addon/tomato-clock/">Tomato Clock</a> and <a href="http://addons.mozilla.org/firefox/addon/turn-off-the-lights">Turn Off the Lights</a> — they’re Recommended, which is like our gold star for having exceptional security and functionality.</p>
+        </div>
+        <div class="c-block-media l-v-center l-h-start l-media-constrain-on-sm">
+        <img alt="A human brain connected to the world." class="c-block-media-img" src="{{ static('img/firefox/home/think.svg') }}" width="260">
+        </div>
+      </div>
+    </div>
+
+    <div class="t-devices c-block l-reversed">
+      <div class="c-block-container">
+        <div class="c-block-body l-v-center">
+          <h3 class="mzp-u-title-sm">Your stuff, on all your screens</h3>
+          <p>Get Firefox mobile so your passwords, tabs and history — and the privacy and security you rely on — go with you wherever you go.</p>
+          <div class="mobile-download-buttons-wrapper">
+            {% block mobile_secondary_cta %}
+              <ul class="mobile-download-buttons">
+                <li class="android">
+                  {{ google_play_button() }}
+                </li>
+                <li class="ios">
+                  {{ apple_app_store_button(href=ios_url) }}
+                </li>
+              </ul>
+            {% endblock %}
+          </div>
+        </div>
+        <div class="c-block-media l-v-end l-h-end l-media-constrain-on-sm">
+        <img alt="Desktop, laptop, and phone. " class="c-block-media-img" src="{{ static('img/firefox/home/screens.svg') }}" width="350">
         </div>
       </div>
     </div>
   </section>
 
-   <section class="mzp-c-section-heading">
-     {% block discover_cta %}
-       {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
-     {% endblock %}
-   </section>
+  <div class="t-custom">
+  <section class="mzp-l-content mzp-t-content-md">
+    <h2 class="mzp-c-section-heading">*Really* make it yours</h2>
 
-   <section class="c-support">
-     {% set questions_attrs = 'href="https://support.mozilla.org/products/firefox%s&utm_content=mozilla-support" rel="external noopener" data-cta-text="Mozilla support"'|safe|format(referrals) %}
-     {{ ftl('firefox-desktop-download-questions', attrs=questions_attrs) }}
-   </section>
+    <div class="c-screen">
+      <div class="c-screenshot">
+        <img alt="Firefox in dark mode." src="{{ static('img/firefox/home/dark.svg') }}" width="1000">
+      </div>
+    </div>
 
-   <aside id="mobile-banner" class="show-android show-ios" data-nosnippet>
-     <div class="c-mobile mzp-t-dark">
-       <div class="mzp-l-content">
-         <div class="c-mobile-text">
-           <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
-           <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
+    <ul class="mzp-l-columns mzp-t-columns-two">
+      <li>
+        <h3>Work smarter, play harder</h3>
+        <p>Explore the possibilities for research, shopping and more in <a href="https://addons.mozilla.org/firefox/extensions/">extensions</a>.</p>
+      </li>
 
-           <p>{{ ftl('firefox-desktop-download-download-the-mobile') }}</p>
+      <li>
+        <h3>Bye, boring browser</h3>
+        <p>The internet can be all kittens and rainbows — with the right add-on <a href="https://addons.mozilla.org/firefox/themes/">theme</a>.</p>
+      </li>
+    </ul>
+  </section>
+</div>
 
-           {% block mobile_primary_cta %}
-             <div class="show-android">
-               {{ google_play_button() }}
-             </div>
-             <div class="show-ios">
-               {{ apple_app_store_button(href=ios_url) }}
-             </div>
-           {% endblock %}
-         </div>
-       </div>
-     </div>
-     <h2 class="c-desktop">
-       <a href="#next">{{ ftl('firefox-desktop-download-learn-about-the') }}</a>
-     </h2>
-     <span id="next"></span>
-   </aside>
- </main>
+  <section class="mzp-l-content t-free">
+  <div class="mzp-c-emphasis-box js-animate">
+    <div class="c-free">
+      <div class="c-free-img">
+        <img alt="Firefox on a desktop." src="{{ static('img/firefox/home/free.svg') }}" width="300">
+      </div>
+      <div class="c-free-body">
+        <h2>Billionaire-free for 20+ years</h2>
+        <p>Firefox was created in 2004 by Mozilla as a faster, more private, and customizable alternative to browsers like Internet Explorer. Today, we are still not-for-profit, still not owned by any billionaires and still working to make the internet — and the time you spend on it — better.</p>
+      </div>
+    </div>
+  </div>
+</section>
 
- {% endblock %}
+  <section class="mzp-c-section-heading">
+    {% block discover_cta %}
+      {{ default_browser_checkbox(id='default-browser-checkbox-discover') }}
+      {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+    {% endblock %}
+  </section>
 
- {% block js %}
-   {{ js_bundle('firefox-home-en-us-ca') }}
- {% endblock %}
+  <section class="c-support">
+    {% set questions_attrs = 'href="https://support.mozilla.org/products/firefox%s&utm_content=mozilla-support" rel="external noopener" data-cta-text="Mozilla support"'|safe|format(referrals) %}
+    {{ ftl('firefox-desktop-download-questions', attrs=questions_attrs) }}
+  </section>
+
+  <aside id="mobile-banner" class="show-android show-ios" data-nosnippet>
+    <div class="c-mobile mzp-t-dark">
+      <div class="mzp-l-content">
+        <div class="c-mobile-text">
+          <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
+          <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
+
+          <p>{{ ftl('firefox-desktop-download-download-the-mobile') }}</p>
+
+          {% block mobile_primary_cta %}
+            <div class="show-android">
+              {{ google_play_button() }}
+            </div>
+            <div class="show-ios">
+              {{ apple_app_store_button(href=ios_url) }}
+            </div>
+          {% endblock %}
+        </div>
+      </div>
+    </div>
+    <h2 class="c-desktop">
+      <a href="#next">{{ ftl('firefox-desktop-download-learn-about-the') }}</a>
+    </h2>
+    <span id="next"></span>
+  </aside>
+</main>
+
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-home-en-us-ca') }}
+
+{% if download_as_default_enabled %}
+  {{ js_bundle('download_as_default') }}
+{% endif %}
+
+{% endblock %}

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -6,6 +6,19 @@
 
 {% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 
+{% if switch('download_as_default') and not needs_data_consent(country_code) and ftl_has_messages('firefox-desktop-set-as-default') %}
+  {% set download_as_default_enabled = true %}
+{% else %}
+  {% set download_as_default_enabled = false %}
+{% endif %}
+
+{% macro default_browser_checkbox(id='default-browser-checkbox') -%}
+<label for="{{ id }}" class="default-browser-label hidden">
+  <input type="checkbox" id="{{ id }}" class="default-browser-checkbox">
+  {{ ftl('firefox-desktop-set-as-default') }}
+</label>
+{%- endmacro %}
+
 {% extends "firefox/download/desktop/base.html" %}
 
 {% set referrals = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
@@ -84,6 +97,7 @@
           <p>{{ ftl('firefox-desktop-download-fast-reliable-private', fallback='firefox-desktop-download-no-shady') }}</p>
         <div class="c-intro-download">
           {% block primary_cta %}
+            {{ default_browser_checkbox(id='default-browser-checkbox-primary') }}
             {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
           {% endblock %}
 
@@ -351,6 +365,7 @@
         </div>
       </div>
       {% block features_cta %}
+        {{ default_browser_checkbox(id='default-browser-checkbox-features') }}
         {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
       {% endblock %}
 
@@ -516,6 +531,7 @@
       </div>
     </div>
     {% block discover_cta %}
+      {{ default_browser_checkbox(id='default-browser-checkbox-discover') }}
       {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
     {% endblock %}
   </section>
@@ -554,4 +570,8 @@
 
 {% block js %}
   {{ js_bundle('firefox_desktop_download') }}
+
+  {% if download_as_default_enabled %}
+    {{ js_bundle('download_as_default') }}
+  {% endif %}
 {% endblock %}

--- a/tests/unit/spec/firefox/new/desktop/download-as-default.js
+++ b/tests/unit/spec/firefox/new/desktop/download-as-default.js
@@ -1,0 +1,256 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import DownloadAsDefault from '../../../../../../media/js/firefox/download/desktop/download-as-default.es6';
+
+describe('download-as-default.es6.js', function () {
+    beforeEach(function () {
+        const optOut = `<div id="opt-out">
+            <label for="default-opt-out-primary" class="default-browser-label hidden">
+                <input type="checkbox" id="default-opt-out-primary"" class="default-browser-checkbox">
+                Set Firefox as your default browser.
+            </label>
+            <label for="default-opt-out-secondary" class="default-browser-label hidden">
+                <input type="checkbox" id="default-opt-out-secondary" class="default-browser-checkbox">
+                Set Firefox as your default browser.
+            </label>
+        </div>`;
+
+        document.body.insertAdjacentHTML('beforeend', optOut);
+    });
+
+    beforeEach(function () {
+        window.site.platform = 'windows';
+        window.site.fxSupported = 'true';
+    });
+
+    afterEach(function () {
+        const optOut = document.getElementById('opt-out');
+        optOut.parentNode.removeChild(optOut);
+
+        document
+            .getElementsByTagName('html')[0]
+            .removeAttribute('data-needs-consent');
+
+        window.site.platform = 'other';
+    });
+
+    describe('meetsRequirements', function () {
+        it('should return false if OS is not Windows', function () {
+            window.site.platform = 'osx';
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+        });
+
+        it('should return false if OS is too old', function () {
+            window.site.fxSupported = false;
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+        });
+
+        it('should return false if GPC is enabled', function () {
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+            delete window.Mozilla.gpcEnabled;
+        });
+
+        it('should return false if DNT is enabled', function () {
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+            delete window.Mozilla.dntEnabled;
+        });
+
+        it('should return false if consent cookie rejects analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(
+                    JSON.stringify({
+                        analytics: false,
+                        preference: true
+                    })
+                );
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+        });
+
+        it('should return false if visitor is in EU/EAA country', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'True');
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+        });
+
+        it('should return false if attribution requirements are not satisfied', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(false);
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+        });
+
+        it('should return true if attribution requirements are satisfied', function () {
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeTrue();
+        });
+    });
+    describe('init()', function () {
+        it('should refresh attribution data and and update URL when visitor unchecks input', function () {
+            spyOn(DownloadAsDefault, 'meetsRequirements').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'removeAttributionData');
+            spyOn(window.Mozilla.StubAttribution, 'init').and.callFake(
+                (callback) => {
+                    callback();
+                }
+            );
+            spyOn(DownloadAsDefault, 'removeUTMParams').and.callThrough();
+            spyOn(window.history, 'replaceState');
+
+            const result = DownloadAsDefault.init();
+            expect(result).toBeTrue();
+
+            let checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+
+            document.getElementById('default-opt-out-primary').click();
+            expect(
+                window.Mozilla.StubAttribution.removeAttributionData
+            ).toHaveBeenCalled();
+
+            expect(DownloadAsDefault.removeUTMParams).toHaveBeenCalled();
+            expect(window.history.replaceState).toHaveBeenCalled();
+            expect(window.Mozilla.StubAttribution.init).toHaveBeenCalled();
+
+            checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should opt back into analytics and init attribution if visitor re-checks input', function () {
+            spyOn(DownloadAsDefault, 'meetsRequirements').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'removeAttributionData');
+            spyOn(window.Mozilla.StubAttribution, 'init').and.callFake(
+                (callback) => {
+                    callback();
+                }
+            );
+            spyOn(DownloadAsDefault, 'addUTMParams').and.callThrough();
+            spyOn(DownloadAsDefault, 'removeUTMParams').and.callThrough();
+            spyOn(window.history, 'replaceState');
+
+            const result = DownloadAsDefault.init();
+            expect(result).toBeTrue();
+
+            let checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+
+            // Opt out
+            document.getElementById('default-opt-out-primary').click();
+
+            checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+
+            // Opt in
+            document.getElementById('default-opt-out-secondary').click();
+
+            expect(
+                window.Mozilla.StubAttribution.removeAttributionData
+            ).toHaveBeenCalledTimes(3);
+            expect(DownloadAsDefault.removeUTMParams).toHaveBeenCalledTimes(3);
+            expect(DownloadAsDefault.addUTMParams).toHaveBeenCalledTimes(2);
+            expect(window.history.replaceState).toHaveBeenCalledTimes(3);
+            expect(window.Mozilla.StubAttribution.init).toHaveBeenCalledTimes(
+                3
+            );
+
+            checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+        });
+    });
+
+    describe('removeUTMParams', function () {
+        it('should remove UTM parameters from a URL as expected', function () {
+            const href =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER';
+            const expected = 'https://www.mozilla.org/en-US/firefox/new/';
+            const result = DownloadAsDefault.removeUTMParams(href);
+            expect(result).toEqual(expected);
+
+            const href2 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment';
+            const expected2 = 'https://www.mozilla.org/en-US/firefox/new/';
+            const result2 = DownloadAsDefault.removeUTMParams(href2);
+            expect(result2).toEqual(expected2);
+
+            const href3 = 'https://www.mozilla.org/en-US/firefox/new/';
+            const result3 = DownloadAsDefault.removeUTMParams(href3);
+            expect(result3).toEqual(href3);
+
+            const href4 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER#download';
+            const expected4 =
+                'https://www.mozilla.org/en-US/firefox/new/#download';
+            const result4 = DownloadAsDefault.removeUTMParams(href4);
+            expect(result4).toEqual(expected4);
+        });
+    });
+
+    describe('addUTMParams', function () {
+        it('should add UTM parameters to a URL as expected', function () {
+            const href = 'https://www.mozilla.org/en-US/firefox/new/';
+            const expected =
+                'https://www.mozilla.org/en-US/firefox/new/?utm_campaign=SET_DEFAULT_BROWSER';
+            const result = DownloadAsDefault.addUTMParams(href);
+            expect(result).toEqual(expected);
+
+            const href2 = 'https://www.mozilla.org/en-US/firefox/new/';
+            const expected2 =
+                'https://www.mozilla.org/en-US/firefox/new/?utm_campaign=SET_DEFAULT_BROWSER';
+            const result2 = DownloadAsDefault.addUTMParams(href2);
+            expect(result2).toEqual(expected2);
+
+            const href3 = 'https://www.mozilla.org/en-US/firefox/new/#download';
+            const expected3 =
+                'https://www.mozilla.org/en-US/firefox/new/?utm_campaign=SET_DEFAULT_BROWSER#download';
+            const result3 = DownloadAsDefault.addUTMParams(href3);
+            expect(result3).toEqual(expected3);
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Port Download-as-Default work from Bedrock

## Significant changes and points to review

- Porting over work from bedrock
  - the changes to download-en-us-ca.html are not as bad as the diff makes it look since there's a whitespace change. Disable whitespace in the diff settings to see what really changed.
- Docs are only in bedrock for now
- Also copied over some string expiry dates

## Issue / Bugzilla link

Fix #294 

## Testing

The code itself was already reviewed. Just make sure the HTML, CSS, and JS are showing up where they're supposed to.

See https://github.com/mozilla/bedrock/pull/16330 for testing.