### PR TITLE
Add connect.mozilla.org to community column in footer #289

### DIFF
--- a/l10n/en/footer-firefox.ftl
+++ b/l10n/en/footer-firefox.ftl
@@ -37,6 +37,7 @@ footer-enterprise = { -brand-name-enterprise }
 footer-community = Community
 footer-contribute = Contribute
 footer-developer = Developer
+footer-connect = Connect
 
 ## Links to resources
 

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -45,6 +45,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             {{ ftl('footer-community') }}
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-community">
+            <li><a href="https://connect.mozilla.org/?{{utm_params}}" data-link-position="footer" data-link-text="Connect">{{ ftl('footer-connect') }}</a></li>
             <li><a href="https://www.mozilla.org/contribute/?{{utm_params}}" data-link-position="footer" data-link-text="Contribute">{{ ftl('footer-contribute') }}</a></li>
             <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Developer">{{ ftl('footer-developer') }}</a></li>
           </ul>


### PR DESCRIPTION
## One-line summary

Add connect.mozilla.org to community column in footer

## Significant changes and points to review



## Issue / Bugzilla link

Fix  #289

## Testing

Link is in the footer and text displays correctly.