### PR TITLE
Update pencil-banner close affordance highlight color

### DIFF
--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -42,7 +42,7 @@
 
         &:hover,
         &:focus {
-            border-color: $m24-color-green;
+            border-color: $m24-color-orange;
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Change activation affordance decoration color for close button of pencil banner.

## Significant changes and points to review

It gives a 1.94:1 contrast ratio https://webaim.org/resources/contrastchecker/?fcolor=FF9456&bcolor=FAF0E6 failing for UI:

![Screenshot 2025-06-18 at 16 35 59](https://github.com/user-attachments/assets/a3de3d93-c003-4074-97c7-47f2459d3109)

(Not sure if it's exactly binding for such decoration as the component proper has enough contrast in its basic state — NB: it was failing before with the green as well with even lower ratio.)

## Issue / Bugzilla link

Resolves #306

## Testing

(make sure you meet the conditions for showing the banner; then hover or focus the "X" close button.)