### PR TITLE
Remove download button from some pages, add spacer (Fix #311)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -165,6 +165,18 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     }
 }
 
+// spacer to center nav items when CTA isn't there
+
+.spacer-gif {
+    display: none;
+
+    @media #{$mq-md} {
+        display: inline-block;
+        width: 120px; // matches width of Firefox logo
+    }
+}
+
+
 // * -------------------------------------------------------------------------- */
 // Menu
 

--- a/springfield/base/templates/includes/navigation/nav-cta.html
+++ b/springfield/base/templates/includes/navigation/nav-cta.html
@@ -14,4 +14,7 @@
     {% else %}
       {{ custom_nav_cta }}
     {% endif %}
+  {% else %}
+  <div class="spacer-gif"></div>
 {% endif %}
+

--- a/springfield/firefox/templates/firefox/download/basic/base.html
+++ b/springfield/firefox/templates/firefox/download/basic/base.html
@@ -37,6 +37,12 @@
   <![endif]-->
 {% endblock %}
 
+{% block site_header %}
+  {% with hide_nav_cta=True %}
+    {% include 'includes/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block old_ie_styles %}{% endblock %}
 {% block site_css %}{% endblock %}
 {% block page_css %}{% endblock %}

--- a/springfield/firefox/templates/firefox/download/desktop/base.html
+++ b/springfield/firefox/templates/firefox/download/desktop/base.html
@@ -41,4 +41,10 @@
   {{ css_bundle('protocol') }}
 {% endblock %}
 
+{% block site_header %}
+  {% with hide_nav_cta=True %}
+    {% include 'includes/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block body_class %}mzp-t-firefox{% endblock %}

--- a/springfield/privacy/templates/privacy/cookie-settings.html
+++ b/springfield/privacy/templates/privacy/cookie-settings.html
@@ -16,10 +16,7 @@
 {% endblock %}
 
 {% block site_header %}
-  {% with
-    hide_nav_download_button=True,
-    hide_nav_get_vpn_button=True
-  %}
+  {% with hide_nav_cta=True %}
     {% include 'includes/navigation/navigation.html' %}
   {% endwith %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Remove download button from download page

## Significant changes and points to review

- Removes download button from download pages that appear at / 
- Adds spacer to help center navigation items when CTA is not present

## Issue / Bugzilla link

Fix #311 
Fix #239 

## Testing

http://localhost:8000/en-US/
http://localhost:8000/fr/
http://localhost:8000/fr/?xv=basic
http://localhost:8000/en-US/browsers/desktop/windows/
http://localhost:8000/en-US/privacy/websites/cookie-settings/