### PR TITLE
Hide breadcrumbs under mobile nav

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -449,6 +449,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 body:has(.m24-c-navigation-items.mzp-is-open) {
     & > .m24-pencil-banner,
     & > .c-sub-navigation,
+    & > .mzp-c-breadcrumb,
     & > .moz-consent-banner.is-visible,
     & > .c-banner.c-banner-is-visible,
     & > #outer-wrapper {


### PR DESCRIPTION
## One-line summary

Breadcrumbs must be among the elements (direct descendants of body) to hide when the fullscreen menu opens on smaller layouts.

## Significant changes and points to review

This will need porting to bedrock too.

## Issue / Bugzilla link

Resolves #313

## Testing

http://localhost:8000/en-US/privacy/websites/cookie-settings/?geo=de (in case you don't see the breadcrumbs open this after some other page in the session; if you still don't see them try landing at cookie-settings by following a link from e.g. http://localhost:8000/en-US/newsletter/?geo=de consent banner that gets shown under some conditions /e.g. EU/EEA, no DNT/GPC etc./ so this might depend on your browser/version)