### PR TITLE
Fix homepage navigation tests with wildcards and un-wildcard some others

### DIFF
--- a/tests/playwright/specs/404.spec.js
+++ b/tests/playwright/specs/404.spec.js
@@ -25,7 +25,7 @@ test.describe(
             const goBackLink = page.getByTestId('link-go-back');
             await expect(goBackLink).toBeVisible();
             await goBackLink.click();
-            await page.waitForURL('**/?automation=true', {
+            await page.waitForURL('**/?automation=true*', {
                 waitUntil: 'commit'
             });
         });

--- a/tests/playwright/specs/404.spec.js
+++ b/tests/playwright/specs/404.spec.js
@@ -8,10 +8,10 @@
 
 const { test, expect } = require('@playwright/test');
 const openPage = require('../scripts/open-page');
-const url = '/en-US/';
+const url = '/en-US/compare/';
 
 test.describe(
-    `${url} page`,
+    `404 page`,
     {
         tag: '@firefox'
     },
@@ -25,7 +25,7 @@ test.describe(
             const goBackLink = page.getByTestId('link-go-back');
             await expect(goBackLink).toBeVisible();
             await goBackLink.click();
-            await page.waitForURL('**/?automation=true*', {
+            await page.waitForURL('/en-US/compare/?automation=true', {
                 waitUntil: 'commit'
             });
         });

--- a/tests/playwright/specs/footer.spec.js
+++ b/tests/playwright/specs/footer.spec.js
@@ -30,7 +30,7 @@ test.describe(
 
             // Change page language from /en-US/ to /de/
             await languageSelect.selectOption('de');
-            await page.waitForURL('**/de/?automation=true*', {
+            await page.waitForURL('/de/?automation=true*', {
                 waitUntil: 'commit'
             });
 

--- a/tests/playwright/specs/footer.spec.js
+++ b/tests/playwright/specs/footer.spec.js
@@ -30,7 +30,7 @@ test.describe(
 
             // Change page language from /en-US/ to /de/
             await languageSelect.selectOption('de');
-            await page.waitForURL('**/de/?automation=true', {
+            await page.waitForURL('**/de/?automation=true*', {
                 waitUntil: 'commit'
             });
 

--- a/tests/playwright/specs/navigation.spec.js
+++ b/tests/playwright/specs/navigation.spec.js
@@ -112,7 +112,7 @@ test.describe(
 
             // Click firefox desktop link
             await firefoxMenuLink.click();
-            await page.waitForURL('**/', {
+            await page.waitForURL('/en-US/browsers/desktop/', {
                 waitUntil: 'commit'
             });
 


### PR DESCRIPTION
## One-line summary

Allow cases where e.g. extra `utm_campaign` param is being added to the location.

## Significant changes and points to review

```
specs/footer.spec.js:25:9 › /en-US/ footer (mobile) › Footer language change @firefox 
    =========================== logs ===========================
    waiting for navigation to "**/de/?automation=true" until "commit"
      navigated to "https://stage.springfield.nonprod.webservices.mozgcp.net/de/?automation=true&utm_campaign=SET_DEFAULT_BROWSER"
```

Right now we don't exactly care how the query string looks like — and since the home is also download page now, it can have a varying degree or parameters added and removed etc.

Ideally it should not happen with `?automation=true` but this is a hotfix for now.

(This exact failure is weird given it comes from a Linux UA that should not be triggering said campaign, but that's another question.)

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/actions/runs/15740357974/job/44406845294#step:5:532

## Testing
