### PR TITLE
Update CDN SSL test for firefox.com setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help:
 	@echo "  uninstall-custom-git-hooks     - uninstall custom git hooks"
 	@echo "  clean-local-deps               - remove all local installed Python dependencies"
 	@echo "  preflight                      - refresh installed dependencies and fetch latest DB ahead of local dev"
-	@echo "  preflight -- --retain-DB		- refresh installed dependencies WITHOUT fetching latest DB"
+	@echo "  preflight -- --retain-DB	- refresh installed dependencies WITHOUT fetching latest DB"
 	@echo "  run-local-task-queue           - run rqworker on your local machine. Requires redis to be running"
 
 .env:
@@ -122,7 +122,7 @@ test: .docker-build-pull
 	${DC} run --rm test
 
 test-cdn: .docker-build-pull test_infra/fixtures/tls.json
-	${DC} run test pytest --base-url https://${TEST_DOMAIN} test_infra
+	${DC} run test pytest --base-url https://${TEST_DOMAIN} -m cdn
 
 test-image: .docker-build
 	${DC} run test-image

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,15 @@
 [tool:pytest]
 addopts = --showlocals -r a --ignore=node_modules
 DJANGO_SETTINGS_MODULE = springfield.settings.test
-sensitive_url = (firefox\.(com|org)|springfield-prod|springfield\.prod)
+sensitive_url = (firefox\.com|\.prod\.springfield|springfield\.prod)
 testpaths =
     springfield
     lib
     tests
 # Declare custom pytest markers to reduce test-output noise
 markers =
+    cdn
+    cdnprod
     download
     headless
     skip_if_firefox

--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -173,12 +173,13 @@ def test_tls(get_ssllabs_results):
     for endp in data[0]["endpoints"]:
         for sim in endp["details"]["sims"]["results"]:
             if sim["errorCode"] != 0:
-                # IE 6 is expected to fail
+                # Expected handshake fails
                 if sim["client"]["name"] == "IE" and sim["client"]["version"] == "6":
                     continue
-
-                # TODO: Working with Fastly on configuring TLS to accept this but for now
-                # it will fail
+                if sim["client"]["name"] == "IE" and sim["client"]["version"] == "8" and sim["client"]["platform"] == "XP":
+                    continue
+                if sim["client"]["name"] == "Android" and sim["client"]["version"] == "2.3.7":
+                    continue
                 if sim["client"]["name"] == "Java" and sim["client"]["version"] == "6u45":
                     continue
 


### PR DESCRIPTION
## One-line summary

Adds more exclusions to TLS tests due to SNI compatibility, see https://github.com/mozmeao/springfield/issues/286#issuecomment-2980764151

## Significant changes and points to review

This still doesn't save it from failing on 502, 503 or 429 from upstream API but that's to be sorted out separately.

This at least adds the markers to config to get rid of them warnings.

\+Updated sensitive URLs removed hosts no longer existing and added a pre-prod prod one.
\+Updated make command is only for local use, CI runs it via ./bin/*

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/286#issuecomment-2980764151

## Testing

`docker compose run test pytest --base-url https://www.firefox.com -m cdn`