### PR TITLE
Fix wrapping chevron safari issue (fixes #309)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -347,6 +347,7 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
 
         h2 {
             font-weight: inherit;
+            white-space: nowrap; // fix safari bug, issue #309
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Keep chevron on same line as menu title

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/309


## Testing
- [ ] http://localhost:8000/en-CA/ on Safari 18.5 