### PR TITLE
Update string expiries (www-firefox-l10n#42)

### DIFF
--- a/l10n/en/firefox/download/desktop.ftl
+++ b/l10n/en/firefox/download/desktop.ftl
@@ -26,7 +26,7 @@ firefox-desktop-download-fast-reliable-private = Fast, reliable and private — 
 
 firefox-desktop-set-as-default = Set { -brand-name-firefox } as your default browser.
 
-# Obsolete string (expires: 2025-04-17)
+# Obsolete string (expires: 2025-07-21)
 firefox-desktop-download-no-shady = No shady privacy policies or back doors for advertisers. Just a lightning fast browser that doesn’t sell you out.
 
 firefox-desktop-download-download-options = Download options and other languages
@@ -35,7 +35,7 @@ firefox-desktop-download-browser-support = { -brand-name-firefox-browser } suppo
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
 firefox-desktop-download-do-what-you-do-v2 = Do what you do online.<br> { -brand-name-firefox-browser } has got you <strong>covered</strong>.
 
-# Obsolete string (expires: 2025-04-17)
+# Obsolete string (expires: 2025-07-21)
 firefox-desktop-download-do-what-you-do = Do what you do online.<br> { -brand-name-firefox-browser } <strong>isn’t</strong> watching.
 
 firefox-desktop-download-we-block-the-ad = We block the ad trackers. You explore the internet faster.


### PR DESCRIPTION
## One-line summary

Update string expiry dates for migrated strings. 

Updated to be 2 months from when they were added to the springfield code base.

## Issue / Bugzilla link

https://github.com/mozilla-l10n/www-firefox-l10n/pull/42
