### PR TITLE
Fix home mobile #next anchor for refresh locales

### DIFF
--- a/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download-en-us-ca.html
@@ -94,7 +94,7 @@ Set Firefox as your default browser.
   </section>
 
 
-<section class="mzp-l-content t-releases">
+<section class="mzp-l-content t-releases" id="next">
   <div class="mzp-c-emphasis-box js-animate">
     <h2 class="mzp-c-section-heading">Latest Firefox features</h2>
     <ul class="c-trio">
@@ -246,7 +246,6 @@ Set Firefox as your default browser.
     <h2 class="c-desktop">
       <a href="#next">{{ ftl('firefox-desktop-download-learn-about-the') }}</a>
     </h2>
-    <span id="next"></span>
   </aside>
 </main>
 


### PR DESCRIPTION
## One-line summary

Moving the id on the actual element to land on.

## Significant changes and points to review

No matter where in DOM the banners are repositioned, this keeps their target reasonable in the document outline.

## Issue / Bugzilla link

Fixes #184

## Testing

http://localhost:8000/en-CA/ with UA triggering mobile aside
(or http://localhost:8000/en-CA/#next in general)