### PR TITLE
Only bind pencil-banner setup if it has close button

### DIFF
--- a/media/js/base/banners/m24-pencil-banner.es6.js
+++ b/media/js/base/banners/m24-pencil-banner.es6.js
@@ -96,7 +96,7 @@ M24PencilBanner.init = function () {
         typeof window.Mozilla.Cookies !== 'undefined' &&
         window.Mozilla.Cookies.enabled();
 
-    _pencilBanner = document.querySelector('.m24-pencil-banner');
+    _pencilBanner = document.querySelector('.m24-pencil-banner:has(.m24-pencil-banner-close)');
 
     // If the banner does not exist on a page then do nothing.
     if (!_pencilBanner) {

--- a/media/js/base/banners/m24-pencil-banner.es6.js
+++ b/media/js/base/banners/m24-pencil-banner.es6.js
@@ -96,7 +96,9 @@ M24PencilBanner.init = function () {
         typeof window.Mozilla.Cookies !== 'undefined' &&
         window.Mozilla.Cookies.enabled();
 
-    _pencilBanner = document.querySelector('.m24-pencil-banner:has(.m24-pencil-banner-close)');
+    _pencilBanner = document.querySelector(
+        '.m24-pencil-banner:has(.m24-pencil-banner-close)'
+    );
 
     // If the banner does not exist on a page then do nothing.
     if (!_pencilBanner) {


### PR DESCRIPTION
## One-line summary

Only init pencil banner that is actually interactive.

## Significant changes and points to review

This skips pushing the GA datalayer in case the banner is used only as a form of notification when can't be dismissed etc. — sounds OK to me.

## Issue / Bugzilla link

Fixes #328 (and possibly #324 too)

## Testing

http://localhost:8000/en
http://localhost:8000/skr
http://localhost:8000/eo