### PR TITLE
Refactor pencil banner button bind for legacy IE

### DIFF
--- a/media/js/base/banners/m24-pencil-banner.es6.js
+++ b/media/js/base/banners/m24-pencil-banner.es6.js
@@ -76,10 +76,12 @@ M24PencilBanner.close = function () {
 };
 
 M24PencilBanner.bindEvents = function () {
+    const closeButton = _pencilBanner.querySelector('.m24-pencil-banner-close');
+
     // Wire up close button
-    _pencilBanner
-        .querySelector('.m24-pencil-banner-close')
-        .addEventListener('click', M24PencilBanner.close, false);
+    if (closeButton) {
+        closeButton.addEventListener('click', M24PencilBanner.close, false);
+    }
 
     // Record widget display action in GA4
     window.dataLayer.push({
@@ -96,9 +98,7 @@ M24PencilBanner.init = function () {
         typeof window.Mozilla.Cookies !== 'undefined' &&
         window.Mozilla.Cookies.enabled();
 
-    _pencilBanner = document.querySelector(
-        '.m24-pencil-banner:has(.m24-pencil-banner-close)'
-    );
+    _pencilBanner = document.querySelector('.m24-pencil-banner');
 
     // If the banner does not exist on a page then do nothing.
     if (!_pencilBanner) {


### PR DESCRIPTION
## One-line summary

Rewrites #329 in a more conservative way to avoid _SyntaxError_ on legacy IE.

## Significant changes and points to review

Not that the button would work in IE to start with. It just seems to choke badly on a selector it doesn't understand in the JS query… TIL

## Issue / Bugzilla link

#324

## Testing

[/actions/runs/15898256192/job/44834926423](https://github.com/mozmeao/springfield/actions/runs/15898256192/job/44834926423) :shipit: 🚢 ✅ 