### PR TITLE
Fix grammar of de hardcoded string

### DIFF
--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -171,7 +171,7 @@
     {% set feature1_body = 'Firefox View zeigt dir deine offenen Tabs von anderen Geräten und den aktuellen Verlauf.' %}
     {% set feature2_title = 'PDFs direkt bearbeiten' %}
     {% set feature2_body = 'Nie wieder ein PDF ausdrucken. Bearbeite jetzt Dokumente direkt in Firefox.' %}
-    {% set feature3_title = 'Spürbar geschützt Browsen' %}
+    {% set feature3_title = 'Spürbar geschützt browsen' %}
     {% set feature3_body = 'Der vollständige Cookie-Schutz von Firefox gibt dir standardmäßig höchste Privatsphäre.' %}
   {% else %}
     {% set features_section_title = '<strong>Latest</strong> Firefox features' %}


### PR DESCRIPTION
## One-line summary

Fix case in German MR106 feature as reported via QA form. 

## Significant changes and points to review

That’s because das ist kein Substantiv!

## Issue / Bugzilla link



## Testing
