### PR TITLE
Add heading anchors to release notes

### DIFF
--- a/springfield/firefox/templates/firefox/releases/notes.html
+++ b/springfield/firefox/templates/firefox/releases/notes.html
@@ -160,7 +160,7 @@
     {% if release.is_public and release_notes %}
       {% for note in release_notes if note.tag == "New" %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
             <div class="mzp-l-sidebar">
               <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/highlight.svg') }}" width="30" height="30">
               <h3>{{ note.tag }}</h3>
@@ -178,7 +178,7 @@
 
       {% for note in release_notes if note.tag == "Fixed" %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
             <div class="mzp-l-sidebar">
               <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/check.svg') }}" width="30" height="30">
               <h3>{{ note.tag }}</h3>
@@ -196,7 +196,7 @@
 
       {% for note in release_notes if note.tag == "Changed" %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
             <div class="mzp-l-sidebar">
               <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/features.svg') }}" width="30" height="30">
               <h3>{{ note.tag }}</h3>
@@ -214,7 +214,7 @@
 
       {% for note in release_notes if note.tag == "Enterprise" %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
             <div class="mzp-l-sidebar">
               <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/enterprise.svg') }}" width="30" height="30">
               <h3>{{ note.tag }}</h3>
@@ -239,7 +239,7 @@
           {% continue %}
         {% endif %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
             <div class="mzp-l-sidebar">
               <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/developer.svg') }}" width="30" height="30">
               <h3>Developer</h3>
@@ -257,7 +257,7 @@
 
       {% for note in release_notes if note.tag == "HTML5" %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
             <div class="mzp-l-sidebar">
               <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/globe.svg') }}" width="30" height="30">
               <h3>Web Platform</h3>
@@ -307,9 +307,11 @@
 
       {% for note in release_notes if note.tag == "Known" %}
         {% if loop.first %}
-          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="known">
-            <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/stop.svg') }}" width="30" height="30">
-            <div class="mzp-l-sidebar"><h3>Unresolved</h3></div>
+          <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
+            <div class="mzp-l-sidebar">
+              <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/stop.svg') }}" width="30" height="30">
+              <h3>Unresolved</h3>
+            </div>
             <div class="mzp-l-main mzp-l-article">
               <ul>
         {% endif %}
@@ -324,17 +326,17 @@
       {% for note in release_notes if note.tag == "Community" %}
         {% if loop.first %}
           <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="{{ note.tag|lower() }}">
-          <div class="mzp-l-sidebar">
-            <img class="sidebar-icon" alt="" src="{{ static('img/firefox/releasenotes/community.svg') }}" width="30" height="30">
-            <h3>Community Contributions</h3>
-          </div>
-          <div class="mzp-l-main mzp-l-article">
-            <ul>
+            <div class="mzp-l-sidebar">
+              <img class="sidebar-icon" alt="" src="{{ static('img/firefox/releasenotes/community.svg') }}" width="30" height="30">
+              <h3>Community Contributions</h3>
+            </div>
+            <div class="mzp-l-main mzp-l-article">
+              <ul>
         {% endif %}
         {{ note_entry(note) }}
         {% if loop.last %}
-            </ul>
-          </div>
+              </ul>
+            </div>
           </div>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## One-line summary

Porting over https://github.com/mozilla/bedrock/pull/16286 in case MDN starts using these…

## Significant changes and points to review

Checked for any preexisting IDs hypothetically clashing with the note tag names used for this, but all looks good.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16277
https://github.com/mozilla/nucleus/issues/1077

## Testing

http://localhost:8000/firefox/128.0/releasenotes/#community
http://localhost:8000/firefox/android/128.0/releasenotes/#fixed
http://localhost:8000/firefox/ios/139.0/releasenotes/#new
http://localhost:8000/firefox/128.0beta/releasenotes/#developer
http://localhost:8000/firefox/139.0a1/releasenotes/#html5
http://localhost:8000/firefox/39.0/releasenotes/#changed
http://localhost:8000/firefox/organizations/notes/#developer
http://localhost:8000/firefox/notes/#fixed