### PR TITLE
Mark missing SSL test results as `xfail`

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -7,7 +7,7 @@ env:
   SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
 on:
   schedule:
-    - cron: "0 11 * * *" # 11am daily
+    - cron: "50 11 * * *" # 11:50 AM UTC daily
   workflow_dispatch:
     inputs:
       springfield_service_hostname:

--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -130,6 +130,8 @@ def test_cdn_cache(base_url):
 @pytest.mark.nondestructive
 @pytest.mark.parametrize("version", supported_versions, ids=itemgetter(0))
 def test_enabled_protocols(version, get_ssllabs_results):
+    if not get_ssllabs_results:
+        pytest.xfail("SSL scan results are not available")
     supported_protocols = get_ssllabs_results[0]["endpoints"][0]["details"]["protocols"]
     found = False
     for prot in supported_protocols:
@@ -142,6 +144,8 @@ def test_enabled_protocols(version, get_ssllabs_results):
 @pytest.mark.nondestructive
 @pytest.mark.parametrize("version", unsupported_versions, ids=itemgetter(0))
 def test_disabled_protocols(version, get_ssllabs_results):
+    if not get_ssllabs_results:
+        pytest.xfail("SSL scan results are not available")
     supported_protocols = get_ssllabs_results[0]["endpoints"][0]["details"]["protocols"]
     found = False
     for prot in supported_protocols:
@@ -154,6 +158,8 @@ def test_disabled_protocols(version, get_ssllabs_results):
 @pytest.mark.nondestructive
 @pytest.mark.parametrize("cipher", ciphers, ids=itemgetter(0))
 def test_enabled_ciphers(cipher, get_ssllabs_results):
+    if not get_ssllabs_results:
+        pytest.xfail("SSL scan results are not available")
     supported_suite = get_ssllabs_results[0]["endpoints"][0]["details"]["suites"]["list"]
     found = False
     for cipher_description in supported_suite:
@@ -167,6 +173,8 @@ def test_enabled_ciphers(cipher, get_ssllabs_results):
 @pytest.mark.nondestructive
 def test_tls(get_ssllabs_results):
     """Check get_ssllabs_results to make sure that all expected clients connected without issue"""
+    if not get_ssllabs_results:
+        pytest.xfail("SSL scan results are not available")
     data = get_ssllabs_results
 
     errors = 0


### PR DESCRIPTION
## One-line summary

If there’s no results from upstream API, these are expected to fail. Let’s mark them as such in that case, so they don’t fail the whole pipeline which is still very useful. 

## Significant changes and points to review

Also triggers in a different time slot than bedrock so we’re not getting unnecessarily rate-limited etc.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16339

## Testing
