### PR TITLE
Update footer subheading classes to fix mobile vertical alignment

### DIFF
--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -128,6 +128,7 @@ $image-path: '/media/protocol/img';
                 "platforms business";
             grid-template-columns: repeat(2, minmax(0, 1fr));
             margin-bottom: $layout-sm;
+            padding-bottom: $layout-sm;
 
             .c-footer-heading-download {
                 grid-area: download;

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -36,8 +36,22 @@ $image-path: '/media/protocol/img';
 
 .c-footer-section-download, .c-footer-section-platforms {
     .c-footer-subheading {
-        font-weight: bold;
-        color: m24.$m24-color-white;
+        font-weight: var(--title-font-weight);
+        color: m24.$token-color-off-white;
+
+        // Ensure links within footer subheadings inherit the parent's styles
+        a:link,
+        a:visited {
+            color: inherit;
+            font-weight: inherit;
+        }
+
+        a:hover,
+        a:focus,
+        a:active {
+            color: inherit;
+            font-weight: inherit;
+        }
     }
 
     // Override responsive margin for Download Firefox sub heading to prevent it from breaking the layout

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -34,6 +34,18 @@ $image-path: '/media/protocol/img';
     }
 }
 
+.c-footer-section-download, .c-footer-section-platforms {
+    .c-footer-subheading {
+        font-weight: bold;
+        color: m24.$m24-color-white;
+    }
+
+    // Override responsive margin for Download Firefox sub heading to prevent it from breaking the layout
+    .c-footer-section-platforms .c-footer-subheading {
+        margin: 0;
+    }
+}
+
 // external link icon
 .mzp-c-footer-section a[href^="http"]::after {
     @include bidi((
@@ -109,12 +121,8 @@ $image-path: '/media/protocol/img';
                 grid-column-start: 1;
             }
 
-            .c-footer-list-download {
+            .c-footer-section-platforms {
                 grid-area: platforms;
-
-                li:last-child {
-                    margin-bottom: 0;
-                }
             }
 
             .c-footer-section-latest {

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -36,14 +36,14 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <li><a href="{{ url('firefox.all') }}" data-link-position="footer" data-link-text="Custom Download">{{ ftl('footer-custom-download') }}</a></li>
           </ul>
           <div class="c-footer-section-latest">
-            <h3 class="c-footer-subheading">{{ ftl('footer-latest') }}</h3>
+            <h3 class="mzp-c-footer-heading">{{ ftl('footer-latest') }}</h3>
             <ul class="mzp-c-footer-list">
               <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-position="footer" data-link-text="Nightly">{{ ftl('footer-nightly') }}</a></li>
               <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-position="footer" data-link-text="Beta">{{ ftl('footer-beta') }}</a></li>
             </ul>
           </div>
           <div class="c-footer-section-business">
-            <h3 class="c-footer-subheading">{{ ftl('footer-business') }}</h3>
+            <h3 class="mzp-c-footer-heading">{{ ftl('footer-business') }}</h3>
             <ul class="mzp-c-footer-list">
               <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Enterprise">{{ ftl('footer-enterprise') }}</a></li>
             </ul>

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -27,7 +27,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </h2>
           <div class="c-footer-section-platforms">
             {# Download link should be locale neutral see bedrock issue 7982 #}
-            <h3 class="mzp-c-footer-heading c-footer-subheading"><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></h3>
+            <h3 class="c-footer-subheading"><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></h3>
             <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
               <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
               <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
@@ -38,14 +38,14 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             </ul>
           </div>
           <div class="c-footer-section-latest">
-            <h3 class="mzp-c-footer-heading c-footer-subheading">{{ ftl('footer-latest') }}</h3>
+            <h3 class="c-footer-subheading">{{ ftl('footer-latest') }}</h3>
             <ul class="mzp-c-footer-list">
               <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-position="footer" data-link-text="Nightly">{{ ftl('footer-nightly') }}</a></li>
               <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-position="footer" data-link-text="Beta">{{ ftl('footer-beta') }}</a></li>
             </ul>
           </div>
           <div class="c-footer-section-business">
-            <h3 class="mzp-c-footer-heading c-footer-subheading">{{ ftl('footer-business') }}</h3>
+            <h3 class="c-footer-subheading">{{ ftl('footer-business') }}</h3>
             <ul class="mzp-c-footer-list">
               <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Enterprise">{{ ftl('footer-enterprise') }}</a></li>
             </ul>

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -25,25 +25,27 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <h2 class="mzp-c-footer-heading c-footer-heading-download" data-testid="footer-heading-download">
             {{ ftl('footer-download') }}
           </h2>
-          <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
-             {# Download link should be locale neutral see bedrock issue 7982 #}
-            <li><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-position="footer" data-link-text="Android">{{ ftl('footer-android') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.desktop.linux') }}" data-link-position="footer" data-link-text="Linux">{{ ftl('footer-linux') }}</a></li>
-            <li><a href="{{ url('firefox.all') }}" data-link-position="footer" data-link-text="Custom Download">{{ ftl('footer-custom-download') }}</a></li>
-          </ul>
+          <div class="c-footer-section-platforms">
+            {# Download link should be locale neutral see bedrock issue 7982 #}
+            <h3 class="mzp-c-footer-heading c-footer-subheading"><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></h3>
+            <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
+              <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-position="footer" data-link-text="Android">{{ ftl('footer-android') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.desktop.linux') }}" data-link-position="footer" data-link-text="Linux">{{ ftl('footer-linux') }}</a></li>
+              <li><a href="{{ url('firefox.all') }}" data-link-position="footer" data-link-text="Custom Download">{{ ftl('footer-custom-download') }}</a></li>
+            </ul>
+          </div>
           <div class="c-footer-section-latest">
-            <h3 class="mzp-c-footer-heading">{{ ftl('footer-latest') }}</h3>
+            <h3 class="mzp-c-footer-heading c-footer-subheading">{{ ftl('footer-latest') }}</h3>
             <ul class="mzp-c-footer-list">
               <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-position="footer" data-link-text="Nightly">{{ ftl('footer-nightly') }}</a></li>
               <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-position="footer" data-link-text="Beta">{{ ftl('footer-beta') }}</a></li>
             </ul>
           </div>
           <div class="c-footer-section-business">
-            <h3 class="mzp-c-footer-heading">{{ ftl('footer-business') }}</h3>
+            <h3 class="mzp-c-footer-heading c-footer-subheading">{{ ftl('footer-business') }}</h3>
             <ul class="mzp-c-footer-list">
               <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Enterprise">{{ ftl('footer-enterprise') }}</a></li>
             </ul>


### PR DESCRIPTION
## One-line summary

Changes the classnames on the "Latest Builds" and "Firefox for Business" h3 tags to `.mzp-c-footer-heading` from `.c-footer-subheading` for consistent alignment with other headings in the footer, at all breakpoints.

## Significant changes and points to review

The vertical alignment is now fixed for breakpoints below 480px, and the h2/h3 heading levels are unchanged, but the correct semantics of the markup of this footer section still need review.

## Issue / Bugzilla link

Fixes #308 