### PR TITLE
Make FxA `/pair` vanity redirect case–insensitive

### DIFF
--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -68,7 +68,7 @@ redirectpatterns = (
         r"^containers/?$", "https://www.mozilla.org/firefox/facebookcontainer/?redirect_source=firefox-com", permanent=False
     ),  # TODO remove or amend depending on whether we port the page
     redirect(r"^pdx/?$", "firefox", permanent=False),
-    redirect(r"^pair/?$", "https://accounts.firefox.com/pair/", permanent=False),
+    redirect(r"^pair/?$", "https://accounts.firefox.com/pair/", permanent=False, re_flags="i"),
     redirect(r"^(join|rejoindre)/?$", "https://www.mozilla.org/firefox/accounts/?redirect_source=join", permanent=False),
     redirect(r"^(privacy|privatsphaere)/?$", "https://www.mozilla.org/products/?redirect_source=firefox-com", permanent=False),
     redirect(r"^nightly/?$", "/channel/desktop/#nightly", permanent=False),


### PR DESCRIPTION
## One-line summary

There's a few 404s so this accepts `/PAIR` as `/pair`, too.

## Significant changes and points to review

We handle firefox.com/pair but it's expected to be typed manually — thus folks may scream and end up 404ing on FIREFOX.COM/PAIR so we should make this redirect case insensitive.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/336#issuecomment-3016105989

## Testing

localhost:8000/PAIR