### PR TITLE
Fix release notes style specificity

### DIFF
--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -209,7 +209,7 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    h3 {
+    .c-release-notes h3 {
         @include text-title-xs;
         margin-bottom: $layout-sm;
     }


### PR DESCRIPTION
## One-line summary

This fixes oversized headings in the footer which were caused by release page CSS rules that were lacking specificity.

![image](https://github.com/user-attachments/assets/35b3c65b-6fa9-4f21-922e-0449a582809c)

## Significant changes and points to review

Made the release page CSS more specific by adding the `.c-release-notes` class selector to the release notes heading styles.

## Issue / Bugzilla link

This is part of Footer mobile vertical alignment #308 which may be split into a separate issue.
