### PR TITLE
fix best-browser page hero and cta section styles (fix#350)

### DIFF
--- a/media/css/firefox/more/best-browser.scss
+++ b/media/css/firefox/more/best-browser.scss
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+
+.seo-hero {
+    background: $color-purple-90 url('/media/img/firefox/more/best-browser/hero-pattern.png') 55% 60% no-repeat;
+    @include background-size(2500px);
+    color: $body-text-color-inverse;
+    text-align: center;
+    min-height: 520px;
+    margin-bottom: $spacing-xl;
+
+    @supports (--css: variables) {
+        color: var(--body-text-color-inverse);
+    }
+
+    .hero-content {
+        padding-top: $layout-xl;
+        padding-bottom: $layout-xl;
+
+        .mzp-c-logo {
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        h1 {
+            @include text-title-lg;
+            color: $title-text-color-inverse;
+            margin: 0 auto $spacing-2xl;
+            max-width: 580px;
+
+            @supports (--css: variables) {
+                color: var(--title-text-color-inverse);
+            }
+        }
+
+        p {
+            color: $color-orange-50;
+            font-weight: bold;
+        }
+
+        img {
+            margin-bottom: $spacing-md;
+        }
+    }
+}
+
+.mzp-c-article {
+    margin: 0 auto $layout-lg;
+
+    hr {
+        border: 0 solid $color-purple-90;
+        border-top-width: 4px;
+        margin: $layout-lg auto $layout-lg;
+        width: 100px;
+    }
+
+    .article-section {
+        margin-bottom: $layout-lg;
+
+        h2 {
+            @include text-title-md;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Call out
+
+.mzp-l-compact.mzp-t-dark {
+    background: $color-purple-90;
+
+    .mzp-c-callout-title {
+        color: $color-orange-50;
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -327,6 +327,12 @@
     },
     {
       "files": [
+        "css/firefox/more/best-browser.scss"
+      ],
+      "name": "best-browser"
+    },
+    {
+      "files": [
         "css/firefox/more/article.scss"
       ],
       "name": "more-article"

--- a/springfield/firefox/templates/firefox/more/best-browser.html
+++ b/springfield/firefox/templates/firefox/more/best-browser.html
@@ -19,7 +19,7 @@
 {% block page_css %}
   {{ css_bundle('protocol-article') }}
   {{ css_bundle('protocol-callout') }}
-  {{ css_bundle('more-article') }}
+  {{ css_bundle('best-browser') }}
 {% endblock %}
 
 {% block content %}

--- a/springfield/firefox/templates/firefox/more/cta.html
+++ b/springfield/firefox/templates/firefox/more/cta.html
@@ -15,7 +15,7 @@
 
 {% call callout_compact(
   title=callout_title,
-  class='mzp-t-product-firefox mzp-t-firefox mzp-t-background-secondary',
+  class='mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
   brand=True,
   brand_product='firefox',
   brand_type='logo',


### PR DESCRIPTION
## One-line summary

This PR fixes the style of the `best-browser` page hero and bottom CTA sections.

## Significant changes and points to review

- hero section
- bottom CTA section

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/350

## Testing

http://localhost:8000/en-US/more/best-browser/