### PR TITLE
Enable DownloadAsDefault in EU (Fix #358)

### DIFF
--- a/media/js/base/stub-attribution/stub-attribution.js
+++ b/media/js/base/stub-attribution/stub-attribution.js
@@ -498,7 +498,7 @@ if (typeof window.Mozilla === 'undefined') {
     /**
      * Gets utm parameters and referrer information from the web page if they exist.
      * @param {String} ref - Optional referrer to facilitate testing.
-     * @param {Boolean} omitNonEssentialFields - Optional flag to omit fields that are nonEssential for RTAMO.
+     * @param {Boolean} omitNonEssentialFields - Optional flag to omit fields that are nonEssential.
      * @return {Object} - Stub attribution data object.
      */
     StubAttribution.getAttributionData = function (
@@ -625,7 +625,11 @@ if (typeof window.Mozilla === 'undefined') {
     /**
      * Determines whether to make a request to the stub authentication service.
      */
-    StubAttribution.init = function (successCallback, timeoutCallback) {
+    StubAttribution.init = function (
+        successCallback,
+        timeoutCallback,
+        omitNonEssentialFields = false
+    ) {
         var data = {};
 
         if (!StubAttribution.meetsRequirements()) {
@@ -655,7 +659,10 @@ if (typeof window.Mozilla === 'undefined') {
             // Wait for GA4 to load and return client IDs
             StubAttribution.waitForGoogleAnalyticsThen(function () {
                 // get attribution data
-                data = StubAttribution.getAttributionData();
+                data = StubAttribution.getAttributionData(
+                    null,
+                    omitNonEssentialFields
+                );
 
                 if (
                     data &&

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -6,7 +6,7 @@
 
 {% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 
-{% if switch('download_as_default') and not needs_data_consent(country_code) and ftl_has_messages('firefox-desktop-set-as-default') %}
+{% if switch('download_as_default') and ftl_has_messages('firefox-desktop-set-as-default') %}
   {% set download_as_default_enabled = true %}
 {% else %}
   {% set download_as_default_enabled = false %}

--- a/springfield/firefox/templates/firefox/download/home.html
+++ b/springfield/firefox/templates/firefox/download/home.html
@@ -6,7 +6,7 @@
 
 {% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 
-{% if switch('download_as_default') and not needs_data_consent(country_code) %}
+{% if switch('download_as_default') %}
 {% set download_as_default_enabled = true %}
 {% else %}
 {% set download_as_default_enabled = false %}

--- a/tests/unit/spec/firefox/new/desktop/download-as-default.js
+++ b/tests/unit/spec/firefox/new/desktop/download-as-default.js
@@ -58,52 +58,6 @@ describe('download-as-default.es6.js', function () {
             expect(result).toBeFalse();
         });
 
-        it('should return false if GPC is enabled', function () {
-            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
-
-            const result = DownloadAsDefault.meetsRequirements();
-            expect(result).toBeFalse();
-            delete window.Mozilla.gpcEnabled;
-        });
-
-        it('should return false if DNT is enabled', function () {
-            window.Mozilla.dntEnabled = sinon.stub().returns(true);
-
-            const result = DownloadAsDefault.meetsRequirements();
-            expect(result).toBeFalse();
-            delete window.Mozilla.dntEnabled;
-        });
-
-        it('should return false if consent cookie rejects analytics', function () {
-            spyOn(window.Mozilla.Cookies, 'hasItem')
-                .withArgs('moz-consent-pref')
-                .and.returnValue(true);
-            spyOn(window.Mozilla.Cookies, 'getItem')
-                .withArgs('moz-consent-pref')
-                .and.returnValue(
-                    JSON.stringify({
-                        analytics: false,
-                        preference: true
-                    })
-                );
-
-            const result = DownloadAsDefault.meetsRequirements();
-            expect(result).toBeFalse();
-        });
-
-        it('should return false if visitor is in EU/EAA country', function () {
-            spyOn(window.Mozilla.Cookies, 'hasItem')
-                .withArgs('moz-consent-pref')
-                .and.returnValue(false);
-
-            document
-                .getElementsByTagName('html')[0]
-                .setAttribute('data-needs-consent', 'True');
-
-            const result = DownloadAsDefault.meetsRequirements();
-            expect(result).toBeFalse();
-        });
-
         it('should return false if attribution requirements are not satisfied', function () {
             spyOn(window.Mozilla.Cookies, 'hasItem')
                 .withArgs('moz-consent-pref')
@@ -120,6 +74,100 @@ describe('download-as-default.es6.js', function () {
         it('should return true if attribution requirements are satisfied', function () {
             const result = DownloadAsDefault.meetsRequirements();
             expect(result).toBeTrue();
+        });
+    });
+    describe('onlyEssential', function () {
+        it('with no consent signal - should return false', function () {
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeFalse();
+        });
+
+        it('with no other consent signal - should return true if GPC is enabled', function () {
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeTrue();
+            delete window.Mozilla.gpcEnabled;
+        });
+
+        it('with no other consent signal - should return true if DNT is enabled', function () {
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeTrue();
+            delete window.Mozilla.dntEnabled;
+        });
+
+        it('with no other consent signal - should return true if consent cookie rejects analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(
+                    JSON.stringify({
+                        analytics: false,
+                        preference: true
+                    })
+                );
+
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeTrue();
+        });
+
+        it('with no other consent signal - should return true if visitor is in EU/EAA country', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'True');
+
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeTrue();
+        });
+
+        it('with no other consent signal - should return false if consent cookie accepts analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(
+                    JSON.stringify({
+                        analytics: true,
+                        preference: true
+                    })
+                );
+
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeFalse();
+        });
+
+        it('despite other consent signals - should return true if consent cookie accepts analytics', function () {
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'True');
+
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(
+                    JSON.stringify({
+                        analytics: true,
+                        preference: true
+                    })
+                );
+
+            const result = DownloadAsDefault.onlyEssential();
+            expect(result).toBeFalse();
+            delete window.Mozilla.gpcEnabled;
+            delete window.Mozilla.dntEnabled;
         });
     });
     describe('init()', function () {


### PR DESCRIPTION
## One-line summary

Enable DownloadAsDefault in EU

## Significant changes and points to review

- Update stubAttribution to accept omitNonEssentialFields parameter on init
- Update DaD to init with omitNonEssentialFields = true when consent required
- Update switch config for downloadAsDefault to remove check for EU/EAA
- Update tests for stubAttribution and downloadAsDefault

## Issue / Bugzilla link

Fix #358

## Testing

In _a windows version greater than 8.1_ the checkbox appears on:

- [x] http://localhost:8000/en-US/?geo=fr
- [x] http://localhost:8000/en-US/?geo=fr&xv=legacy
- [x] http://localhost:8000/en-US/?geo=us
- [x] http://localhost:8000/en-US/?geo=us&xv=legacy

[Follow these steps for testing stubAttribution data](https://mozilla.github.io/bedrock/attribution/0002-firefox-desktop/#manual-testing-for-code-reviews):

In any case where the user has not given explicit consent stubAttribution should omit fields not essential to delivering the downloadAsDefault functionality the `moz-stub-attribution-code` cookie should decode to match this string:

```
source=(not set)&medium=(direct)&campaign=SET_DEFAULT_BROWSER&content=(not set)&experiment=(not set)&variation=(not set)&ua=other&client_id_ga4=(not set)&session_id=(not set)&dlsource=fxdotcom
```

- [x] DNT enabled
- [x] GCP enabled
- [x] Consent cookie set to reject analytics
- [x] Geolocation in EU

In any case where the user has agreed to or is not required to agree to analytics the `moz-stub-attribution-code` cookie must include the value `&campaign=SET_DEFAULT_BROWSER` and may contain other values. To check that non-essiential fields are not being ommited you can see if the `ua` is defined instead of set to other.

- [x] Geolocation outside of EU
- [x] Consent cookie set to accept analytics with DNT enabled
- [x] Consent cookie set to accept analytics with GCP enabled
- [x] Consent cookie set to accept analytics with geolocation in EU