### PR TITLE
simplify footer landmark (fix #284)

### DIFF
--- a/l10n/en/footer-firefox.ftl
+++ b/l10n/en/footer-firefox.ftl
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# An accessible label used to describe that the role of the element is the
-# primary website navigation.
-footer-landmark-label = Supplementary
-
 ## Download links for stable versions of Firefox across multiple platforms.
 
 # Section title

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -19,7 +19,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 <footer class="mzp-c-footer" id="colophon" role="contentinfo">
   <div class="mzp-l-content">
-    <nav class="mzp-c-footer-primary" aria-label="{{ ftl('footer-landmark-label') }}">
+    <div class="mzp-c-footer-primary">
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section c-footer-section-download" aria-label="{{ ftl('footer-download') }}">
           <h2 class="mzp-c-footer-heading c-footer-heading-download" data-testid="footer-heading-download">
@@ -92,8 +92,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       <div class="c-footer-logo">
         <a href="{{ url('firefox') }}" data-link-position="footer" data-link-text="Firefox">{{ ftl('footer-firefox') }}</a>
       </div>
-    </nav>
-    <nav class="mzp-c-footer-secondary">
+    </div>
+    <div class="mzp-c-footer-secondary">
       <div class="mzp-c-footer-legal">
         <ul class="mzp-c-footer-terms">
           {% if LANG == "de" %}
@@ -126,6 +126,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
 
-    </nav>
+    </div>
   </div>
 </footer>


### PR DESCRIPTION
## One-line summary

This PR simplifies the footer landmark into one.

## Significant changes and points to review

Footer is simplified to just one landmark.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/284

## Testing
