### PR TITLE
fix nav content horizontal shift (fix #365)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -165,18 +165,6 @@ $margin-top: 58px; // top margin offset for mobile navigation menu
     }
 }
 
-// spacer to center nav items when CTA isn't there
-
-.spacer-gif {
-    display: none;
-
-    @media #{$mq-md} {
-        display: inline-block;
-        width: 120px; // matches width of Firefox logo
-    }
-}
-
-
 // * -------------------------------------------------------------------------- */
 // Menu
 
@@ -527,5 +515,6 @@ body:has(.m24-c-navigation-items.mzp-is-open) {
 
     @media #{$mq-md} {
         display: inline-block;
+        min-width: 156px; // prevent nav content shift when CTA is not displayed
     }
 }

--- a/springfield/base/templates/includes/navigation/nav-cta.html
+++ b/springfield/base/templates/includes/navigation/nav-cta.html
@@ -13,6 +13,5 @@
       {{ custom_nav_cta }}
     {% endif %}
   {% else %}
-  <div class="spacer-gif"></div>
 {% endif %}
 


### PR DESCRIPTION
## One-line summary

This PR fixes the issue that nav content shift when download button is not displayed.

## Significant changes and points to review

Compare navigation content when download button is displayed or not

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/365

## Testing

http://localhost:8000/en-US/
http://localhost:8000/en-US/browsers/mobile/