### PR TITLE
Fixup release notes heading size/alignment

### DIFF
--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -208,15 +208,15 @@ $image-path: '/media/protocol/img';
             visibility: hidden;
         }
     }
-
-    .c-release-notes h3 {
-        @include text-title-xs;
-        margin-bottom: $layout-sm;
-    }
 }
 
 .c-release-notes > .mzp-l-content {
     padding-top: $layout-lg;
+
+    h3 {
+        @include text-title-xs;
+        margin-bottom: $layout-sm;
+    }
 
     &::before {
         content: '';


### PR DESCRIPTION
## One-line summary

Fixes h3 size not being applied due to wrong element order in selector cascade.

## Significant changes and points to review

Moves the selector to an appropriate block.

## Issue / Bugzilla link

Fixes #369

## Testing

http://localhost:8000/en-US/firefox/140.0/releasenotes/