### PR TITLE
Ensure l10n files have been synced down ahead of other data-prep commands

### DIFF
--- a/bin/run-db-update.sh
+++ b/bin/run-db-update.sh
@@ -32,6 +32,8 @@ failure_detected=false
 
 # Please ensure all new command calls are suffixed with || failure_detected=true
 
+# make sure l10n files are here for use in other commands
+python manage.py l10n_update || failure_detected=true
 python manage.py update_product_details_files || failure_detected=true
 python manage.py update_release_notes --quiet || failure_detected=true
 python manage.py update_newsletter_data --quiet || failure_detected=true


### PR DESCRIPTION

Without this, the sitemap generation only uses the DB-backed pages to determine available locales, which wouldn't be correct.

Because the cronjob pod that runs this command is ephemeral and there is no sidecar pod that holds the l10n data, we have to explicitly get the files
