### PR TITLE
Update consent banner name

### DIFF
--- a/l10n/en/banners/consent-banner.ftl
+++ b/l10n/en/banners/consent-banner.ftl
@@ -4,7 +4,7 @@
 
 ### URL: https://www-dev.springfield.moz.works/newsletter/?geo=de
 
-consent-banner-heading = Help us improve your { -brand-name-mozilla } experience
+consent-banner-fx-heading = Help us improve your { -brand-name-firefox } experience
 consent-banner-body-v2 = In addition to Cookies necessary for this site to function, we’d like your permission to set some additional Cookies to better understand your browsing needs and improve your experience. Rest assured — we value your privacy.
 
 consent-banner-button-reject = Reject All Additional Cookies

--- a/l10n/en/banners/consent-banner.ftl
+++ b/l10n/en/banners/consent-banner.ftl
@@ -4,7 +4,7 @@
 
 ### URL: https://www-dev.springfield.moz.works/newsletter/?geo=de
 
-consent-banner-fx-heading = Help us improve your { -brand-name-firefox } experience
+consent-banner-fx-heading = Help us improve your firefox.com experience
 consent-banner-body-v2 = In addition to Cookies necessary for this site to function, we’d like your permission to set some additional Cookies to better understand your browsing needs and improve your experience. Rest assured — we value your privacy.
 
 consent-banner-button-reject = Reject All Additional Cookies

--- a/springfield/base/templates/includes/banners/consent-banner.html
+++ b/springfield/base/templates/includes/banners/consent-banner.html
@@ -6,7 +6,7 @@
 
 <aside class="moz-consent-banner" id="moz-consent-banner" role="region" aria-label="{{ ftl('consent-banner-aria-label') }}" data-nosnippet="true" data-testid="consent-banner">
   <div class="moz-consent-banner-content">
-    <h2 class="moz-consent-banner-heading">{{ ftl('consent-banner-heading') }}</h2>
+    <h2 class="moz-consent-banner-heading">{{ ftl('consent-banner-fx-heading') }}</h2>
     <div class="moz-consent-banner-copy">
       <p>{{ ftl('consent-banner-body-v2') }}</p>
       <div class="moz-consent-banner-controls">

--- a/springfield/firefox/templates/firefox/features/adblocker-2025.html
+++ b/springfield/firefox/templates/firefox/features/adblocker-2025.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% block page_title %}{{ ftl('features-adblocker-meta-title-v2', fallback=ftl('features-adblocker-meta-title')) }}{% endblock %}
+{% block page_title %}{{ ftl('features-adblocker-meta-title-v2', fallback='features-adblocker-meta-title') }}{% endblock %}
 {% block page_desc %}{{ ftl('features-adblocker-meta-desc') }}{% endblock %}
 
 {% block article_title_short %}{{ ftl('features-adblocker-ad-blocking') }}{% endblock %}


### PR DESCRIPTION
## One-line summary
We want to make clear the consent banner applies to `firefox.com` and not `mozilla.org`

## Significant changes and points to review



## Issue / Bugzilla link
from Slack


## Testing
- [ ] http://localhost:8000/en-US/landing/get/?geo=GB (or any country from the [consent countries list](https://github.com/mozmeao/springfield/blob/b2d39847860b37295b61217faca77c7f6a4ba550/springfield/settings/base.py#L1069)) 

<img width="993" height="194" alt="firefox-consent" src="https://github.com/user-attachments/assets/32b0ddcf-e9c4-42dc-8457-e2b8cfdfb4f1" />
