### PR TITLE
Add footer download sections styling to highlight the relation/hierarchy

### DIFF
--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -104,7 +104,7 @@ $image-path: '/media/protocol/img';
                 grid-area: platforms;
 
                 li:last-child {
-                    margin-bottom: 0;
+                    margin-bottom: 2em;
                 }
             }
 

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -22,16 +22,7 @@ $image-path: '/media/protocol/img';
 
 .c-footer-subheading {
     @extend .mzp-c-footer-heading; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
-    color: m24.$token-color-mid-gray;
-
-    @media screen and (max-width: #{$screen-sm - 1}) {
-        padding-top: 0;
-        padding-bottom: 0;
-    }
-
-    @media #{$mq-lg} {
-        margin-top: $layout-sm / 2 * -1;
-    }
+    color: m24.$token-color-off-white;
 }
 
 // external link icon

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -23,6 +23,18 @@ $image-path: '/media/protocol/img';
 .c-footer-subheading {
     @extend .mzp-c-footer-heading; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
     color: m24.$token-color-off-white;
+
+    @media screen and (max-width: #{$screen-sm - 1}) {
+        padding: 0;
+    }
+
+    @media #{$mq-lg} {
+        margin-top: $layout-sm / 2 * -1;
+
+        .c-footer-list-download & {
+          margin: 0;
+        }
+    }
 }
 
 // external link icon

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -25,18 +25,20 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <h2 class="mzp-c-footer-heading c-footer-heading-download" data-testid="footer-heading-download">
             {{ ftl('footer-download') }}
           </h2>
-          <h3 class="c-footer-subheading">
-            {# Download link should be locale neutral see bedrock issue 7982 #}
-            <a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a>
-          </h3>
-          <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
-            <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-position="footer" data-link-text="Android">{{ ftl('footer-android') }}</a></li>
-            <li><a href="{{ url('firefox.browsers.desktop.linux') }}" data-link-position="footer" data-link-text="Linux">{{ ftl('footer-linux') }}</a></li>
-            <li><a href="{{ url('firefox.all') }}" data-link-position="footer" data-link-text="Custom Download">{{ ftl('footer-custom-download') }}</a></li>
-          </ul>
+          <div class="c-footer-list-download">
+            <h3 class="c-footer-subheading">
+              {# Download link should be locale neutral see bedrock issue 7982 #}
+              <a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a>
+            </h3>
+            <ul class="mzp-c-footer-list c-footer-list-platforms" data-testid="footer-list-download">
+              <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-position="footer" data-link-text="Android">{{ ftl('footer-android') }}</a></li>
+              <li><a href="{{ url('firefox.browsers.desktop.linux') }}" data-link-position="footer" data-link-text="Linux">{{ ftl('footer-linux') }}</a></li>
+              <li><a href="{{ url('firefox.all') }}" data-link-position="footer" data-link-text="Custom Download">{{ ftl('footer-custom-download') }}</a></li>
+            </ul>
+          </div>
           <div class="c-footer-section-latest">
             <h3 class="c-footer-subheading">{{ ftl('footer-latest') }}</h3>
             <ul class="mzp-c-footer-list">

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -27,7 +27,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </h2>
           <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
              {# Download link should be locale neutral see bedrock issue 7982 #}
-            <li><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a></li>
+            <li><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox"><strong>{{ ftl('footer-download-auto') }}</strong></a></li>
             <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
             <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
             <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -25,9 +25,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <h2 class="mzp-c-footer-heading c-footer-heading-download" data-testid="footer-heading-download">
             {{ ftl('footer-download') }}
           </h2>
+          <h3 class="c-footer-subheading">
+            {# Download link should be locale neutral see bedrock issue 7982 #}
+            <a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox">{{ ftl('footer-download-auto') }}</a>
+          </h3>
           <ul class="mzp-c-footer-list c-footer-list-download" data-testid="footer-list-download">
-             {# Download link should be locale neutral see bedrock issue 7982 #}
-            <li><a href="/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-position="footer" data-link-text="Download Firefox"><strong>{{ ftl('footer-download-auto') }}</strong></a></li>
             <li><a href="{{ url('firefox.browsers.desktop.windows') }}" data-link-position="footer" data-link-text="Windows">{{ ftl('footer-windows') }}</a></li>
             <li><a href="{{ url('firefox.browsers.desktop.mac') }}" data-link-position="footer" data-link-text="Mac">{{ ftl('footer-mac') }}</a></li>
             <li><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-position="footer" data-link-text="iOS">{{ ftl('footer-ios') }}</a></li>


### PR DESCRIPTION
## One-line summary

Fixes footer download content alignment between headings / items in mobile viewport while making the style consistent.

## Significant changes and points to review

I think I finally inferred what was behind the design https://github.com/mozmeao/springfield/issues/308#issue-3157265563 — so given the subheadings are the same size as links, only differ in weight/color, I've made the first download link list item also stand out with weight/color… and these two now seem to match. Without having the figma internals, that looks like being close enough to the layout posted, while also making sense markup-wise?

## Issue / Bugzilla link

Resolves #308
(also closes #349 by superseding it)

## Testing

<img width="553" height="520" alt="Screenshot 2025-07-16 at 23 08 21" src="https://github.com/user-attachments/assets/9888210c-953e-4c1c-b642-6edd5a5e1dae" />

<img width="874" height="562" alt="Screenshot 2025-07-16 at 23 08 54" src="https://github.com/user-attachments/assets/743e3125-c999-4c08-9eb4-e742dec90909" />
