### PR TITLE
Decrease feature heading font-size for non-EN langs (#381)

### DIFF
--- a/media/css/firefox/home.scss
+++ b/media/css/firefox/home.scss
@@ -457,6 +457,12 @@ button.mzp-c-cta-link {
     }
 
     @media #{$mq-lg} {
+         h3 {
+            /* decrease heading size */
+            @include font-size($title-sm-size);
+            line-height: $title-sm-line-height;
+        }
+
         li {
             float: left;
             width: calc(33.3% - (#{$h-grid-lg} - #{math.div($h-grid-lg, 3)}));
@@ -476,6 +482,14 @@ button.mzp-c-cta-link {
 
         .t-cursor img {
             max-height: 38px;
+        }
+    }
+
+    @media #{$mq-xl} {
+        /* bring heading size back up for english only */
+        html[lang^='en'] & h3 {
+            @include font-size($title-md-size);
+            line-height: $title-md-line-height;
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Decrease feature heading font-size for non-EN langs

## Significant changes and points to review

- Decreased font size for all languages on `lg` screens
- Increased font size to original value on `xl` screens for English only.

## Issue / Bugzilla link

#381  (not totally fixed)

## Testing

(run `make preflight` to update your local translations)

http://localhost:8000/pl/

If that doesn't work just copy/paste the long word from prod ;) 