### PR TITLE
Don't attempt UITour for Fx < 136, it's not enabled on fxc (#337)

### DIFF
--- a/media/css/firefox/download/desktop/download.scss
+++ b/media/css/firefox/download/desktop/download.scss
@@ -999,7 +999,7 @@ button.mzp-c-cta-link {
 #protection-report {
     display: none;
 
-    .state-firefox-desktop-70 & {
+    .state-firefox-desktop-136 & {
         display: block;
     }
 }

--- a/media/css/firefox/home.scss
+++ b/media/css/firefox/home.scss
@@ -527,7 +527,7 @@ button.mzp-c-cta-link {
 #protection-report {
     display: none;
 
-    .state-firefox-desktop-70 & {
+    .state-firefox-desktop-136 & {
         display: block;
     }
 }

--- a/media/js/base/fxa-form.es6.js
+++ b/media/js/base/fxa-form.es6.js
@@ -258,7 +258,7 @@ FxaForm.setServiceContext = function () {
     const contextField = form.querySelector('[name="context"]');
     const userVer = parseFloat(Mozilla.Client._getFirefoxVersion());
     const useUITourForFxA =
-        userVer >= 80 && typeof Mozilla.UITour !== 'undefined';
+        userVer >= 136 && typeof Mozilla.UITour !== 'undefined';
 
     if (useUITourForFxA) {
         // context is required for all Firefox desktop clients.

--- a/media/js/base/fxa-link.es6.js
+++ b/media/js/base/fxa-link.es6.js
@@ -90,8 +90,9 @@ FxaLink.init = function (callback) {
     }
 
     const userVer = parseFloat(client._getFirefoxVersion());
+    // FXC doesn't support UITour below 136
     const useUITourForFxA =
-        userVer >= 80 && typeof Mozilla.UITour !== 'undefined';
+        userVer >= 136 && typeof Mozilla.UITour !== 'undefined';
     const fxaSigninLink = document.querySelectorAll('.js-fxa-cta-link');
 
     if (useUITourForFxA) {

--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -229,8 +229,8 @@ if (typeof window.Mozilla === 'undefined') {
 
     /**
      * Use the async mozUITour API of Firefox to retrieve the user's browser info, including the update channel and
-     * accurate, patch-level version number. This API is available on Firefox 35 and later. See
-     * http://bedrock.readthedocs.org/en/latest/uitour.html for details.
+     * accurate, patch-level version number. This API is available on Firefox 35 and later *however* it is
+     * not available on www.firefox.com until 136. See http://bedrock.readthedocs.org/en/latest/uitour.html for details.
      *
      * @param  {Function} callback - callback function to be executed with the Firefox details
      * @return {None}
@@ -324,20 +324,20 @@ if (typeof window.Mozilla === 'undefined') {
      *     - firefox: true if Firefox
      *     - legacy: true if older than FxALastSupported
      *     - mobile: false | android | ios
-     *     - setup: true if Fx >= 29 and logged into *Sync*.
-     *              true if Fx >= 74 and logged into *FxA*.
+     *     - setup: true if Fx >= 136 and logged into *Sync*.
+     *              true if Fx >= 136 and logged into *FxA*.
      *     - browserServices.sync
      *              setup: logged into Sync.
      *              desktopDevices: number of desktop devices synced.
      *              mobileDevices: number of mobile devices synced.
      *              totalDevices: number of total devices synced.
      * Notes:
-     * - Fx < 50 has FxA and UITour support but the API does not return device counts
+     * - Fx < 136 does not have UITour enabled on www.firefox.com
      * - Fx < FxALastSupported accounts.firefox.com does not work
      *     - FxALastSupported is supplied by the FxA team
      *     - these versions are still capable of logging in through the browser
      *     - differentiated because we generally do not give these versions the FxA calls to action (eg. "Create an Account")
-     * - Fx < 29 the mozUITour API is not available, though the user may still be logged in
+     * - Fx < 136 the mozUITour API is not available, though the user may still be logged in
      * - If you're curious, "sync" began with Fx 4.
      *
      * @param  {Function} callback - callback function to be executed with the FxA details
@@ -387,7 +387,7 @@ if (typeof window.Mozilla === 'undefined') {
             details.firefox = true;
             var userVer = parseFloat(Client._getFirefoxVersion());
 
-            if (userVer < 29) {
+            if (userVer < 136) {
                 // UITour not supported
                 details.legacy = true;
                 returnFxaDetails();
@@ -395,6 +395,8 @@ if (typeof window.Mozilla === 'undefined') {
             } else {
                 // UITour supported
                 // still note if it's older than accounts.firefox.com supports
+                // this check isn't as relavant on www.firefox.com because if UITour is enabled, it's more
+                // modern than FxALastSupported. However, I fear removing it.
                 if (userVer < Client.FxALastSupported) {
                     details.legacy = true;
                 }

--- a/media/js/firefox/download/desktop/download.js
+++ b/media/js/firefox/download/desktop/download.js
@@ -200,11 +200,11 @@
     }
 
     if (client.isFirefoxDesktop) {
-        if (client._getFirefoxMajorVersion() >= 70) {
+        if (client._getFirefoxMajorVersion() >= 136) {
             // show "See what Firefox has blocked for you" links.
             document
                 .querySelector('body')
-                .classList.add('state-firefox-desktop-70');
+                .classList.add('state-firefox-desktop-136');
 
             // Intercept link clicks to open about:protections page using UITour.
             Mozilla.UITour.ping(function () {

--- a/media/js/firefox/home.js
+++ b/media/js/firefox/home.js
@@ -81,11 +81,11 @@
     }
 
     if (client.isFirefoxDesktop) {
-        if (client._getFirefoxMajorVersion() >= 70) {
+        if (client._getFirefoxMajorVersion() >= 136) {
             // show "See what Firefox has blocked for you" links.
             document
                 .querySelector('body')
-                .classList.add('state-firefox-desktop-70');
+                .classList.add('state-firefox-desktop-136');
 
             // Intercept link clicks to open about:protections page using UITour.
             Mozilla.UITour.ping(function () {

--- a/tests/unit/spec/base/fxa-form.js
+++ b/tests/unit/spec/base/fxa-form.js
@@ -61,10 +61,10 @@ describe('fxa-form.js', function () {
         });
     });
 
-    it('should configure the form for Firefox desktop < 80', function () {
+    it('should configure the form for Firefox desktop < 136', function () {
         spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
         spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-            '79.0'
+            '135.0'
         );
 
         // Configure Sync for Firefox desktop before initializing attribution.
@@ -87,10 +87,10 @@ describe('fxa-form.js', function () {
         });
     });
 
-    it('should configure the form for Firefox desktop >= 80', function () {
+    it('should configure the form for Firefox desktop >= 136', function () {
         spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
         spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-            '80.0'
+            '136.0'
         );
 
         // Configure Sync for Firefox desktop before initializing attribution.
@@ -192,7 +192,7 @@ describe('fxa-form.js', function () {
     it('should pass through utm parameters from the URL to the form into the UITour', function () {
         spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
         spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-            '80.0'
+            '136.0'
         );
         spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
             function (callback) {
@@ -271,7 +271,7 @@ describe('fxa-form.js', function () {
     it('should pass through utm parameters from the URL to the form into the UITour', function () {
         spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
         spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-            '80.0'
+            '136.0'
         );
         spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
             function (callback) {
@@ -350,7 +350,7 @@ describe('fxa-form.js', function () {
     it('should allow attribution to be skipped', function () {
         spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
         spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-            '80.0'
+            '136.0'
         );
         spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
             function (callback) {
@@ -408,7 +408,7 @@ describe('fxa-form.js', function () {
     it('should allow attribution to be skipped even if init() is never called', function () {
         spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
         spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-            '80.0'
+            '136.0'
         );
         spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
             function (callback) {

--- a/tests/unit/spec/base/fxa-link.js
+++ b/tests/unit/spec/base/fxa-link.js
@@ -32,12 +32,12 @@ describe('fxa-link.js', function () {
             });
         });
 
-        it('should add context param for Firefox desktop >= 80', function () {
+        it('should add context param for Firefox desktop >= 136', function () {
             spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
                 true
             );
             spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '80.0'
+                '136.0'
             );
             FxaLink.init();
             const link = document.querySelector('.js-fxa-cta-link');
@@ -46,12 +46,12 @@ describe('fxa-link.js', function () {
             );
         });
 
-        it('should not add context param for Firefox desktop < 80', function () {
+        it('should not add context param for Firefox desktop < 136', function () {
             spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
                 true
             );
             spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '79.0'
+                '135.0'
             );
             FxaLink.init();
             const link = document.querySelector('.js-fxa-cta-link');
@@ -71,13 +71,13 @@ describe('fxa-link.js', function () {
             );
         });
 
-        it('should use the UITour for Firefox Desktop >= 80', function () {
+        it('should use the UITour for Firefox Desktop >= 136', function () {
             spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
                 true
             );
             spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
             spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '80.0'
+                '136.0'
             );
             return FxaLink.init(() => {
                 const link = document.querySelector('.js-fxa-cta-link');
@@ -97,7 +97,7 @@ describe('fxa-link.js', function () {
             });
         });
 
-        it('does NOT use the UITour for non-FxA domains in Fx >= 80', function () {
+        it('does NOT use the UITour for non-FxA domains in Fx >= 136', function () {
             const link = document.querySelectorAll('.js-fxa-cta-link')[0];
             link.href = 'https://monitor.mozilla.org';
             spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
@@ -105,14 +105,14 @@ describe('fxa-link.js', function () {
             );
             spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
             spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '80.0'
+                '136.0'
             );
             return FxaLink.init(() => {
                 expect(link.getAttribute('role')).toEqual(null);
             });
         });
 
-        it('handles flow and entrypoint parameters on the link in Fx >= 80', function () {
+        it('handles flow and entrypoint parameters on the link in Fx >= 136', function () {
             const link = document.querySelectorAll('.js-fxa-cta-link')[0];
             link.href =
                 'https://accounts.firefox.com/signin?form_type=button&entrypoint=mozilla.org-firefoxnav&' +
@@ -128,7 +128,7 @@ describe('fxa-link.js', function () {
             window.Mozilla.UITour.ping = sinon.stub().callsArg(0);
             spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
             spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '80.0'
+                '136.0'
             );
             return FxaLink.init(() => {
                 const link = document.querySelector('.js-fxa-cta-link');


### PR DESCRIPTION
## One-line summary

UITour doesn't work on www.firefox.com for Firefox versions before 136, stop trying.

## Significant changes and points to review

- updated version number which indicates UITour is available
- half hearted attempt to update the comments too

## Issue / Bugzilla link

Inspired by #337 may fix https://github.com/mozmeao/springfield/issues/323

## Testing

You will need to be in a version of Firefox older than 136. [ESR is available here](https://www.firefox.com/en-US/download/all/desktop-esr/). 

"See your protection report" on the home page should only appear in more recent versions. 