### PR TITLE
Refactor app store URL generation and tracking parameters

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -100,7 +100,7 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             downloadURL.split('?')[1]
         );
     } else {
-        params = [];
+        params = {};
     }
 
     let eventObject = {};
@@ -190,7 +190,10 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             'release'
         );
     } else if (msStoreUrl.test(downloadURL) || msStoreUrl2.test(downloadURL)) {
-        const channel = params.mz_cn ? params.mz_cn : 'unrecognized';
+        const channel =
+            params.mz_cn === 'release' || params.mz_cn === 'beta'
+                ? params.mz_cn
+                : 'unrecognized';
         eventObject = TrackProductDownload.getEventObject(
             'firefox',
             'win',

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -182,40 +182,20 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             androidRelease
         );
     } else if (appStoreURL.test(downloadURL) || iTunesURL.test(downloadURL)) {
-        let iosProduct = 'unrecognized';
-        if (downloadURL.indexOf('/id989804926') !== -1) {
-            iosProduct = 'firefox_mobile';
-        } else if (downloadURL.indexOf('/id1055677337') !== -1) {
-            iosProduct = 'focus';
-        } else if (downloadURL.indexOf('/id1073435754') !== -1) {
-            iosProduct = 'klar';
-        } else if (downloadURL.indexOf('/id309601447') !== -1) {
-            iosProduct = 'pocket';
-        } else if (downloadURL.indexOf('/id1489407738') !== -1) {
-            iosProduct = 'vpn';
-        }
-
-        // Apple App Store
+        const storeProduct = params.mz_pr ? params.mz_pr : 'unrecognized';
         eventObject = TrackProductDownload.getEventObject(
-            iosProduct,
+            storeProduct,
             'ios',
             'store',
             'release'
         );
     } else if (msStoreUrl.test(downloadURL) || msStoreUrl2.test(downloadURL)) {
-        let channel = 'unrecognized';
-        if (downloadURL.indexOf('9nzvdkpmr9rd') !== -1) {
-            channel = 'release';
-        } else if (downloadURL.indexOf('9nzw26frndln') !== -1) {
-            channel = 'beta';
-        }
-
-        // MS Store
+        const storeProduct = params.mz_pr ? params.mz_pr : 'unrecognized';
         eventObject = TrackProductDownload.getEventObject(
-            'firefox',
+            storeProduct,
             'win',
             'store',
-            channel
+            'release'
         );
     }
 

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -182,20 +182,20 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             androidRelease
         );
     } else if (appStoreURL.test(downloadURL) || iTunesURL.test(downloadURL)) {
-        const storeProduct = params.mz_pr ? params.mz_pr : 'unrecognized';
+        const iosProduct = params.mz_pr ? params.mz_pr : 'unrecognized';
         eventObject = TrackProductDownload.getEventObject(
-            storeProduct,
+            iosProduct,
             'ios',
             'store',
             'release'
         );
     } else if (msStoreUrl.test(downloadURL) || msStoreUrl2.test(downloadURL)) {
-        const storeProduct = params.mz_pr ? params.mz_pr : 'unrecognized';
+        const channel = params.mz_cn ? params.mz_cn : 'unrecognized';
         eventObject = TrackProductDownload.getEventObject(
-            storeProduct,
+            'firefox',
             'win',
             'store',
-            'release'
+            channel
         );
     }
 

--- a/springfield/firefox/templates/firefox/all/mobile.html
+++ b/springfield/firefox/templates/firefox/all/mobile.html
@@ -16,7 +16,8 @@
   {% set qr_url = android_nightly_url %}
   {% set android_url = android_nightly_url %}
 {% else %}
-  {% set qr_url = app_store_url('firefox', 'firefox-all') %}
+  {# This URL is hard coded so the user that scans it gets redirected to the right app store URL for their device and locale #}
+  {% set qr_url = "https://www.firefox.com/browsers/mobile/app/?product=firefox&campaign=firefox-all" %}
 {% endif %}
 
 <div class="c-mobile">

--- a/springfield/firefox/templates/firefox/all/mobile.html
+++ b/springfield/firefox/templates/firefox/all/mobile.html
@@ -16,7 +16,7 @@
   {% set qr_url = android_nightly_url %}
   {% set android_url = android_nightly_url %}
 {% else %}
-  {% set qr_url ="https://www.firefox.com/browsers/mobile/app/?product=firefox&campaign=firefox-all" %}
+  {% set qr_url = app_store_url('firefox', 'firefox-all') %}
 {% endif %}
 
 <div class="c-mobile">

--- a/springfield/firefox/templates/firefox/browsers/mobile/includes/s2d-ios.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/includes/s2d-ios.html
@@ -6,7 +6,7 @@
 
 {# Send-to-device widget for Firefox for iOS #}
 
-{% set qr_url = "https://apps.apple.com/app/apple-store/id989804926?pt=373246&ct=firefox-browsers-mobile-ios&mt=8" %}
+{% set qr_url = app_store_url('firefox', 'firefox-browsers-mobile-ios') %}
 
 <div class="c-inline-form">
   <h2 class="c-inline-form-title">{{ ftl('mobile-ios-get-firefox-for') }}</h2>

--- a/springfield/firefox/templates/firefox/browsers/mobile/includes/s2d-ios.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/includes/s2d-ios.html
@@ -6,7 +6,8 @@
 
 {# Send-to-device widget for Firefox for iOS #}
 
-{% set qr_url = app_store_url('firefox', 'firefox-browsers-mobile-ios') %}
+{# This URL is hard coded so it doesn't include the locale, and Apple will redirect to the right app store URL for the user's device and locale #}
+{% set qr_url = "https://apps.apple.com/app/apple-store/id989804926?pt=373246&ct=firefox-browsers-mobile-ios&mt=8&mz_pr=firefox_mobile" %}
 
 <div class="c-inline-form">
   <h2 class="c-inline-form-title">{{ ftl('mobile-ios-get-firefox-for') }}</h2>

--- a/springfield/firefox/templatetags/misc.py
+++ b/springfield/firefox/templatetags/misc.py
@@ -466,7 +466,18 @@ def app_store_url(ctx, product, campaign=None):
     """Returns a localised app store URL for a given product"""
     locale = getattr(ctx["request"], "locale", "en-US")
     countries = settings.APPLE_APPSTORE_COUNTRY_MAP
-    params = "?pt=373246&ct={cmp}&mt=8"
+
+    # Map product names to tracking product codes
+    product_mapping = {
+        "firefox": "firefox_mobile",
+        "firefox_beta": "firefox_mobile",
+        "firefox_nightly": "firefox_mobile",
+        "focus": "focus",
+        "klar": "klar",
+        "vpn": "vpn",
+    }
+
+    tracking_product = product_mapping.get(product, "unrecognized")
 
     if product == "focus" and locale == "de":
         base_url = getattr(settings, "APPLE_APPSTORE_KLAR_LINK")
@@ -474,7 +485,11 @@ def app_store_url(ctx, product, campaign=None):
         base_url = getattr(settings, f"APPLE_APPSTORE_{product.upper()}_LINK")
 
     if campaign:
-        base_url = base_url + params.format(cmp=campaign)
+        params = "?mz_pr={tp}&pt=373246&ct={cmp}&mt=8"
+        base_url = base_url + params.format(tp=tracking_product, cmp=campaign)
+    else:
+        params = "?mz_pr={tp}"
+        base_url = base_url + params.format(tp=tracking_product)
 
     if locale in countries:
         return base_url.format(country=countries[locale])

--- a/springfield/firefox/templatetags/misc.py
+++ b/springfield/firefox/templatetags/misc.py
@@ -528,6 +528,16 @@ def ms_store_url(ctx, product="firefox", mode="mini", campaign=None, handler=Non
     See https://apps.microsoft.com/badge for details.
     """
 
+    channel_mapping = {
+        "firefox": "release",
+        "firefox_beta": "beta",
+    }
+
+    channel = channel_mapping.get(product, "unrecognized")
+
+    if product not in channel_mapping:
+        product = "firefox"
+
     if handler == "ms-windows-store":
         base_url = getattr(settings, f"MICROSOFT_WINDOWS_STORE_{product.upper()}_DIRECT_LINK")
     else:
@@ -536,6 +546,7 @@ def ms_store_url(ctx, product="firefox", mode="mini", campaign=None, handler=Non
     params = {
         "mode": mode,
         "cid": campaign,
+        "mz_cn": channel,
     }
 
     return urlparams(base_url, **params)

--- a/springfield/firefox/tests/test_helper_misc.py
+++ b/springfield/firefox/tests/test_helper_misc.py
@@ -777,34 +777,38 @@ class TestMSStoreURL(TestCase):
 
     def test_firefox_release_ms_store_url(self):
         """should return a MS Store URL for Firefox release channel"""
-        assert self._render(product="firefox") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=mini"
+        assert self._render(product="firefox") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=mini&amp;mz_cn=release"
 
     def test_firefox_beta_ms_store_url(self):
         """should return a MS Store URL for Firefox Beta channel"""
-        assert self._render(product="firefox_beta") == "https://apps.microsoft.com/detail/9nzw26frndln?mode=mini"
+        assert self._render(product="firefox_beta") == "https://apps.microsoft.com/detail/9nzw26frndln?mode=mini&amp;mz_cn=beta"
 
     def test_firefox_ms_store_url_launch_mode(self):
         """should return a MS Store URL including different launch mode parameters"""
-        assert self._render(product="firefox", mode="full") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=full"
-        assert self._render(product="firefox", mode="direct") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=direct"
+        assert self._render(product="firefox", mode="full") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=full&amp;mz_cn=release"
+        assert self._render(product="firefox", mode="direct") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=direct&amp;mz_cn=release"
 
     def test_firefox_ms_store_url_campaign(self):
         """should return a MS Store URL including campaign parameters"""
         assert (
             self._render(product="firefox", campaign="test-firefox-home")
-            == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=mini&amp;cid=test-firefox-home"
+            == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=mini&amp;cid=test-firefox-home&amp;mz_cn=release"
         )
 
     def test_firefox_ms_store_url_protocol_handler(self):
         """should return a MS Store URL including campaign parameters"""
         assert (
             self._render(product="firefox", campaign="test-firefox-home", handler="ms-windows-store")
-            == "ms-windows-store://pdp/?productid=9nzvdkpmr9rd&amp;mode=mini&amp;cid=test-firefox-home"
+            == "ms-windows-store://pdp/?productid=9nzvdkpmr9rd&amp;mode=mini&amp;cid=test-firefox-home&amp;mz_cn=release"
         )
         assert (
             self._render(product="firefox_beta", campaign="test-firefox-home", handler="ms-windows-store")
-            == "ms-windows-store://pdp/?productid=9nzw26frndln&amp;mode=mini&amp;cid=test-firefox-home"
+            == "ms-windows-store://pdp/?productid=9nzw26frndln&amp;mode=mini&amp;cid=test-firefox-home&amp;mz_cn=beta"
         )
+
+    def test_firefox_unknown_product_ms_store_url(self):
+        """should return a MS Store URL with unrecognized channel for unknown product"""
+        assert self._render(product="unknown_product") == "https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=mini&amp;mz_cn=unrecognized"
 
 
 class TestLangShort(TestCase):

--- a/springfield/firefox/tests/test_helper_misc.py
+++ b/springfield/firefox/tests/test_helper_misc.py
@@ -637,62 +637,62 @@ class TestAppStoreURL(TestCase):
 
     def test_firefox_app_store_url_no_locale(self):
         """No locale, fallback to default URL"""
-        assert self._render("firefox", "", "") == "https://apps.apple.com/app/apple-store/id989804926"
+        assert self._render("firefox", "", "") == "https://apps.apple.com/app/apple-store/id989804926?mz_pr=firefox_mobile"
 
     def test_firefox_app_store_url_default(self):
         """should fallback to default URL"""
-        assert self._render("firefox", "", "ar") == "https://apps.apple.com/app/apple-store/id989804926"
-        assert self._render("firefox", "", "zu") == "https://apps.apple.com/app/apple-store/id989804926"
+        assert self._render("firefox", "", "ar") == "https://apps.apple.com/app/apple-store/id989804926?mz_pr=firefox_mobile"
+        assert self._render("firefox", "", "zu") == "https://apps.apple.com/app/apple-store/id989804926?mz_pr=firefox_mobile"
 
     def test_firefox_app_store_url_localized(self):
         """should return localized URL"""
-        assert self._render("firefox", "", "en-US") == "https://apps.apple.com/us/app/apple-store/id989804926"
-        assert self._render("firefox", "", "es-ES") == "https://apps.apple.com/es/app/apple-store/id989804926"
-        assert self._render("firefox", "", "de") == "https://apps.apple.com/de/app/apple-store/id989804926"
+        assert self._render("firefox", "", "en-US") == "https://apps.apple.com/us/app/apple-store/id989804926?mz_pr=firefox_mobile"
+        assert self._render("firefox", "", "es-ES") == "https://apps.apple.com/es/app/apple-store/id989804926?mz_pr=firefox_mobile"
+        assert self._render("firefox", "", "de") == "https://apps.apple.com/de/app/apple-store/id989804926?mz_pr=firefox_mobile"
 
     def test_firefox_app_store_url_localized_campaign(self):
         """should return localized URL with additional campaign parameters"""
         assert (
             self._render("firefox", "firefox-home", "en-US")
-            == "https://apps.apple.com/us/app/apple-store/id989804926?pt=373246&amp;ct=firefox-home&amp;mt=8"
+            == "https://apps.apple.com/us/app/apple-store/id989804926?mz_pr=firefox_mobile&amp;pt=373246&amp;ct=firefox-home&amp;mt=8"
         )
         assert (
             self._render("firefox", "firefox-home", "es-ES")
-            == "https://apps.apple.com/es/app/apple-store/id989804926?pt=373246&amp;ct=firefox-home&amp;mt=8"
+            == "https://apps.apple.com/es/app/apple-store/id989804926?mz_pr=firefox_mobile&amp;pt=373246&amp;ct=firefox-home&amp;mt=8"
         )
         assert (
             self._render("firefox", "firefox-home", "de")
-            == "https://apps.apple.com/de/app/apple-store/id989804926?pt=373246&amp;ct=firefox-home&amp;mt=8"
+            == "https://apps.apple.com/de/app/apple-store/id989804926?mz_pr=firefox_mobile&amp;pt=373246&amp;ct=firefox-home&amp;mt=8"
         )
 
     def test_focus_app_store_url_localized_campaign(self):
         """should return localized URL with additional campaign parameters"""
         assert (
             self._render("focus", "firefox-home", "en-US")
-            == "https://apps.apple.com/us/app/apple-store/id1055677337?pt=373246&amp;ct=firefox-home&amp;mt=8"
+            == "https://apps.apple.com/us/app/apple-store/id1055677337?mz_pr=focus&amp;pt=373246&amp;ct=firefox-home&amp;mt=8"
         )
         assert (
             self._render("focus", "firefox-home", "es-ES")
-            == "https://apps.apple.com/es/app/apple-store/id1055677337?pt=373246&amp;ct=firefox-home&amp;mt=8"
+            == "https://apps.apple.com/es/app/apple-store/id1055677337?mz_pr=focus&amp;pt=373246&amp;ct=firefox-home&amp;mt=8"
         )
         assert (
             self._render("focus", "firefox-home", "de")
-            == "https://apps.apple.com/de/app/apple-store/id1073435754?pt=373246&amp;ct=firefox-home&amp;mt=8"
+            == "https://apps.apple.com/de/app/apple-store/id1073435754?mz_pr=focus&amp;pt=373246&amp;ct=firefox-home&amp;mt=8"
         )
 
     def test_vpn_app_store_url_localized_campaign(self):
         """should return localized URL with additional campaign parameters"""
         assert (
             self._render("vpn", "vpn-landing-page", "en-US")
-            == "https://apps.apple.com/us/app/apple-store/id1489407738?pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
+            == "https://apps.apple.com/us/app/apple-store/id1489407738?mz_pr=vpn&amp;pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
         )
         assert (
             self._render("vpn", "vpn-landing-page", "es-ES")
-            == "https://apps.apple.com/es/app/apple-store/id1489407738?pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
+            == "https://apps.apple.com/es/app/apple-store/id1489407738?mz_pr=vpn&amp;pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
         )
         assert (
             self._render("vpn", "vpn-landing-page", "de")
-            == "https://apps.apple.com/de/app/apple-store/id1489407738?pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
+            == "https://apps.apple.com/de/app/apple-store/id1489407738?mz_pr=vpn&amp;pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
         )
 
 

--- a/springfield/redirects/util.py
+++ b/springfield/redirects/util.py
@@ -92,15 +92,27 @@ def mobile_app_redirector(request, product, campaign):
     android_re = re.compile(r"\bAndroid\b", flags=re.I)
     value = request.headers.get("User-Agent", "")
 
+    # Map product names to tracking product codes
+    product_mapping = {
+        "firefox": "firefox_mobile",
+        "firefox_beta": "firefox_mobile",
+        "firefox_nightly": "firefox_mobile",
+        "focus": "focus",
+        "klar": "klar",
+        "vpn": "vpn",
+    }
+
+    tracking_product = product_mapping.get(product, "unrecognized")
+
     if android_re.search(value):
         base_url = getattr(settings, f"GOOGLE_PLAY_{product.upper()}_LINK")
         params = "&referrer=utm_source%3Dwww.firefox.com%26utm_medium%3Dreferral%26utm_campaign%3D{cmp}"
     else:
         base_url = getattr(settings, f"APPLE_APPSTORE_{product.upper()}_LINK").replace("/{country}/", "/")
-        params = "?pt=373246&ct={cmp}&mt=8"
+        params = "?pt=373246&ct={cmp}&mt=8&mz_pr={tp}"
 
     if campaign:
-        return base_url + params.format(cmp=campaign)
+        return base_url + params.format(cmp=campaign, tp=tracking_product)
     else:
         return base_url
 

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -137,7 +137,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify product for Focus in the App Store', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://itunes.apple.com/{country}/app/firefox-focus-privacy-browser/id1055677337'
+            'https://itunes.apple.com/{country}/app/firefox-focus-privacy-browser/id1055677337?mz_pr=focus'
         );
         expect(testEvent['product']).toBe('focus');
     });
@@ -149,7 +149,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify product for Klar in the App Store', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://itunes.apple.com/{country}/app/klar-by-firefox/id1073435754'
+            'https://itunes.apple.com/{country}/app/klar-by-firefox/id1073435754?mz_pr=klar'
         );
         expect(testEvent['product']).toBe('klar');
     });
@@ -337,11 +337,11 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         expect(testEvent['product']).toBe('firefox');
         expect(testEvent['platform']).toBe('win');
         expect(testEvent['method']).toBe('store');
-        expect(testEvent['release_channel']).toBe('release');
+        expect(testEvent['release_channel']).toBe('unrecognized');
     });
     it('should identify Firefox Beta in the MS Store', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://apps.microsoft.com/detail/9nzw26frndln?mode=direct&cid=firefox-all'
+            'https://apps.microsoft.com/detail/9nzw26frndln?mode=direct&cid=firefox-all&mz_cn=beta'
         );
         expect(testEvent['product']).toBe('firefox');
         expect(testEvent['platform']).toBe('win');
@@ -350,7 +350,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify Firefox in the MS Store using ms-windows-store protocol handler', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'ms-windows-store://pdp/?productid=9nzvdkpmr9rd'
+            'ms-windows-store://pdp/?productid=9nzvdkpmr9rd&mz_cn=release'
         );
         expect(testEvent['product']).toBe('firefox');
         expect(testEvent['platform']).toBe('win');
@@ -359,7 +359,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify Firefox Beta in the MS Store using ms-windows-store protocol handler', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'ms-windows-store://pdp/?productid=9nzw26frndln'
+            'ms-windows-store://pdp/?productid=9nzw26frndln&mz_cn=beta'
         );
         expect(testEvent['product']).toBe('firefox');
         expect(testEvent['platform']).toBe('win');
@@ -384,14 +384,14 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         expect(testEvent['method']).toBe('store');
         expect(testEvent['release_channel']).toBe('beta');
     });
-    it('should fall back to product ID detection when mz_cn parameter is not present', function () {
+    it('should use unrecognized channel when mz_cn parameter is not present', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
             'https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=direct&cid=firefox-home'
         );
         expect(testEvent['product']).toBe('firefox');
         expect(testEvent['platform']).toBe('win');
         expect(testEvent['method']).toBe('store');
-        expect(testEvent['release_channel']).toBe('release');
+        expect(testEvent['release_channel']).toBe('unrecognized');
     });
     it('should use unrecognized channel when mz_cn parameter has unknown value', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
@@ -412,7 +412,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify Mozilla VPN for iOS', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://apps.apple.com/us/app/apple-store/id1489407738?pt=373246&ct=vpn-landing-page&mt=8'
+            'https://apps.apple.com/us/app/apple-store/id1489407738?pt=373246&ct=vpn-landing-page&mt=8&mz_pr=vpn'
         );
         expect(testEvent['product']).toBe('vpn');
         expect(testEvent['platform']).toBe('ios');

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -123,9 +123,9 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         );
         expect(testEvent['product']).toBe('firefox');
     });
-    it('should identify product for Firefox in the App Store', function () {
+    it('should identify product for Firefox in the App Store using mz_pr parameter', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926?mz_pr=firefox_mobile'
         );
         expect(testEvent['product']).toBe('firefox_mobile');
     });
@@ -134,18 +134,6 @@ describe('TrackProductDownload.getEventFromUrl', function () {
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
         );
         expect(testEvent['product']).toBe('firefox_mobile');
-    });
-    it('should identify product for Pocket in the App Store', function () {
-        const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://itunes.apple.com/{country}/app/pocket-save-read-grow/id309601447'
-        );
-        expect(testEvent['product']).toBe('pocket');
-    });
-    it('should identify product for Pocket in the Play Store', function () {
-        const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro'
-        );
-        expect(testEvent['product']).toBe('pocket');
     });
     it('should identify product for Focus in the App Store', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
@@ -216,7 +204,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify platform for Firefox in the App Store', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926?mz_pr=firefox_mobile'
         );
         expect(testEvent['platform']).toBe('ios');
     });
@@ -293,9 +281,9 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         );
         expect(testEvent['release_channel']).toBe('esr115');
     });
-    it('should identify release_channel for Firefox iOS', function () {
+    it('should identify release_channel for Firefox iOS using mz_pr parameter', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
-            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926?mz_pr=firefox_mobile'
         );
         expect(testEvent['release_channel']).toBe('release');
     });

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -366,6 +366,42 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         expect(testEvent['method']).toBe('store');
         expect(testEvent['release_channel']).toBe('beta');
     });
+    it('should identify Firefox release channel using mz_cn parameter', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=direct&cid=firefox-home&mz_cn=release'
+        );
+        expect(testEvent['product']).toBe('firefox');
+        expect(testEvent['platform']).toBe('win');
+        expect(testEvent['method']).toBe('store');
+        expect(testEvent['release_channel']).toBe('release');
+    });
+    it('should identify Firefox beta channel using mz_cn parameter', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://apps.microsoft.com/detail/9nzw26frndln?mode=direct&cid=firefox-all&mz_cn=beta'
+        );
+        expect(testEvent['product']).toBe('firefox');
+        expect(testEvent['platform']).toBe('win');
+        expect(testEvent['method']).toBe('store');
+        expect(testEvent['release_channel']).toBe('beta');
+    });
+    it('should fall back to product ID detection when mz_cn parameter is not present', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=direct&cid=firefox-home'
+        );
+        expect(testEvent['product']).toBe('firefox');
+        expect(testEvent['platform']).toBe('win');
+        expect(testEvent['method']).toBe('store');
+        expect(testEvent['release_channel']).toBe('release');
+    });
+    it('should use unrecognized channel when mz_cn parameter has unknown value', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://apps.microsoft.com/detail/9nzvdkpmr9rd?mode=direct&cid=firefox-home&mz_cn=unknown'
+        );
+        expect(testEvent['product']).toBe('firefox');
+        expect(testEvent['platform']).toBe('win');
+        expect(testEvent['method']).toBe('store');
+        expect(testEvent['release_channel']).toBe('unrecognized');
+    });
     it('should identify Mozilla VPN for Android', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox.vpn&referrer=utm_source%3Dwww.firefox.com%26utm_medium%3Dreferral%26utm_campaign%3Dvpn-landing-page&hl=en'


### PR DESCRIPTION
- This is a fix for https://github.com/mozilla/bedrock/issues/14079
- Updated the app_store_url function to include a mapping for product names to tracking codes.
- Modified the mobile_app_redirector to append tracking parameters to the app store URLs.
- Adjusted the datalayer-productdownload logic to utilize the new tracking parameters.
- Updated tests to reflect changes in URL structure and ensure correct tracking for various products.

## One-line summary

Simplify product download tracking by replacing hardcoded app IDs with query string parameters (mz_pr) for iOS and Microsoft Store URLs (keeping existing Android Play Store tracking logic).


## Significant changes and points to review

- Updated logic in datalayer-productdownload.es6.js to use `mz_pr` parameter for App Store and Microsoft Store URLs, inferring platform from domain (`ios` for App Store, `win` for Microsoft Store).
- Updated `app_store_url` in misc.py to include `mz_pr` parameter
- Updated `mobile_app_redirector` in util.py to include `mz_pr` parameter
- Replaced hardcoded App Store URLs with `app_store_url` helper in s2d-ios.html and mobile.html
- Android Play Store tracking remains unchanged, using existing id parameter logic
- URLs without `mz_pr` parameter are tracked as "unrecognized" product
- Using `firefox_mobile` for all mobile products, instead of separate names, for consistency with past tracking

## Issue / Bugzilla link

Related to https://github.com/mozilla/bedrock/issues/14079 to apply first to Springfield and then to Bedrock, per @stevejalim 

## Testing

[ ] Verify App Store URLs and Microsoft Store URLs include correct `mz_pr` parameter
[ ] Test QR code generation on /en-US/download/all/mobile-release/
[ ] Test send-to-device functionality on /en-US/browsers/mobile/ios/
