### PR TITLE
Run l10n cleanup cron in even months

### DIFF
--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -1,7 +1,7 @@
 name: Bimonthly l10n cleanup reminder
 on:
   schedule:
-    - cron: 0 09 14 */2 *
+    - cron: 0 10 15 */2 *
 
 jobs:
   create_issue:

--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -1,7 +1,7 @@
 name: Bimonthly l10n cleanup reminder
 on:
   schedule:
-    - cron: 0 10 15 */2 *
+    - cron: 0 10 15 2-12/2 *
 
 jobs:
   create_issue:

--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -36,7 +36,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: "[bot] Remove obsolete l10n strings and ftl files"
           ASSIGNEES:
-          LABELS: L10N,Frontend
+          LABELS: L10n,Frontend
           BODY: |
             ### Remove obsolete strings
 

--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -48,13 +48,13 @@ jobs:
 
             ### Remove obsolete ftl files
 
-            Compare the files in /l10n/en-US/ to the /en/ folder in the www-l10n repo and remove
-            files from www-l10n that no longer exist in springfield.
+            Compare the files in /l10n/en-US/ to the /en/ folder in the www-firefox-l10n repo
+            and remove files from www-firefox-l10n that no longer exist in springfield.
 
             If you have both repos installed and up to date you can run this command:
             `diff -r www-firefox-l10n/en springfield/l10n/en | grep ".ftl"`
 
             - [ ] Remove files
-            - [ ] Remove references in www-l10n/configs/pontoon.toml
+            - [ ] Remove references in www-firefox-l10n/configs/pontoon.toml
           PINNED: false
           CLOSE_PREVIOUS: true


### PR DESCRIPTION
## One-line summary

Open obsolete ftl reminders on different schedule to wmo (and refer the correct l10n repo).

## Significant changes and points to review

Bedrock is run on odd months, so this aims to spread the workload/pings a bit.

- [x] Also: The workflow needs its "L10N" label created, it will be failing until that happens. (See link below for the error.)

## Issue / Bugzilla link

[/actions/runs/16262675495/job/45911310377#step:2:50](https://github.com/mozmeao/springfield/actions/runs/16262675495/job/45911310377#step:2:50)

## Testing
