### PR TITLE
fix homepage release section rtl and mobile styles (fix #389)

### DIFF
--- a/media/css/firefox/home.scss
+++ b/media/css/firefox/home.scss
@@ -440,7 +440,7 @@ button.mzp-c-cta-link {
         text-align: center;
         position: absolute;
         top: 0;
-        left: 0;
+        width: auto;
         max-height: $layout-sm;
     }
 
@@ -450,9 +450,7 @@ button.mzp-c-cta-link {
 
     @media #{$mq-md} {
         img {
-            float: left;
-            margin-left: 0;
-            margin-right: $layout-sm;
+            @include bidi(((margin-left, 0, $layout-sm), (margin-right, $layout-sm, 0)));
         }
     }
 
@@ -464,7 +462,7 @@ button.mzp-c-cta-link {
         }
 
         li {
-            float: left;
+            @include bidi(((float, left, right),));
             width: calc(33.3% - (#{$h-grid-lg} - #{math.div($h-grid-lg, 3)}));
             margin-bottom: 0;
             padding-top: 54px + $spacing-xl;


### PR DESCRIPTION
## One-line summary

This PR fixes the homepage release section style bugs.

## Significant changes and points to review

- rtl image horizontal alignment
- mobile image alignment

<img width="922" height="1792" alt="mobile" src="https://github.com/user-attachments/assets/727af1ab-3131-416f-94fe-47f5a51eafee" />


## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/389

## Testing

http://localhost:8000/en-US/
http://localhost:8000/ar/

