### PR TITLE
hide banner close button when JS is disabled (fix #226)

### DIFF
--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -52,3 +52,10 @@ html[data-pencil-banner-closed="true"] {
         display: none;
     }
 }
+
+// No JS
+.no-js {
+    .m24-pencil-banner-close {
+        display: none;
+    }
+}


### PR DESCRIPTION
## One-line summary

This PR hide banner close button when JS is disabled.

## Significant changes and points to review

Pencil banner with JS is diabled

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/226

## Testing

- disable browser JS
- http://localhost:8000/en-US/