### PR TITLE
Enable writing webpack files to disk in dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,7 +105,8 @@ module.exports = {
         hot: false,
         static: false,
         devMiddleware: {
-            index: false // specify to enable root proxy'ing
+            index: false, // specify to enable root proxy'ing
+            writeToDisk: true // Write files to disk so Django can serve them
         },
         proxy: [
             {


### PR DESCRIPTION
This fixes an issue where `npm start` wasn't building/re-building CSS files in dev mode, sometimes causing CSS assets to return 404s or preventing changes from getting written to disk after re-building in watch mode

## One-line summary

Sets `devServer.devMiddleware.writeToDisk = true` in the webpack config, enabling CSS files to be written to disk in dev mode.

## Significant changes and points to review

This only affects development, and writes files to the disk that were otherwise only stored in memory. I've only tested this locally, not in Docker, but I don't anticipate that it would change anything in Docker.

## Issue / Bugzilla link

None

## Testing

Run `npm start` to start the app, then make a CSS change. The CSS should get re-built and written to disk. Refresh in the browser to confirm that the changes worked.