### PR TITLE
Fixup failing tests for features/translate changeset

### DIFF
--- a/springfield/firefox/templates/firefox/features/translate.html
+++ b/springfield/firefox/templates/firefox/features/translate.html
@@ -6,10 +6,6 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% block js %}
-  {{ js_bundle('firefox_features_translate') }}
-{% endblock %}
-
 {% block page_desc %}{{ ftl('features-translate-firefox-translations-is-a-built-in-v2') }}{% endblock %}
 
 {% block article_title_short %}{{ ftl('features-translate-translate-the-web') }}{% endblock %}
@@ -88,4 +84,9 @@
 
 <h2>{{ ftl('features-translate-firefox-speaks-your-language') }}</h2>
 <p>{{ ftl('features-translate-the-firefox-translations-feature-v2', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox'))) }}</p>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_features_translate') }}
 {% endblock %}

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -708,10 +708,7 @@ def firefox_features_translate(request):
 
     names = get_translations_native_names(sorted(translate_langs))
 
-    context = {
-        "context_test": names,
-        "translate_langs": translate_langs
-    }
+    context = {"context_test": names, "translate_langs": translate_langs}
 
     template_name = "firefox/features/translate.html"
 


### PR DESCRIPTION
## One-line summary

Removed JS from base template started failing Fx vs. non-Fx CTA tests in integration, adding `super()` to load it back. Also a formatting fix for linting failing before unit tests.

## Significant changes and points to review

Moving the JS block after the markup is loaded while at it, as is the norm around here not to block content, should not have impact on the CLDR experience as that's triggered on DOM ready now — however should in general guarantee the DOM elements would be available at that point (probably enabling further simplification of the JS to not wait for readystates at all).

Ruff formatting wrinkle fails all subsequent CI runs now after being merged on main. That line is probably about to be changed/simplified anyway so I just had ruff reformat it to its liking.

## Issue / Bugzilla link

[/actions/runs/16841344929](https://github.com/mozmeao/springfield/actions/runs/16841344929) ❌ 
[/actions/runs/16841537751](https://github.com/mozmeao/springfield/actions/runs/16841537751) ❌ 
#405 followup

## Testing

[/actions/runs/16875321818](https://github.com/mozmeao/springfield/actions/runs/16875321818) 💚 
[/actions/runs/16877229526](https://github.com/mozmeao/springfield/actions/runs/16877229526) 💚 