### PR TITLE
Fix typeof check for MzpSupports object in navigation Fix #380

### DIFF
--- a/media/js/base/protocol/navigation.es6.js
+++ b/media/js/base/protocol/navigation.es6.js
@@ -225,7 +225,7 @@ MzpNavigation.onClick = (e) => {
 MzpNavigation.menuButtonVisible = (callback) => {
     // check if Intersection observer is supported
     if (
-        window.MzpSupports !== 'undefined' &&
+        typeof window.MzpSupports !== 'undefined' &&
         window.MzpSupports.intersectionObserver
     ) {
         const observer = new IntersectionObserver(
@@ -249,7 +249,7 @@ MzpNavigation.menuButtonVisible = (callback) => {
  */
 MzpNavigation.setAria = () => {
     if (
-        window.MzpSupports !== 'undefined' &&
+        typeof window.MzpSupports !== 'undefined' &&
         window.MzpSupports.intersectionObserver
     ) {
         MzpNavigation.menuButtonVisible((isVisible, menuButton) => {


### PR DESCRIPTION
## One-line summary

Changed string literal comparison to typeof check to correctly determine if window.MzpSupports object is defined.

## Issue / Bugzilla link

Fix #380

## Testing

