### PR TITLE
Fix result contamination in Playwright when looping pages

### DIFF
--- a/tests/playwright/specs/products/firefox/firefox-features.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-features.spec.js
@@ -21,7 +21,7 @@ const slugs = [
 
 slugs.forEach((slug) => {
     test.describe(
-        `${url}/${slug} page`,
+        `${url}${slug} page`,
         {
             tag: '@firefox'
         },

--- a/tests/playwright/specs/products/firefox/firefox-features.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-features.spec.js
@@ -19,13 +19,13 @@ const slugs = [
     'translate'
 ];
 
-test.describe(
-    `${url} page`,
-    {
-        tag: '@firefox'
-    },
-    () => {
-        for (const slug of slugs) {
+slugs.forEach((slug) => {
+    test.describe(
+        `${url}/${slug} page`,
+        {
+            tag: '@firefox'
+        },
+        () => {
             test.beforeEach(async ({ page, browserName }) => {
                 await openPage(url + `${slug}/`, page, browserName);
             });
@@ -42,5 +42,5 @@ test.describe(
                 }
             });
         }
-    }
-);
+    );
+});


### PR DESCRIPTION
## One-line summary

Makes finding a test fail culprit easier by getting rid of false positives.

## Significant changes and points to review

Moves the loop outside of describing the test, to make that actually distinct tests.

## Issue / Bugzilla link

Fixes #412

## Testing

_(Before:)_

> <img width="1130" height="734" alt="Screenshot 2025-08-11 at 12 36 33" src="https://github.com/user-attachments/assets/2546c6ca-26f3-4a0a-befa-433867494704" />

_(After:)_

> <img width="1130" height="730" alt="Screenshot 2025-08-11 at 12 40 50" src="https://github.com/user-attachments/assets/2a8637f1-52b6-40c6-bbea-0c08767e768b" />