### PR TITLE
Fixup fx/landing asset paths

### DIFF
--- a/media/css/firefox/landing/index.scss
+++ b/media/css/firefox/landing/index.scss
@@ -386,11 +386,11 @@ main {
 
             &,
             .android & {
-                @include at2x('/media/img/firefox/new/desktop/android.png', contain);
+                @include at2x('/media/img/firefox/download/desktop/android.png', contain);
             }
 
             .ios & {
-                @include at2x('/media/img/firefox/new/desktop/ios.png', contain);
+                @include at2x('/media/img/firefox/download/desktop/ios.png', contain);
             }
         }
 
@@ -428,7 +428,7 @@ main {
 
 .c-desktop a {
     @include text-title-xs;
-    background-image: url('/media/img/firefox/new/desktop/mobile-arrow.svg');
+    background-image: url('/media/img/firefox/download/desktop/mobile-arrow.svg');
     background-position: bottom center;
     background-repeat: no-repeat;
     color: $color-purple-50;


### PR DESCRIPTION
## One-line summary

> "The file 'img/firefox/new/desktop/android.png' could not be found"

(et al.)

## Significant changes and points to review

Maybe we should look into having the strict builds in CI somehow before merging to verify such things. (I've def been bitten by that a few times already.)

```
3.171     cache_name = self.clean_name(self.hashed_name(name))
3.171                                  ~~~~~~~~~~~~~~~~^^^^^^
3.171   File "/venv/lib/python3.13/site-packages/django/contrib/staticfiles/storage.py", line 144, in hashed_name
3.171     raise ValueError(
3.171         "The file '%s' could not be found with %r." % (filename, self)
3.171     )
3.171 ValueError: The file 'img/firefox/new/desktop/android.png' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at …>.
------
failed to solve: process "/bin/sh -c honcho run --env docker/envfiles/prod.env docker/bin/build_staticfiles.sh" did not complete successfully: exit code: 1
make: *** [Makefile:149: build-ci] Error 1
```

## Issue / Bugzilla link

[/actions/runs/16950752101/job/48042793590](https://github.com/mozmeao/springfield/actions/runs/16950752101/job/48042793590) ❌ 

## Testing

`make build-prod`