### PR TITLE
Silence SASS deprecation warnings for future major versions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,14 @@ module.exports = {
                             url: false
                         }
                     },
-                    'sass-loader'
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sassOptions: {
+                                silenceDeprecations: ['mixed-decls', 'import']
+                            }
+                        }
+                    }
                 ]
             }
         ]


### PR DESCRIPTION
## One-line summary

Turns off dart-sass 3.x+ (=years ahead) planned deprecations in verbose mode that are already tracked for resolving.

## Significant changes and points to review

Silences thousands lines of useless output in terminal/logs that only obscure actionable warnings of other kinds.

## Issue / Bugzilla link

https://github.com/mozilla/protocol/issues/998
https://github.com/mozilla/protocol/issues/755
#362

## Testing

[/runs/16877852132/job/47806456732#step:4:6988](https://github.com/mozilla/bedrock/actions/runs/16877852132/job/47806456732#step:4:6988) usable again