### PR TITLE
remove obsolete l10n strings (fix #421)

### DIFF
--- a/l10n/en/firefox/download/desktop.ftl
+++ b/l10n/en/firefox/download/desktop.ftl
@@ -26,17 +26,11 @@ firefox-desktop-download-fast-reliable-private = Fast, reliable and private — 
 
 firefox-desktop-set-as-default = Set { -brand-name-firefox } as your default browser.
 
-# Obsolete string (expires: 2025-07-21)
-firefox-desktop-download-no-shady = No shady privacy policies or back doors for advertisers. Just a lightning fast browser that doesn’t sell you out.
-
 firefox-desktop-download-download-options = Download options and other languages
 firefox-desktop-download-browser-support = { -brand-name-firefox-browser } support
 
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
 firefox-desktop-download-do-what-you-do-v2 = Do what you do online.<br> { -brand-name-firefox-browser } has got you <strong>covered</strong>.
-
-# Obsolete string (expires: 2025-07-21)
-firefox-desktop-download-do-what-you-do = Do what you do online.<br> { -brand-name-firefox-browser } <strong>isn’t</strong> watching.
 
 firefox-desktop-download-we-block-the-ad = We block the ad trackers. You explore the internet faster.
 firefox-desktop-download-ads-are-distracting = Ads are distracting and make web pages load slower while their trackers watch every move you make online. The { -brand-name-firefox-browser } blocks most trackers automatically, so there’s no need to dig into your security settings.
@@ -129,7 +123,7 @@ firefox-desktop-download-firefox-was-created = { -brand-name-firefox } was creat
 #   $attrs (attrs) - link to https://www.mozilla.org/privacy/firefox/
 firefox-desktop-download-as-the-internet-v2 = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy — that’s always been our thing. Learn more about our data practices in our <a { $attrs }>Privacy Notice</a>.
 
-# Obsolete string
+# Obsolete string (expires 19-09-2025)
 # Variables:
 #   $attrs (attrs) - link to https://www.mozilla.org/privacy/
 firefox-desktop-download-as-the-internet = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy  — we call it the <a { $attrs }>Personal Data Promise</a>: Take less. Keep it safe. No secrets. Your data, your web activity, your life online is protected with { -brand-name-firefox }.

--- a/springfield/firefox/templates/firefox/download/desktop/download.html
+++ b/springfield/firefox/templates/firefox/download/desktop/download.html
@@ -94,7 +94,7 @@
       <div class="c-block-body">
         <h1>{{ ftl('firefox-desktop-download-firefox') }}</h1>
           <h2 class="mzp-has-zap-7">{{ ftl('firefox-desktop-download-get-the-browser') }}</h2>
-          <p>{{ ftl('firefox-desktop-download-fast-reliable-private', fallback='firefox-desktop-download-no-shady') }}</p>
+          <p>{{ ftl('firefox-desktop-download-fast-reliable-private') }}</p>
         <div class="c-intro-download">
           {% block primary_cta %}
             {{ default_browser_checkbox(id='default-browser-checkbox-primary') }}
@@ -214,7 +214,7 @@
 {% endif %}
 
   <section class="t-highlights">
-    <h2 class="mzp-c-section-heading mzp-has-zap-11">{{ ftl('firefox-desktop-download-do-what-you-do-v2', fallback='firefox-desktop-download-do-what-you-do') }}</h2>
+    <h2 class="mzp-c-section-heading mzp-has-zap-11">{{ ftl('firefox-desktop-download-do-what-you-do-v2') }}</h2>
 
     <div class="t-block c-block l-reversed">
       <div class="c-block-container">


### PR DESCRIPTION
## One-line summary

This PR removes obsolete l10n strings

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/421

## Testing
