### PR TITLE
Wrap dataLayer pushes in try/catch #323

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -245,9 +245,20 @@ TrackProductDownload.sendEventFromURL = (downloadURL) => {
  * @param {Object} - product details formatted into a product_download event
  */
 TrackProductDownload.sendEvent = (eventObject) => {
-    window.dataLayer.push(eventObject);
-    // we also want to keep the old event name around for a few months to help with the transition
-    // this can be deleted as part of the UA cleanup
+    // Treating this as the source of mozmeao/springfield#323 and wrapping it in a try/catch
+    try {
+        const result = window.dataLayer.push(eventObject);
+        // Handle if dataLayer.push returns a promise (some GTM configurations do this)
+        if (result && typeof result.then === 'function') {
+            result.catch(() => {
+                // Silently handle promise rejections to prevent unhandled rejection errors
+            });
+        }
+    } catch (error) {
+        // Handle synchronous errors
+    }
+    // we wanted to keep the old event name around for a few months to help with the transition
+    // now there are a bunch of dashboards built to use it so it gets to live on forever
     TrackProductDownload.sendOldEvent(eventObject);
 };
 
@@ -256,12 +267,23 @@ TrackProductDownload.sendEvent = (eventObject) => {
  * @param {Object} - product details formatted into a product_download event
  */
 TrackProductDownload.sendOldEvent = (eventObject) => {
-    // deep copy of event object
-    const oldEventObject = JSON.parse(JSON.stringify(eventObject));
-    // replace event name with old event name
-    oldEventObject['event'] = 'product_download';
-    // add to dataLayer
-    window.dataLayer.push(oldEventObject);
+    // Treating this as the source of mozmeao/springfield#323 and wrapping it in a try/catch
+    try {
+        // deep copy of event object
+        const oldEventObject = JSON.parse(JSON.stringify(eventObject));
+        // replace event name with old event name
+        oldEventObject['event'] = 'product_download';
+        // add to dataLayer
+        const result = window.dataLayer.push(oldEventObject);
+        // Handle if dataLayer.push returns a promise (some GTM configurations do this)
+        if (result && typeof result.then === 'function') {
+            result.catch(() => {
+                // Silently handle promise rejections to prevent unhandled rejection errors
+            });
+        }
+    } catch (error) {
+        // Handle synchronous errors (JSON.stringify/parse or dataLayer.push errors)
+    }
 };
 
 export default TrackProductDownload;


### PR DESCRIPTION
## One-line summary

Wrap `TrackProductDownload` `dataLayer` pushes in try/catch #323

## Significant changes and points to review

- This is an attempt to address the (so far) unreproducible error in #323.
- Wraps both dataLayer calls in a try/catch for promise rejection

## Issue / Bugzilla link

#323 

## Testing

Make sure the events still fire as expected.