### PR TITLE
Update meta info for iOS summarizer page

### DIFF
--- a/springfield/firefox/templates/firefox/landing/ios-summarizer.html
+++ b/springfield/firefox/templates/firefox/landing/ios-summarizer.html
@@ -9,6 +9,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 {% set ios_url = app_store_url('firefox', 'firefox-browsers-mobile-ios-summarizer') %}
 
@@ -23,8 +25,7 @@
   {% endif %}
 {% endblock %}
 
-{# Issue 13019: Avoid duplicate content for English pages. #}
-{%- block page_title_full -%} {{ ftl('mobile-ios-summarizer-page-title') }} - Mozilla {%- endblock -%}
+{% block page_title %}{{ ftl('mobile-ios-summarizer-page-title') }}{% endblock %}
 
 {% block page_desc %}{{ ftl('mobile-ios-summarizer-page-description') }}{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Update meta info for iOS summarizer page

## Significant changes and points to review

- landing pages should be noindex
- switch to using `page_title` block for page title

## Issue / Bugzilla link

#442 

## Testing
