### PR TITLE
Fix Japanese macOS ESR links

### DIFF
--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -18,6 +18,8 @@
 {% endblock %}
 
 {% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=enterprise' %}
+{% set win_download_lang = LANG %}
+{% set mac_download_lang = "ja-JP-mac" if LANG == "ja" else LANG %}
 
 {% block body_id %}firefox{% endblock %}
 
@@ -127,22 +129,22 @@
             <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-win64-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}" data-download-version="win64" data-cta-text="Win64 - Download - Firefox" data-testid="firefox-enterprise-win64-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64" data-cta-text="Win64 - Download - Firefox" data-testid="firefox-enterprise-win64-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}" data-download-version="win64-msi" data-cta-text="Win64 - Download - Firefox MSI" data-testid="firefox-enterprise-win64-msi-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64-msi" data-cta-text="Win64 - Download - Firefox MSI" data-testid="firefox-enterprise-win64-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser-msi-installer') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-download-version="win64" data-cta-text="Win64 - Download - Firefox ESR" data-testid="firefox-enterprise-win64-esr-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64" data-cta-text="Win64 - Download - Firefox ESR" data-testid="firefox-enterprise-win64-esr-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}" data-download-version="win64-msi" data-cta-text="Win64 - Download - Firefox ESR MSI" data-testid="firefox-enterprise-win64-esr-msi-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64-msi" data-cta-text="Win64 - Download - Firefox ESR MSI" data-testid="firefox-enterprise-win64-esr-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release-msi') }}
                 </a>
               </li>
@@ -170,12 +172,12 @@
             <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-mac-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}" data-download-version="osx" data-cta-text="MacOS - Download - Firefox" data-testid="firefox-enterprise-mac-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx" data-cta-text="MacOS - Download - Firefox" data-testid="firefox-enterprise-mac-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-download-version="osx" data-cta-text="MacOS - Download - Firefox ESR" data-testid="firefox-enterprise-mac-esr-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx" data-cta-text="MacOS - Download - Firefox ESR" data-testid="firefox-enterprise-mac-esr-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
@@ -202,22 +204,22 @@
             <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-win32-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}" data-download-version="win" data-cta-text="Win32 - Download - Firefox" data-testid="firefox-enterprise-win32-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ win_download_lang }}" data-download-version="win" data-cta-text="Win32 - Download - Firefox" data-testid="firefox-enterprise-win32-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}" data-download-version="win-msi" data-cta-text="Win32 - Download - Firefox MSI" data-testid="firefox-enterprise-win32-msi-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ win_download_lang }}" data-download-version="win-msi" data-cta-text="Win32 - Download - Firefox MSI" data-testid="firefox-enterprise-win32-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser-msi-installer') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-download-version="win" data-cta-text="Win32 - Download - Firefox ESR" data-testid="firefox-enterprise-win32-esr-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ win_download_lang }}" data-download-version="win" data-cta-text="Win32 - Download - Firefox ESR" data-testid="firefox-enterprise-win32-esr-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}" data-download-version="win-msi" data-cta-text="Win32 - Download - Firefox ESR MSI" data-testid="firefox-enterprise-win32-esr-msi-menu-link">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ win_download_lang }}" data-download-version="win-msi" data-cta-text="Win32 - Download - Firefox ESR MSI" data-testid="firefox-enterprise-win32-esr-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release-msi') }}
                 </a>
               </li>

--- a/tests/playwright/specs/products/firefox/firefox-enterprise.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-enterprise.spec.js
@@ -8,171 +8,180 @@
 
 const { test, expect } = require('@playwright/test');
 const openPage = require('../../../scripts/open-page');
-const url = '/en-US/browsers/enterprise/';
+const languages = ['en-US', 'ja'];
+const pageUrl = '/LANG/browsers/enterprise/';
+const downloadBaseUrl = 'https://download.mozilla.org/';
 
-test.describe(
-    `${url} page`,
-    {
-        tag: '@firefox'
-    },
-    () => {
-        test.beforeEach(async ({ page, browserName }) => {
-            await openPage(url, page, browserName);
-        });
+languages.forEach((lang) => {
+    test.describe(
+        `${pageUrl} page in ${lang}`,
+        {
+            tag: '@firefox'
+        },
+        () => {
+            // Download language code for Windows is the same as the locale code.
+            const winDownloadLang = lang;
+            // For Japanese, the macOS download language code is `ja-JP-mac`.
+            const macDownloadLang = lang === 'ja' ? 'ja-JP-mac' : lang;
 
-        test('Firefox ESR Windows 64bit menu open / close', async ({
-            page
-        }) => {
-            const win64MenuButton = page.getByTestId(
-                'firefox-enterprise-win64-menu-button'
-            );
-            const win64MenuLink = page.getByTestId(
-                'firefox-enterprise-win64-menu-link'
-            );
-            const win64MsiMenuLink = page.getByTestId(
-                'firefox-enterprise-win64-msi-menu-link'
-            );
-            const win64EsrMenuLink = page.getByTestId(
-                'firefox-enterprise-win64-esr-menu-link'
-            );
-            const win64EsrMsiMenuLink = page.getByTestId(
-                'firefox-enterprise-win64-esr-msi-menu-link'
-            );
+            test.beforeEach(async ({ page, browserName }) => {
+                await openPage(pageUrl.replace('LANG', lang), page, browserName);
+            });
 
-            await expect(win64MenuLink).not.toBeVisible();
-            await expect(win64MsiMenuLink).not.toBeVisible();
-            await expect(win64EsrMenuLink).not.toBeVisible();
-            await expect(win64EsrMsiMenuLink).not.toBeVisible();
+            test('Firefox ESR Windows 64bit menu open / close', async ({
+                page
+            }) => {
+                const win64MenuButton = page.getByTestId(
+                    'firefox-enterprise-win64-menu-button'
+                );
+                const win64MenuLink = page.getByTestId(
+                    'firefox-enterprise-win64-menu-link'
+                );
+                const win64MsiMenuLink = page.getByTestId(
+                    'firefox-enterprise-win64-msi-menu-link'
+                );
+                const win64EsrMenuLink = page.getByTestId(
+                    'firefox-enterprise-win64-esr-menu-link'
+                );
+                const win64EsrMsiMenuLink = page.getByTestId(
+                    'firefox-enterprise-win64-esr-msi-menu-link'
+                );
 
-            // open menu
-            await win64MenuButton.click();
+                await expect(win64MenuLink).not.toBeVisible();
+                await expect(win64MsiMenuLink).not.toBeVisible();
+                await expect(win64EsrMenuLink).not.toBeVisible();
+                await expect(win64EsrMsiMenuLink).not.toBeVisible();
 
-            // Assert Windows 64-bit menu links are displayed.
-            await expect(win64MenuLink).toBeVisible();
-            await expect(win64MenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-latest-ssl&os=win64/
-            );
-            await expect(win64MsiMenuLink).toBeVisible();
-            await expect(win64MsiMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-msi-latest-ssl&os=win64/
-            );
-            await expect(win64EsrMenuLink).toBeVisible();
-            await expect(win64EsrMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-esr-latest-ssl&os=win64/
-            );
-            await expect(win64EsrMsiMenuLink).toBeVisible();
-            await expect(win64EsrMsiMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-esr-msi-latest-ssl&os=win64/
-            );
+                // open menu
+                await win64MenuButton.click();
 
-            // close menu
-            await win64MenuButton.click();
+                // Assert Windows 64-bit menu links are displayed.
+                await expect(win64MenuLink).toBeVisible();
+                await expect(win64MenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-latest-ssl&os=win64&lang=${winDownloadLang}`
+                );
+                await expect(win64MsiMenuLink).toBeVisible();
+                await expect(win64MsiMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-msi-latest-ssl&os=win64&lang=${winDownloadLang}`
+                );
+                await expect(win64EsrMenuLink).toBeVisible();
+                await expect(win64EsrMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-esr-latest-ssl&os=win64&lang=${winDownloadLang}`
+                );
+                await expect(win64EsrMsiMenuLink).toBeVisible();
+                await expect(win64EsrMsiMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-esr-msi-latest-ssl&os=win64&lang=${winDownloadLang}`
+                );
 
-            // Assert Windows 64-bit menu links are hidden.
-            await expect(win64MenuLink).not.toBeVisible();
-            await expect(win64MsiMenuLink).not.toBeVisible();
-            await expect(win64EsrMenuLink).not.toBeVisible();
-            await expect(win64EsrMsiMenuLink).not.toBeVisible();
-        });
+                // close menu
+                await win64MenuButton.click();
 
-        test('Firefox ESR macOS menu open / close', async ({ page }) => {
-            const macMenuButton = page.getByTestId(
-                'firefox-enterprise-mac-menu-button'
-            );
-            const macMenuLink = page.getByTestId(
-                'firefox-enterprise-mac-menu-link'
-            );
-            const macEsrMenuLink = page.getByTestId(
-                'firefox-enterprise-mac-esr-menu-link'
-            );
+                // Assert Windows 64-bit menu links are hidden.
+                await expect(win64MenuLink).not.toBeVisible();
+                await expect(win64MsiMenuLink).not.toBeVisible();
+                await expect(win64EsrMenuLink).not.toBeVisible();
+                await expect(win64EsrMsiMenuLink).not.toBeVisible();
+            });
 
-            await expect(macMenuLink).not.toBeVisible();
-            await expect(macEsrMenuLink).not.toBeVisible();
+            test('Firefox ESR macOS menu open / close', async ({ page }) => {
+                const macMenuButton = page.getByTestId(
+                    'firefox-enterprise-mac-menu-button'
+                );
+                const macMenuLink = page.getByTestId(
+                    'firefox-enterprise-mac-menu-link'
+                );
+                const macEsrMenuLink = page.getByTestId(
+                    'firefox-enterprise-mac-esr-menu-link'
+                );
 
-            // open menu
-            await macMenuButton.click();
+                await expect(macMenuLink).not.toBeVisible();
+                await expect(macEsrMenuLink).not.toBeVisible();
 
-            // Assert macOS menu links are displayed.
-            await expect(macMenuLink).toBeVisible();
-            await expect(macMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-latest-ssl&os=osx/
-            );
-            await expect(macEsrMenuLink).toBeVisible();
-            await expect(macEsrMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-esr-latest-ssl&os=osx/
-            );
+                // open menu
+                await macMenuButton.click();
 
-            // close menu
-            await macMenuButton.click();
+                // Assert macOS menu links are displayed.
+                await expect(macMenuLink).toBeVisible();
+                await expect(macMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-latest-ssl&os=osx&lang=${macDownloadLang}`
+                );
+                await expect(macEsrMenuLink).toBeVisible();
+                await expect(macEsrMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-esr-latest-ssl&os=osx&lang=${macDownloadLang}`
+                );
 
-            // Assert macOS menu links are hidden.
-            await expect(macMenuLink).not.toBeVisible();
-            await expect(macEsrMenuLink).not.toBeVisible();
-        });
+                // close menu
+                await macMenuButton.click();
 
-        test('Firefox ESR Windows 32bit menu open / close', async ({
-            page
-        }) => {
-            const win32MenuButton = page.getByTestId(
-                'firefox-enterprise-win64-menu-button'
-            );
-            const win32MenuLink = page.getByTestId(
-                'firefox-enterprise-win64-menu-link'
-            );
-            const win32MsiMenuLink = page.getByTestId(
-                'firefox-enterprise-win64-msi-menu-link'
-            );
-            const win32EsrMenuLink = page.getByTestId(
-                'firefox-enterprise-win64-esr-menu-link'
-            );
-            const win32EsrMsiMenuLink = page.getByTestId(
-                'firefox-enterprise-win64-esr-msi-menu-link'
-            );
+                // Assert macOS menu links are hidden.
+                await expect(macMenuLink).not.toBeVisible();
+                await expect(macEsrMenuLink).not.toBeVisible();
+            });
 
-            await expect(win32MenuLink).not.toBeVisible();
-            await expect(win32MsiMenuLink).not.toBeVisible();
-            await expect(win32EsrMenuLink).not.toBeVisible();
-            await expect(win32EsrMsiMenuLink).not.toBeVisible();
+            test('Firefox ESR Windows 32bit menu open / close', async ({
+                page
+            }) => {
+                const win32MenuButton = page.getByTestId(
+                    'firefox-enterprise-win32-menu-button'
+                );
+                const win32MenuLink = page.getByTestId(
+                    'firefox-enterprise-win32-menu-link'
+                );
+                const win32MsiMenuLink = page.getByTestId(
+                    'firefox-enterprise-win32-msi-menu-link'
+                );
+                const win32EsrMenuLink = page.getByTestId(
+                    'firefox-enterprise-win32-esr-menu-link'
+                );
+                const win32EsrMsiMenuLink = page.getByTestId(
+                    'firefox-enterprise-win32-esr-msi-menu-link'
+                );
 
-            // open menu
-            await win32MenuButton.click();
+                await expect(win32MenuLink).not.toBeVisible();
+                await expect(win32MsiMenuLink).not.toBeVisible();
+                await expect(win32EsrMenuLink).not.toBeVisible();
+                await expect(win32EsrMsiMenuLink).not.toBeVisible();
 
-            // Assert Windows 32-bit menu links are displayed.
-            await expect(win32MenuLink).toBeVisible();
-            await expect(win32MenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-latest-ssl&os=win64/
-            );
-            await expect(win32MsiMenuLink).toBeVisible();
-            await expect(win32MsiMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-msi-latest-ssl&os=win64/
-            );
-            await expect(win32EsrMenuLink).toBeVisible();
-            await expect(win32EsrMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-esr-latest-ssl&os=win64/
-            );
-            await expect(win32EsrMsiMenuLink).toBeVisible();
-            await expect(win32EsrMsiMenuLink).toHaveAttribute(
-                'href',
-                /\?product=firefox-esr-msi-latest-ssl&os=win64/
-            );
+                // open menu
+                await win32MenuButton.click();
 
-            // close menu
-            await win32MenuButton.click();
+                // Assert Windows 32-bit menu links are displayed.
+                await expect(win32MenuLink).toBeVisible();
+                await expect(win32MenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-latest-ssl&os=win&lang=${winDownloadLang}`
+                );
+                await expect(win32MsiMenuLink).toBeVisible();
+                await expect(win32MsiMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-msi-latest-ssl&os=win&lang=${winDownloadLang}`
+                );
+                await expect(win32EsrMenuLink).toBeVisible();
+                await expect(win32EsrMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-esr-latest-ssl&os=win&lang=${winDownloadLang}`
+                );
+                await expect(win32EsrMsiMenuLink).toBeVisible();
+                await expect(win32EsrMsiMenuLink).toHaveAttribute(
+                    'href',
+                    `${downloadBaseUrl}?product=firefox-esr-msi-latest-ssl&os=win&lang=${winDownloadLang}`
+                );
 
-            // Assert Windows 32-bit menu links are hidden.
-            await expect(win32MenuLink).not.toBeVisible();
-            await expect(win32MsiMenuLink).not.toBeVisible();
-            await expect(win32EsrMenuLink).not.toBeVisible();
-            await expect(win32EsrMsiMenuLink).not.toBeVisible();
-        });
-    }
-);
+                // close menu
+                await win32MenuButton.click();
+
+                // Assert Windows 32-bit menu links are hidden.
+                await expect(win32MenuLink).not.toBeVisible();
+                await expect(win32MsiMenuLink).not.toBeVisible();
+                await expect(win32EsrMenuLink).not.toBeVisible();
+                await expect(win32EsrMsiMenuLink).not.toBeVisible();
+            });
+        }
+    );
+});


### PR DESCRIPTION
## One-line summary

Fix the `lang` param for Japanese macOS ESR download links.

## Significant changes and points to review

- Make the download language conditional to use the correct `ja-JP-mac` lang param.
- Bonus: fix the win32 link tests, which are incorrectly testing win64.

## Issue / Bugzilla link

#468

## Testing

http://localhost:8000/en-CA/browsers/enterprise/