### PR TITLE
Adding product page id (ppid) support

### DIFF
--- a/springfield/firefox/templates/firefox/landing/ios-summarizer.html
+++ b/springfield/firefox/templates/firefox/landing/ios-summarizer.html
@@ -12,7 +12,8 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
-{% set ios_url = app_store_url('firefox', 'firefox-browsers-mobile-ios-summarizer') %}
+{# ppid 908b3bb9-aa78-4a60-8f7f-2407cd3227bc is used to redirect to the specific campaign page for shake to summarize on the app store #}
+{% set ios_url = app_store_url('firefox', 'firefox-browsers-mobile-ios-summarizer', '908b3bb9-aa78-4a60-8f7f-2407cd3227bc') %}
 
 {% block page_css %}
   {{ css_bundle('protocol-split') }}

--- a/springfield/firefox/templatetags/misc.py
+++ b/springfield/firefox/templatetags/misc.py
@@ -462,7 +462,7 @@ def ifeq(a, b, text):
 
 @library.global_function
 @jinja2.pass_context
-def app_store_url(ctx, product, campaign=None):
+def app_store_url(ctx, product, campaign=None, ppid=None):
     """Returns a localised app store URL for a given product"""
     locale = getattr(ctx["request"], "locale", "en-US")
     countries = settings.APPLE_APPSTORE_COUNTRY_MAP
@@ -492,9 +492,15 @@ def app_store_url(ctx, product, campaign=None):
         base_url = base_url + params.format(tp=tracking_product)
 
     if locale in countries:
-        return base_url.format(country=countries[locale])
+        base_url = base_url.format(country=countries[locale])
     else:
-        return base_url.replace("/{country}/", "/")
+        base_url = base_url.replace("/{country}/", "/")
+
+    # ppid stands for Product Page ID and is a parameter added to target a custom product page on the apple app store.
+    if ppid:
+        base_url = base_url + f"&ppid={ppid}"
+
+    return base_url
 
 
 @library.global_function

--- a/springfield/firefox/tests/test_helper_misc.py
+++ b/springfield/firefox/tests/test_helper_misc.py
@@ -627,13 +627,11 @@ def test_csrf():
 class TestAppStoreURL(TestCase):
     rf = RequestFactory()
 
-    def _render(self, product, campaign, locale):
+    def _render(self, product, campaign, locale, ppid=None):
         req = self.rf.get("/")
         req.locale = locale
-        return render(
-            f"{{{{ app_store_url('{product}', '{campaign}') }}}}",
-            {"request": req},
-        )
+        template = "{{ app_store_url(product, campaign, ppid) }}"
+        return render(template, {"request": req, "product": product, "campaign": campaign, "ppid": ppid})
 
     def test_firefox_app_store_url_no_locale(self):
         """No locale, fallback to default URL"""
@@ -693,6 +691,20 @@ class TestAppStoreURL(TestCase):
         assert (
             self._render("vpn", "vpn-landing-page", "de")
             == "https://apps.apple.com/de/app/apple-store/id1489407738?mz_pr=vpn&amp;pt=373246&amp;ct=vpn-landing-page&amp;mt=8"
+        )
+
+    def test_firefox_app_store_url_localized_with_ppid_no_campaign(self):
+        """should append ppid when provided (no campaign)"""
+        assert (
+            self._render("firefox", "", "en-US", ppid="abcd1234")
+            == "https://apps.apple.com/us/app/apple-store/id989804926?mz_pr=firefox_mobile&amp;ppid=abcd1234"
+        )
+
+    def test_firefox_app_store_url_localized_with_campaign_and_ppid(self):
+        """should append ppid after campaign params"""
+        assert (
+            self._render("firefox", "firefox-home", "en-US", ppid="abcd1234")
+            == "https://apps.apple.com/us/app/apple-store/id989804926?mz_pr=firefox_mobile&amp;pt=373246&amp;ct=firefox-home&amp;mt=8&amp;ppid=abcd1234"
         )
 
 


### PR DESCRIPTION
## One-line summary
This PR updates the `ios_url` used to redirect to app store to target the specific campaign for shake to summarize. It does this by adding a new `ppid` param. It should redirect to this instead: https://apps.apple.com/us/app/firefox-private-web-browser/id989804926?ppid=908b3bb9-aa78-4a60-8f7f-2407cd3227bc

## Significant changes and points to review


## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/478


## Testing
