### PR TITLE
Fix ja-JP-mac ESR115 download in unsupported macro

### DIFF
--- a/springfield/firefox/templates/firefox/includes/download-unsupported.html
+++ b/springfield/firefox/templates/firefox/includes/download-unsupported.html
@@ -15,19 +15,20 @@
 {% endif %}
 
 {# ESR115 builds do not exist for "sat" and "skr" languages (see issue #15437). #}
-{% set ESR115_LANG = 'en-US' if LANG in ["sat", "skr"] else LANG %}
+{% set win_download_lang = 'en-US' if LANG in ["sat", "skr"] else LANG %}
+{% set mac_download_lang = 'ja-JP-mac' if LANG == "ja" else win_download_lang %}
 
 <div class="fx-unsupported-message win" data-nosnippet="true">
   <p><strong>{{ ftl('download-button-unsupported-platform', channel_name=channel_name, help_url='https://support.mozilla.org/kb/firefox-users-windows-7-8-and-81-moving-extended-support', os_version='Windows 8.1') }}</strong></p>
   <p>{{ ftl('download-button-please-download-esr') }}</p>
   <div class="download-platform-list">
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang={{ ESR115_LANG }}" data-download-version="win64" data-cta-text="Download Firefox Extended Support Release 64-bit" data-cta-type="firefox">
+      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64" data-cta-text="Download Firefox Extended Support Release 64-bit" data-cta-type="firefox">
         {{ ftl('download-firefox-esr-64') }}
       </a>
     </p>
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win&lang={{ ESR115_LANG }}" data-download-version="win" data-cta-text="Download Firefox Extended Support Release 32-bit" data-cta-type="firefox">
+      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win&lang={{ win_download_lang }}" data-download-version="win" data-cta-text="Download Firefox Extended Support Release 32-bit" data-cta-type="firefox">
         {{ ftl('download-firefox-esr-32') }}
       </a>
     </p>
@@ -45,7 +46,7 @@
   <p>{{ ftl('download-button-please-download-esr') }}</p>
 
   <div class="download-platform-list">
-    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=osx&lang={{ ESR115_LANG }}" data-download-version="osx" data-cta-text="Firefox Extended Support Release MacOS" data-cta-type="firefox">
+    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx" data-cta-text="Firefox Extended Support Release MacOS" data-cta-type="firefox">
       {{ ftl('download-firefox-esr') }}
     </a>
   </div>

--- a/springfield/firefox/templates/firefox/includes/macros.html
+++ b/springfield/firefox/templates/firefox/includes/macros.html
@@ -24,7 +24,7 @@
         </strong>
         <span class="mzp-c-button-icon-end">
           <!-- TODO: replace with new protocol-assets version -->
-          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="">
         </span>
       </a>
 
@@ -43,12 +43,11 @@
 {%- endmacro %}
 
 {% macro firefox_download_desktop_button_mac(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-osx', position='primary cta') -%}
-{% set DOWNLOAD_LANG = "ja-JP-mac" if LANG == "ja" else LANG %}
-
+  {% set download_lang = "ja-JP-mac" if LANG == "ja" else LANG %}
   <div class="firefox-platform-button-mac">
     <div class="firefox-platform-button">
       <a class="download-link os_osx mzp-t-xl mzp-c-button mzp-t-product ga-product-download"
-        id="{{ id }}" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=osx&lang={{ DOWNLOAD_LANG }}"
+        id="{{ id }}" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=osx&lang={{ download_lang }}"
         data-download-version="osx"
         data-cta-text="Download Now"
         data-cta-type="firefox"
@@ -60,7 +59,7 @@
         </strong>
         <span class="mzp-c-button-icon-end">
           <!-- TODO: replace with new protocol-assets version -->
-          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="">
         </span>
       </a>
 
@@ -88,7 +87,7 @@
         </strong>
         <span class="mzp-c-button-icon-end">
           <!-- TODO: replace with new protocol-assets version -->
-          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="">
         </span>
       </a>
 
@@ -98,7 +97,7 @@
         </strong>
         <span class="mzp-c-button-icon-end">
           <!-- TODO: replace with new protocol-assets version -->
-          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="" />
+          <img src="{{ static('img/icons/m24-small/download-white.svg') }}" alt="">
         </span>
       </a>
 


### PR DESCRIPTION
## One-line summary

Adds special casing of `ja-JP-mac` codepage for desktop downloads via unsupported systems CTA helper/macro.

## Significant changes and points to review

Other static CTAs should be covered already. (This aligns some naming/casing across the individual changesets too for consistency.)

## Issue / Bugzilla link

Fixes https://github.com/mozmeao/springfield/issues/468#issuecomment-3276215518
#472

## Testing

UA: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36`

http://localhost:8000/ja/
http://localhost:8000/ja/browsers/desktop/
http://localhost:8000/skr/browsers/desktop/ (control, en-US download)
http://localhost:8000/scn/browsers/desktop/ (control)

This is the "unsupported" macro:

> <img width="1352" height="296" alt="Screenshot 2025-09-17 at 20 52 36" src="https://github.com/user-attachments/assets/4cccd24b-93ab-470e-8dc9-d45dbcfe40bf" />