### PR TITLE
Remove inactive variation JS in mobile/ios template

### DIFF
--- a/springfield/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/ios.html
@@ -166,11 +166,7 @@
 {% endblock %}
 
 {% block js %}
-{% if variation == '2' %}
-  {{ js_bundle('firefox-browsers-ios-sms') }}
-{% else %}
-  {{ js_bundle('firefox-browsers-mobile') }}
-{% endif %}
+{{ js_bundle('firefox-browsers-mobile') }}
 
   {% if show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}


### PR DESCRIPTION
## One-line summary
Removes leftover code that referenced a non-existent JavaScript bundle.


## Issue / Bugzilla link
Fixes #443 


## Testing
- [x] Nonexistent bundle reference removed
- [x] Variant conditions for deleted experiments are removed