### PR TITLE
Fix Sass deprec warn msg

### DIFF
--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -30,7 +30,7 @@ $image-path: '/media/protocol/img';
     }
 
     @media #{$mq-lg} {
-        margin-top: $layout-sm / 2 * -1;
+        margin-top: $layout-sm * -0.5;
     }
 }
 


### PR DESCRIPTION
## One-line summary
Fixed the deprecation warning "Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0"

## Issue / Bugzilla link
Fixes #451 


## Testing
Ref.: https://github.com/ag-grid/ag-grid/issues/4543#issuecomment-868934018