### PR TITLE
Fix download tests by restricting the selector only to page section content

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -104,7 +104,7 @@ def pytest_generate_tests(metafunc):
                     lang_urls = [a.attrib["href"] for a in doc("ul.c-lang-list a")]
                     for url in lang_urls:
                         doc = get_web_page(f"{base_url}{url}")
-                        download_urls = [a.attrib["href"] for a in doc("main a.download-link")]
+                        download_urls = [a.attrib["href"] for a in doc(".c-step-contents a.download-link")]
                         for url in download_urls:
                             urls.append(url)
             assert urls

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -104,7 +104,7 @@ def pytest_generate_tests(metafunc):
                     lang_urls = [a.attrib["href"] for a in doc("ul.c-lang-list a")]
                     for url in lang_urls:
                         doc = get_web_page(f"{base_url}{url}")
-                        download_urls = [a.attrib["href"] for a in doc("a.download-link")]
+                        download_urls = [a.attrib["href"] for a in doc("main a.download-link")]
                         for url in download_urls:
                             urls.append(url)
             assert urls


### PR DESCRIPTION
## One-line summary

Only collects link elements from within the final step of /download/all for l10n bouncer links tests.

## Significant changes and points to review

The issue mentions several mitigations or fixes that are each valid in itself; but for this test I'd expect the constraint to be the actual content block for the final download is the expected behavior.

"5439 selected" matches the value from earlier this week when it passed correctly.

## Issue / Bugzilla link

Fixes #495

## Testing

```
collected 6741 items / 1302 deselected / 5439 selected
succeeded 12 minutes ago in 23m 48s
```

[`@janbrasna/springfield`/actions/runs/17884110774/job/50855539100#step:3:498](https://github.com/janbrasna/springfield/actions/runs/17884110774/job/50855539100#step:3:498) ✅ 

_(triggered from workspace changes via:)_

https://github.com/mozmeao/springfield/blob/ec1c2072ca0e03d471e23ed884a0199fe90fd8f3/.github/workflows/download_tests.yml#L20