### PR TITLE
Add newsletter tests for ported pages

### DIFF
--- a/tests/playwright/specs/newsletter/newsletter-embed.spec.js
+++ b/tests/playwright/specs/newsletter/newsletter-embed.spec.js
@@ -11,13 +11,13 @@ const openPage = require('../../scripts/open-page');
 const url = '/en-US/';
 const slugs = ['channel/desktop', 'channel/desktop/developer', 'newsletter'];
 
-test.describe(
-    `${url} page`,
-    {
-        tag: '@newsletter'
-    },
-    () => {
-        for (const slug of slugs) {
+slugs.forEach((slug) => {
+    test.describe(
+        `${url}${slug} page`,
+        {
+            tag: '@newsletter'
+        },
+        () => {
             test.beforeEach(async ({ page, browserName }) => {
                 await openPage(url + `${slug}/`, page, browserName);
             });
@@ -80,5 +80,5 @@ test.describe(
                 await expect(thanksMessage).not.toBeVisible();
             });
         }
-    }
-);
+    );
+});

--- a/tests/playwright/specs/newsletter/newsletter-embed.spec.js
+++ b/tests/playwright/specs/newsletter/newsletter-embed.spec.js
@@ -1,0 +1,84 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../scripts/open-page');
+const url = '/en-US/';
+const slugs = ['channel/desktop/', 'channel/desktop/developer/', 'newsletter'];
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@newsletter'
+    },
+    () => {
+        for (const slug of slugs) {
+            test.beforeEach(async ({ page, browserName }) => {
+                await openPage(url + `${slug}/`, page, browserName);
+            });
+
+            test(`Newsletter submit success /${slug}/`, async ({ page }) => {
+                const form = page.getByTestId('newsletter-form');
+                const emailField = page.getByTestId('newsletter-email-input');
+                const countryField = page.getByTestId(
+                    'newsletter-country-select'
+                );
+                const privacyCheckbox = page.getByTestId(
+                    'newsletter-privacy-checkbox'
+                );
+                const submitButton = page.getByTestId(
+                    'newsletter-submit-button'
+                );
+                const thanksMessage = page.getByTestId(
+                    'newsletter-thanks-message'
+                );
+
+                // expand form before running test
+                await submitButton.click();
+
+                await expect(thanksMessage).not.toBeVisible();
+                await emailField.fill('success@example.com');
+                await countryField.selectOption('us');
+                await privacyCheckbox.click();
+                await submitButton.click();
+                await expect(form).not.toBeVisible();
+                await expect(thanksMessage).toBeVisible();
+            });
+
+            test(`Newsletter submit failure /${slug}/`, async ({ page }) => {
+                const emailField = page.getByTestId('newsletter-email-input');
+                const countryField = page.getByTestId(
+                    'newsletter-country-select'
+                );
+                const privacyCheckbox = page.getByTestId(
+                    'newsletter-privacy-checkbox'
+                );
+                const submitButton = page.getByTestId(
+                    'newsletter-submit-button'
+                );
+                const thanksMessage = page.getByTestId(
+                    'newsletter-thanks-message'
+                );
+                const errorMessage = page.getByTestId(
+                    'newsletter-error-message'
+                );
+
+                // expand form before running test
+                await page.getByTestId('newsletter-submit-button').click();
+
+                await expect(errorMessage).not.toBeVisible();
+                await emailField.fill('failure@example.com');
+                await countryField.selectOption('us');
+                await privacyCheckbox.click();
+                await submitButton.click();
+                await expect(errorMessage).toBeVisible();
+                await expect(thanksMessage).not.toBeVisible();
+            });
+        }
+    }
+);

--- a/tests/playwright/specs/newsletter/newsletter-embed.spec.js
+++ b/tests/playwright/specs/newsletter/newsletter-embed.spec.js
@@ -9,7 +9,7 @@
 const { test, expect } = require('@playwright/test');
 const openPage = require('../../scripts/open-page');
 const url = '/en-US/';
-const slugs = ['channel/desktop/', 'channel/desktop/developer/', 'newsletter'];
+const slugs = ['channel/desktop', 'channel/desktop/developer', 'newsletter'];
 
 test.describe(
     `${url} page`,


### PR DESCRIPTION
## One-line summary
Follow up to https://github.com/mozilla/bedrock/pull/16599 where we were inadvertently testing redirected pages. This PR moves that check directly to Springfield and adds new URLs with newsletters

## Significant changes and points to review
All newsletter pages on FXC should have associated URL in playwright tests

## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/502

## Testing
https://mozmeao.github.io/platform-docs/testing/?h=play#running-playwright-tests
`npx playwright test newsletter-embed`



┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/WT-221)
┆Priority: P2
┆Sprint: Backlog
