### PR TITLE
Skip linux32 for firefox>=145

### DIFF
--- a/springfield/firefox/firefox_details.py
+++ b/springfield/firefox/firefox_details.py
@@ -86,6 +86,10 @@ class FirefoxDesktop(_ProductDetails):
         else:
             platforms = self.platform_labels.copy()
 
+        # Support for linux32 "i686" platform ends with v145 (see issue #466)
+        if self.latest_major_version(channel) >= 145:
+            del platforms["linux"]
+
         return list(platforms.items())
 
     def latest_version(self, channel="release"):


### PR DESCRIPTION
## One-line summary
Firefox 145+ doesn't have linux32 binaries, so skip that platform for any channel whose major version is >= 145.

## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/466



┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/WT-242)
┆Priority: P2
┆Sprint: Backlog
