### PR TITLE
Add ads.txt file to the site (WT-216)

### DIFF
--- a/root_files/ads.txt
+++ b/root_files/ads.txt
@@ -1,0 +1,1 @@
+indexexchange.com, 213117, DIRECT, 50b1c356f2c5c8fc


### PR DESCRIPTION
## One-line summary

Adds an ads.txt file to the root of the site.

## Significant changes and points to review

The string is in the doc linked to the Jira ticket if you want to compare.

## Issue / Bugzilla link

[WT-216](https://mozilla-hub.atlassian.net/browse/WT-216)

## Testing

http://localhost:8000/ads.txt