### PR TITLE
Adding Firefox Protections page to navigation

### DIFF
--- a/l10n/en/navigation-firefox.ftl
+++ b/l10n/en/navigation-firefox.ftl
@@ -32,6 +32,7 @@ navigation-learn = Learn
 navigation-blog = Blog
 navigation-compare = Compare
 navigation-podcast = Podcast
+navigation-data-protection = Data Protection
 
 ## Download
 

--- a/springfield/base/templates/includes/navigation/menus/resources.html
+++ b/springfield/base/templates/includes/navigation/menus/resources.html
@@ -58,6 +58,11 @@
               {# <!-- The <a> start and end tags must be on the same line to avoid extra white space between the text and external link icon --> #}
               <a class="m24-c-menu-item-link" href="https://www.youtube.com/@firefox/podcasts{{params}}" data-link-text="Podcast" data-link-position="topnav - podcast">{{ ftl('navigation-podcast') }}</a>
             </li>
+            <li>
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.user-privacy') }}" data-link-text="Data Protection" data-link-position="topnav - data protection">
+                {{ ftl('navigation-data-protection') }}
+              </a>
+            </li>
           </ul>
         </div>
       </div>

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -170,5 +170,5 @@ urlpatterns = (
     page("more/faq/", "firefox/more/faq.html", ftl_files="firefox/more/faq"),
     # What's New Page (WNP)
     re_path(f"whatsnew/(?P<version>{version_re})", views.WhatsnewView.as_view(), name="firefox.whatsnew"),
-    page("user-privacy/", "firefox/data.html"),
+    page("user-privacy/", "firefox/data.html", url_name="firefox.user-privacy"),
 )


### PR DESCRIPTION
## One-line summary
Adding the new Firefox protections page to navigation



## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-266

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/WT-268)
┆Priority: P2
┆Sprint: Backlog
