### PR TITLE
Skip tests for linux 32bit if Firefox version >= 145

### DIFF
--- a/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
@@ -97,21 +97,54 @@ test.describe(
             page,
             browserName
         }) => {
-            const linuxBetaDownload = page.getByTestId(
-                'desktop-beta-download-linux'
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Linux'
             );
+
+            // Set Linux UA strings.
+            await page.addInitScript({
+                path: `./scripts/useragent/linux/${browserName}.js`
+            });
+            await page.goto(url + '?automation=true');
+
+            // Linux 32 buttons disappearing in 145 (Issue #466)
+            const latest_firefox = await page.evaluate(
+                () =>
+                    document.documentElement
+                        .getAttribute('data-latest-firefox')
+                        .split('.')[0]
+            );
+            const nightly_linux_32 = latest_firefox < 143 ? true : false;
+            const dev_linux_32 = latest_firefox < 144 ? true : false;
+            const beta_linux_32 = latest_firefox < 144 ? true : false;
+
+            let linuxBetaDownload;
+            if (beta_linux_32) {
+                linuxBetaDownload = page.getByTestId(
+                    'desktop-beta-download-linux'
+                );
+            }
             const linux64BetaDownload = page.getByTestId(
                 'desktop-beta-download-linux64'
             );
-            const linuxDevDownload = page.getByTestId(
-                'desktop-developer-download-linux'
-            );
+
+            let linuxDevDownload;
+            if (dev_linux_32) {
+                linuxDevDownload = page.getByTestId(
+                    'desktop-developer-download-linux'
+                );
+            }
             const linux64DevDownload = page.getByTestId(
                 'desktop-developer-download-linux64'
             );
-            const linuxNightlyDownload = page.getByTestId(
-                'desktop-nightly-download-linux'
-            );
+
+            let linuxNightlyDownload;
+            if (nightly_linux_32) {
+                linuxNightlyDownload = page.getByTestId(
+                    'desktop-nightly-download-linux'
+                );
+            }
             const linux64NightlyDownload = page.getByTestId(
                 'desktop-nightly-download-linux64'
             );
@@ -135,43 +168,38 @@ test.describe(
                 'desktop-nightly-download-osx'
             );
 
-            test.skip(
-                browserName === 'webkit',
-                'Safari not available on Linux'
-            );
-
-            // Set Linux UA strings.
-            await page.addInitScript({
-                path: `./scripts/useragent/linux/${browserName}.js`
-            });
-            await page.goto(url + '?automation=true');
-
             // Assert Linux download buttons are displayed.
-            await expect(linuxBetaDownload).toBeVisible();
-            await expect(linuxBetaDownload).toHaveAttribute(
-                'href',
-                /\?product=firefox-beta-latest-ssl&os=linux/
-            );
+            if (beta_linux_32) {
+                await expect(linuxBetaDownload).toBeVisible();
+                await expect(linuxBetaDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-beta-latest-ssl&os=linux/
+                );
+            }
             await expect(linux64BetaDownload).toBeVisible();
             await expect(linux64BetaDownload).toHaveAttribute(
                 'href',
                 /\?product=firefox-beta-latest-ssl&os=linux64/
             );
-            await expect(linuxDevDownload).toBeVisible();
-            await expect(linuxDevDownload).toHaveAttribute(
-                'href',
-                /\?product=firefox-devedition-latest-ssl&os=linux/
-            );
+            if (dev_linux_32) {
+                await expect(linuxDevDownload).toBeVisible();
+                await expect(linuxDevDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=linux/
+                );
+            }
             await expect(linux64DevDownload).toBeVisible();
             await expect(linux64DevDownload).toHaveAttribute(
                 'href',
                 /\?product=firefox-devedition-latest-ssl&os=linux64/
             );
-            await expect(linuxNightlyDownload).toBeVisible();
-            await expect(linuxNightlyDownload).toHaveAttribute(
-                'href',
-                /\?product=firefox-nightly-latest-ssl&os=linux/
-            );
+            if (nightly_linux_32) {
+                await expect(linuxNightlyDownload).toBeVisible();
+                await expect(linuxNightlyDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-nightly-latest-ssl&os=linux/
+                );
+            }
             await expect(linux64NightlyDownload).toBeVisible();
             await expect(linux64NightlyDownload).toHaveAttribute(
                 'href',

--- a/tests/playwright/specs/products/firefox/firefox-developer.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-developer.spec.js
@@ -90,21 +90,38 @@ test.describe(
             await page.goto(url + '?automation=true');
 
             // Assert Linux download buttons are displayed.
-            await expect(introDownloadLinux).toBeVisible();
-            await expect(introDownloadLinux).toHaveAttribute(
-                'href',
-                /\?product=firefox-devedition-latest-ssl&os=linux/
+
+            // Linux 32 buttons disappearing in release 145 (Release will be at 144 when Dev ed is at 145) (Issue #466)
+            const latest_firefox = await page.evaluate(
+                () =>
+                    document.documentElement
+                        .getAttribute('data-latest-firefox')
+                        .split('.')[0]
             );
+            const dev_linux_32 = latest_firefox < 144 ? true : false;
+
+            if (dev_linux_32) {
+                await expect(introDownloadLinux).toBeVisible();
+                await expect(introDownloadLinux).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=linux/
+                );
+            }
+
             await expect(introDownloadLinux64).toBeVisible();
             await expect(introDownloadLinux64).toHaveAttribute(
                 'href',
                 /\?product=firefox-devedition-latest-ssl&os=linux64/
             );
-            await expect(footerDownloadLinux).toBeVisible();
-            await expect(footerDownloadLinux).toHaveAttribute(
-                'href',
-                /\?product=firefox-devedition-latest-ssl&os=linux/
-            );
+
+            if (dev_linux_32) {
+                await expect(footerDownloadLinux).toBeVisible();
+                await expect(footerDownloadLinux).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=linux/
+                );
+            }
+
             await expect(footerDownloadLinux64).toBeVisible();
             await expect(footerDownloadLinux64).toHaveAttribute(
                 'href',

--- a/tests/playwright/specs/products/firefox/firefox-download.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-download.spec.js
@@ -77,16 +77,28 @@ test.describe(
             });
 
             // Assert Linux 32-bit / 64-bit choices are displayed.
-            const downloadButtonLinux32 = page.getByTestId(
-                'thanks-download-button-linux-32'
+
+            // Linux 32 buttons disappearing in Release 145 (Issue #466)
+            const latest_firefox = await page.evaluate(
+                () =>
+                    document.documentElement
+                        .getAttribute('data-latest-firefox')
+                        .split('.')[0]
             );
+            const release_linux_32 = latest_firefox < 145 ? true : false;
+
+            if (release_linux_32) {
+                const downloadButtonLinux32 = page.getByTestId(
+                    'thanks-download-button-linux-32'
+                );
+                await expect(downloadButtonLinux32).toBeVisible();
+                await expect(downloadButtonLinux32).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-latest-ssl&os=linux/
+                );
+            }
             const downloadButtonLinux64 = page.getByTestId(
                 'thanks-download-button-linux-64'
-            );
-            await expect(downloadButtonLinux32).toBeVisible();
-            await expect(downloadButtonLinux32).toHaveAttribute(
-                'href',
-                /\?product=firefox-latest-ssl&os=linux/
             );
             await expect(downloadButtonLinux64).toBeVisible();
             await expect(downloadButtonLinux64).toHaveAttribute(

--- a/tests/playwright/specs/products/firefox/firefox-home-refresh.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-home-refresh.spec.js
@@ -77,16 +77,28 @@ test.describe(
             });
 
             // Assert Linux 32-bit / 64-bit choices are displayed.
-            const downloadButtonLinux32 = page.getByTestId(
-                'thanks-download-button-linux-32'
+
+            // Linux 32 buttons disappearing in 145 (Issue #466)
+            const latest_firefox = await page.evaluate(
+                () =>
+                    document.documentElement
+                        .getAttribute('data-latest-firefox')
+                        .split('.')[0]
             );
+            const release_linux_32 = latest_firefox < 145 ? true : false;
+
+            if (release_linux_32) {
+                const downloadButtonLinux32 = page.getByTestId(
+                    'thanks-download-button-linux-32'
+                );
+                await expect(downloadButtonLinux32).toBeVisible();
+                await expect(downloadButtonLinux32).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-latest-ssl&os=linux/
+                );
+            }
             const downloadButtonLinux64 = page.getByTestId(
                 'thanks-download-button-linux-64'
-            );
-            await expect(downloadButtonLinux32).toBeVisible();
-            await expect(downloadButtonLinux32).toHaveAttribute(
-                'href',
-                /\?product=firefox-latest-ssl&os=linux/
             );
             await expect(downloadButtonLinux64).toBeVisible();
             await expect(downloadButtonLinux64).toHaveAttribute(


### PR DESCRIPTION
## One-line summary

Skip tests for linux 32bit if Firefox version >= 145

## Significant changes and points to review

Preparing for Linux 32 bit download buttons to start disappearing from the site.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/466

## Testing

`npm run integration-tests`