### PR TITLE
Dim images in dark mode

### DIFF
--- a/media/css/cms/flare-defaults.css
+++ b/media/css/cms/flare-defaults.css
@@ -65,12 +65,8 @@ img, svg {
     margin: 0 0 var(--grids-spacing-interior-spacing-x1)rem 0;
 }
 
-[data-theme="dark"] img, [data-theme="dark"] svg {
-  filter: brightness(.8) contrast(1.2);
-}
-
 @media (prefers-color-scheme: dark) {
-  img, svg {
+  .dim-images-on-dark-mode img {
     filter: brightness(.8) contrast(1.2);
   }
 }

--- a/springfield/cms/templates/components/intro.html
+++ b/springfield/cms/templates/components/intro.html
@@ -17,7 +17,7 @@
     {% endif %}
   </div>
   {% if contents.media %}
-    <div class="intro-media">
+    <div class="intro-media dim-images-on-dark-mode">
       {{ contents.media }}
     </div>
   {% endif %}

--- a/springfield/cms/templates/components/media-content.html
+++ b/springfield/cms/templates/components/media-content.html
@@ -6,7 +6,7 @@
 
 <div class="fl-mediacontent fl-mediacontent-feature{% if media_after %} fl-mediacontent-reverse{% endif %}">
   {% if contents.media %}
-    <div class="fl-mediacontent-media" aria-hidden="true">
+    <div class="fl-mediacontent-media dim-images-on-dark-mode" aria-hidden="true">
       {{ contents.media }}
     </div>
   {% endif %}


### PR DESCRIPTION
## One-line summary

Uses a CSS filter to dim images in dark mode

## Significant changes and points to review

This only applies to img and svg elements, not to CSS background images. Those can either be handled by adding a filter to the element that has a background image, or if it is a hard-coded image, then the dark mode image should just be modified directly instead of relying on the filter.

## Testing

Check pages in dark mode.