### PR TITLE
Remove "global" from global root title

### DIFF
--- a/springfield/base/templates/404-locale.html
+++ b/springfield/base/templates/404-locale.html
@@ -14,7 +14,7 @@
   {%- endif -%}
 {%- endblock -%}
 
-{%- block page_title_suffix -%} — Firefox.com{%- endblock -%}
+{% block page_title_suffix %} — Firefox.com{% endblock %}
 
 {%- block page_desc -%}
   {%- if is_root -%}


### PR DESCRIPTION
## One-line summary

Simplifies root nonlocale page title for robots & link previews.

## Significant changes and points to review

The root title has been already disambiguated from other home pages so this extra bit is perhaps not necessary.

## Issue / Bugzilla link

#453

## Testing

http://localhost:8000/en-US/404-locale/
http://localhost:8000/ (in prod mode, and with Accept-Language empty)