### PR TITLE
Expand hit_popular_pages URLs for performance testing

### DIFF
--- a/profiling/hit_popular_pages.py
+++ b/profiling/hit_popular_pages.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Request a selection of pages that are populat on www.m.o from your local
+"""Request a selection of pages that are populat on www.f.c from your local
 runserver, so  that django-silk can capture performance info on them.
 
 Usage:
@@ -21,19 +21,37 @@ import requests
 
 paths = [
     "/en-US/",
-    "/en-US/firefox/121.0/system-requirements/",
+    "/en-US/thanks/",
+    "/en-US/thanks/?s=direct",
+    "/pt-BR/thanks/",
+    "/zh-TW/download/all/",
     "/en-US/download/all/",
-    "/en-US/firefox/android/124.0/releasenotes/",
+    "/en-US/firefox/123.0/system-requirements/",
+    "/en-US/firefox/android/123.0/releasenotes/",
     "/en-US/channel/desktop/",
     "/en-US/channel/desktop/?reason=manual-update",
     "/en-US/channel/desktop/developer/",
-    "/en-US/thanks/",
-    "/en-US/thanks/?s=direct",
+    "/de/",
+    "/sv-SE/browsers/mobile/get-app/",
+    "/en-US/browsers/mobile/get-app/",
+    "/en-US/browsers/mobile/android/",
+    "/en-US/browsers/mobile/focus/",
+    "/en-US/browsers/mobile/",
+    "/en-US/browsers/desktop/windows/",
+    "/en-US/browsers/desktop/linux/",
+    "/en-US/browsers/desktop/mac/",
+    "/en-US/browsers/desktop/chromebook/",
+    "/en-US/browsers/desktop/",
     "/en-US/browsers/enterprise/",
-    "/en-US/features/",
+    "/en-US/browsers/enterprise/?reason=manual-update",
     "/en-US/download/installer-help/?channel=release&installer_lang=en-US",
     "/en-US/releases/",
+    "/en-US/features/",
+    "/ja/features/",
     "/en-US/landing/set-as-default/thanks/",
+    "/en-US/more/what-is-a-browser/",
+    "/en-US/more/windows-64-bit/",
+    "/en-US/newsletter/",
 ]
 
 


### PR DESCRIPTION
## One-line summary

Expand the profiling list with page types now served from fxc.

## Significant changes and points to review

Selectively moves things removed over at [mozilla/bedrock#16812](https://github.com/mozilla/bedrock/pull/16812/files) …

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16405

## Testing

`ENABLE_DJANGO_SILK=True`
http://localhost:8000/silk/

https://github.com/mozmeao/springfield/blob/8535e817726d76c97130d905e33e681a341784ff/profiling/hit_popular_pages.py#L5-L13