### PR TITLE
Fix video analytics (ported from bedrock #16442)

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/includes/video.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/includes/video.html
@@ -1,0 +1,31 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import video_inline_embed with context %}
+
+{% if LANG == 'de' %}
+<div class="c-hero-video">
+  {{ video_inline_embed(
+    id='7yLoRVwuZlc',
+    title='Falls du noch mehr über die Facebook Container Erweiterung erfahren möchtest, schau dir gern unser Video an',
+    image=resp_img(
+      url='img/firefox/facebook-container/video-poster.png',
+      optional_attributes={
+        'width': '684',
+        'height': '385'
+      }
+    ),
+  ) }}
+</div>
+{% else %}
+<div class="mzp-c-video">
+  <video class="ga-video-engagement" id="fbcontainer-video" preload="metadata" controls title="Click to watch a video about Facebook Container"
+    poster="{{ static('img/firefox/facebook-container/video-poster.png') }}" data-ga-label="Facebook Container Video">
+      <source src="https://assets.mozilla.net/video/facebook-container/facebook-container.webm" type="video/webm">
+      <source src="https://assets.mozilla.net/video/facebook-container/facebook-container.webm" type="video/webm">
+  </video>
+</div>
+{% endif %}

--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -1,0 +1,111 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
+{% from "macros-protocol.html" import split, callout_compact with context %}
+
+{% extends "firefox/base/base-protocol.html" %}
+
+{% set addon_url = "https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-facebookcontainer&utm_source=www.mozilla.org-facebookcontainer&utm_medium=referral" %}
+
+{% block page_title %}{{ ftl('facebook-container-facebook-container-for-firefox') }}{% endblock %}
+{% block page_desc %}{{ ftl('facebook-container-millions-of-people-around') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-split')}}
+  {{ css_bundle('protocol-card')}}
+  {{ css_bundle('protocol-callout')}}
+  {{ css_bundle('firefox_facebook_container') }}
+{% endblock %}
+
+{% block sub_navigation %}
+  {% include 'firefox/includes/sub-nav-firefox.html' %}
+{% endblock %}
+
+{% block content %}
+<main>
+  {% call split(
+    block_class='mzp-l-split-center-on-sm-md mzp-t-split-nospace',
+    theme_class='mzp-t-dark',
+    media_class='mzp-l-split-h-center',
+    media_include='firefox/facebookcontainer/includes/video.html',
+    media_after=True,
+    ) %}
+    <div class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox">{{ ftl('facebook-container-brand-name-firefox-browser') }}</div>
+    <h1 class="mzp-u-title-lg">{{ ftl('facebook-container-facebook-well-contained-keep') }}</h1>
+
+    <p class="extension-cta" data-testid="get-extension-link">
+      <a class="mzp-c-cta-link" href="{{ addon_url }}">{{ ftl('facebook-container-get-the-facebook-container') }}</a>
+    </p>
+
+    <div class="firefox-cta">
+      <p>{{ ftl('facebook-container-download-firefox-and-get-the') }}</p>
+      {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), dom_id="download-firefox-cta") }}
+    </div>
+
+    <div class="mobile-cta">
+        <p>{{ ftl('facebook-container-only-available-for-desktop') }}</p>
+        <p>{{ ftl('facebook-container-visit-to-get-for-desktop', url="https://www.firefox.com/?redirect_source=mozilla-org", link_copy='www.firefox.com') }}</p>
+
+      {% if ftl_has_messages('facebook-container-get-firefox-android-ios') %}
+        <p>{{ ftl('facebook-container-get-firefox-android-ios') }}</p>
+
+        <ul>
+          <li>
+            {{ google_play_button(href=play_store_url('firefox', 'firefox-facebook-container'), id='playStoreLink') }}
+          </li>
+          <li>
+            {{ apple_app_store_button(href=app_store_url('firefox', 'firefox-facebook-container'), id='appStoreLink') }}
+          </li>
+        </ul>
+      {% endif %}
+    </div>
+  {% endcall %}
+
+  <section class="mzp-l-content mzp-l-card-third">
+    <div class="mzp-c-card">
+      <h3 class="mzp-c-card-title">{{ ftl('facebook-container-opt-out-on-your-terms') }}</h3>
+      <p>
+      {{ ftl('facebook-container-facebook-can-track-almost', fbcontainer=addon_url) }}
+      </p>
+    </div>
+    <div class="mzp-c-card">
+      <h3 class="mzp-c-card-title">{{ ftl('facebook-container-install-and-contain') }}</h3>
+      <p>
+      {{ ftl('facebook-container-installing-the-extension-is', fbcontainer=addon_url) }}
+      </p>
+    </div>
+    <div class="mzp-c-card">
+      <h3 class="mzp-c-card-title">{{ ftl('facebook-container-about-firefox-and-mozilla') }}</h3>
+      <p>
+      {{ ftl('facebook-container-were-backed-by-mozilla-the', mozilla=url('mozorg.home')) }}
+      </p>
+    </div>
+  </section>
+
+  <section class="firefox-cta">
+    {% call callout_compact(
+      title=ftl('facebook-container-browse-freely-with-firefox'),
+      class='mzp-t-dark',
+      heading_level=2,
+      brand=True,
+      brand_product='firefox',
+      brand_type='logo',
+      brand_size='lg')
+    %}
+    {{ download_firefox(alt_copy=ftl('download-button-download-now'), dom_id="download-firefox-today") }}
+    {% endcall %}
+  </section>
+</main>
+{% endblock %}
+
+{% block js %}
+  {% if LANG == "de" %}
+    {{ js_bundle('video-inline-embed') }}
+  {% else %}
+    {{ js_bundle('data_videoengagement') }}
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/includes/fx137/video.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/fx137/video.html
@@ -1,0 +1,33 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% from "macros.html" import video_inline_embed with context %}
+
+{% if LANG == "fr" %}
+ {% set video_src= 'https://assets.mozilla.net/video/whatsnew/wnp-137-fr-high-res-v2.webm' %}
+ {% set poster_high_res_src= 'img/firefox/whatsnew/whatsnew137/poster-fr-high-res.avif' %}
+{% elif LANG == "de" %}
+ {% set video_src = 'https://assets.mozilla.net/video/whatsnew/wnp-137-de-high-res-v2.webm' %}
+ {% set poster_high_res_src= 'img/firefox/whatsnew/whatsnew137/poster-de-high-res.avif' %}
+{% else %}
+ {% set video_src = 'https://assets.mozilla.net/video/whatsnew/wnp-137-en-high-res-v2.webm' %}
+ {% set poster_high_res_src= 'img/firefox/whatsnew/whatsnew137/poster-en-high-res.avif' %}
+{% endif %}
+
+<div class="mzp-c-video mzp-has-aspect-4-3">
+  <video
+    class="ga-video-engagement"
+    data-ga-title="wnp-137"
+    id="wnp-video"
+    preload="none"
+    loop
+    controls
+    width="472"
+    height="354"
+    poster="{{ static(poster_high_res_src) }}">
+      <source src="{{ video_src }}" type="video/webm">
+  </video>
+</div>

--- a/bedrock/firefox/templates/firefox/whatsnew/includes/fx138/video.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/fx138/video.html
@@ -1,0 +1,31 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% if LANG == "fr" %}
+  {% set video_src = 'https://assets.mozilla.net/video/whatsnew/138/wnp-138-fr-high-res-v3.webm' %}
+  {% set poster_high_res_src = 'img/firefox/whatsnew/whatsnew138/poster-fr-high-res.png' %}
+{% elif LANG == "de" %}
+  {% set video_src = 'https://assets.mozilla.net/video/whatsnew/138/wnp-138-de-high-res-v3.webm' %}
+  {% set poster_high_res_src = 'img/firefox/whatsnew/whatsnew138/poster-de-high-res.png' %}
+{% else %}
+  {% set video_src = 'https://assets.mozilla.net/video/whatsnew/138/wnp-138-en-high-res-v3.webm' %}
+  {% set poster_high_res_src = 'img/firefox/whatsnew/whatsnew138/poster-en-high-res.png' %}
+{% endif %}
+
+<div class="mzp-c-video">
+  <video
+    class="ga-video-engagement"
+    data-ga-title="wnp-138"
+    id="wnp-video"
+    preload="none"
+    loop
+    controls
+    width="1136"
+    height="641"
+    poster="{{ static(poster_high_res_src) }}">
+      <source src="{{ video_src }}" type="video/webm">
+  </video>
+</div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx137-vertical-tabs.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx137-vertical-tabs.html
@@ -1,0 +1,52 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros-protocol.html" import split with context %}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('firefox_whatsnew_137_vertical_tabs') }}
+{% endblock %}
+
+{% if LANG == 'de' %}
+  {% set main_title = 'Neu: Mehr Übersicht, weniger Tab-Chaos' %}
+  {% set main_tagline = 'Mit der neuen Firefox-Seitenleiste behältst du den Überblick: Tabs einfach zur Seite schieben, Lieblingsseiten anpinnen und deinen KI-Assistenten immer parat haben.' %}
+  {% set main_cta = 'Seitenleiste aktivieren' %}
+{% elif LANG == 'fr' %}
+  {% set main_title = 'À la une ! Moins de désordre et plus de focus grâce aux onglets verticaux' %}
+  {% set main_tagline = 'Le panneau latéral vous permet désormais de déplacer vos onglets sur le côté, d’épingler vos favoris et de garder votre assistant IA sous la main.' %}
+  {% set main_cta = 'Activer le panneau latéral' %}
+{% else %}
+  {% set main_title = 'New! Less clutter and more focus with vertical tabs' %}
+  {% set main_tagline = 'Firefox’s new sidebar lets you move tabs to the side, pin key sites and keep your AI assistant handy.' %}
+  {% set main_cta = 'Enable the new sidebar' %}
+{% endif %}
+
+{% block wnp_content %}
+  {% call split(
+    block_class='wnp-content-main mzp-l-split-center-on-sm-md',
+    body_class='wnp-content-wrapper',
+    media_include='firefox/whatsnew/includes/fx137/video.html',
+    media_class='wnp-video-wrapper mzp-l-split-h-center',
+    media_after=True
+    ) %}
+      <h2 class="wnp-content-title mzp-u-title-sm">{{ main_title }}</h2>
+      <p class="wnp-content-tagline">{{ main_tagline }}</p>
+      <p class="wnp-main-cta"><button data-cta-text="Enable the new sidebar" data-cta-position="primary" class="mzp-c-button mzp-t-product">{{ main_cta }}</button></p>
+  {% endcall %}
+
+  <section class="wnp-footer">
+    <p class="wnp-sign-off">{{ ftl('whatsnew-signoff') }}</p>
+    {% include "firefox/whatsnew/includes/mofo-donate-cta.html" %}
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_137') }}
+  {{ js_bundle('data_videoengagement') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx138-tab-groups.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx138-tab-groups.html
@@ -1,0 +1,56 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros-protocol.html" import split with context %}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('firefox_whatsnew_138') }}
+{% endblock %}
+
+{% if LANG == 'de' %}
+  {% set main_title = 'Übernimm die Kontrolle über deinen Browser – mit Tab-Gruppen' %}
+  {% set main_tagline = '<p>Sag dem Tab-Chaos Lebewohl! Bleibe fokussiert, nutze deine Zeit effizient und behalte stets den Überblick.</p><p>Zieh einfach einen Tab auf einen anderen, um eine Gruppe zu erstellen.</p>' %}
+  {% set main_cta = 'Erfahre jetzt mehr' %}
+  {% set main_cta_url = 'https://support.mozilla.org/de/kb/tab-groups' %}
+{% elif LANG == 'fr' %}
+  {% set main_title = 'Prenez le contrôle de votre navigation avec les groupes d’onglets' %}
+  {% set main_tagline = '<p>Fini le trop-plein d’onglets. Organisez-vous et contrôlez votre temps et votre capacité d’attention.</p><p>Glissez un onglet sur un autre pour créer votre premier groupe.</p>' %}
+  {% set main_cta = 'Montrez-moi' %}
+  {% set main_cta_url = 'https://support.mozilla.org/fr/kb/groupes-onglets' %}
+{% else %}
+  {% set main_title = 'Take control of your browsing with tab groups' %}
+  {% set main_tagline = '<p>No more tab overload. Stay organized and in control of your time and attention.</p><p>Drag one tab onto another to create your first group.</p>' %}
+  {% set main_cta = 'Show me how' %}
+  {% set main_cta_url = 'https://support.mozilla.org/kb/tab-groups' %}
+{% endif %}
+
+{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp138' %}
+
+{% block wnp_content %}
+  {% call split(
+    block_class='wnp-content-main mzp-l-split-center-on-sm-md',
+    body_class='wnp-content-wrapper',
+    media_include='firefox/whatsnew/includes/fx138/video.html',
+    media_class='wnp-video-wrapper mzp-l-split-h-center',
+    media_after=True
+    ) %}
+      <h2 class="wnp-content-title">{{ main_title }}</h2>
+      <div class="wnp-content-tagline">{{ main_tagline | safe }}</div>
+      <p class="wnp-main-cta"><a href="{{ main_cta_url }}?{{ utm_params }}" rel="external" data-cta-text="Show me how" data-cta-position="primary" class="mzp-c-button mzp-t-product">{{ main_cta }}</a></p>
+  {% endcall %}
+
+  <section class="wnp-footer">
+    <p class="wnp-sign-off">{{ ftl('whatsnew-signoff') }}</p>
+    {% include "firefox/whatsnew/includes/mofo-donate-cta.html" %}
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('data_videoengagement') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx141-customize-new-tab.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx141-customize-new-tab.html
@@ -1,0 +1,78 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_141') }}
+{% endblock %}
+
+{# Don't forget to set '<title>%s</title>' content when formatting, e.g. per locale from 'icon_title'. #}
+
+{% set pencil_icon = '<svg role="img" xmlns="http://www.w3.org/2000/svg" width="18" height="19" viewBox="0 0 18 19"><title>%s</title><g clip-path="url(#a)"><path fill="currentColor" d="M16.935 4.622 14 1.672a1.035 1.035 0 0 0-1.46 0L2.135 12.062l-.95 4.1a1.03 1.03 0 0 0 1 1.25q.107.01.215 0l4.145-.95 10.39-10.38a1.035 1.035 0 0 0 0-1.46m-10.89 10.94-3.885.815.885-3.81 7.785-7.755 3 3zM14.5 7.087l-3-3 1.74-1.73 2.95 3z"/></g><defs><clipPath id="a"><path d="M0 .462h18v18H0z"/></clipPath></defs></svg>' %}
+
+{% if LANG == 'de' %}
+  {% set main_title = 'Ein neuer Tab, ganz nach deinem Geschmack.' %}
+  {% set main_tagline = '<p class="t-wrapper">Gestalte einen Raum, der nur dir gehört. Passe die Atmosphäre mit Firefox-Hintergründen, eigenen Farben oder einem Foto an.</p><p>Öffne einen neuen Tab und klicke auf das Icon ' + pencil_icon + ', um mit den Anpassungen zu starten.</p>' %}
+  {% set main_cta = 'Jetzt ausprobieren' %}
+  {% set video_src = 'https://assets.mozilla.net/video/whatsnew/141/wnp-141-de.webm' %}
+  {% set icon_title = 'Anpassen' %}
+{% elif LANG == 'fr' %}
+  {% set main_title = 'Votre nouvel onglet, à votre façon' %}
+  {% set main_tagline = '<p class="t-wrapper">Créez un espace qui vous ressemble. Donnez le ton avec des fonds d’écran Firefox, des coloris personnalisés ou vos propres photos.</p><p>Ouvrez un nouvel onglet et cliquez sur l’icône ' + pencil_icon + ' pour lancer la personnalisation.</p>' %}
+  {% set main_cta = 'Essayer maintenant' %}
+  {% set video_src = 'https://assets.mozilla.net/video/whatsnew/141/wnp-141-fr.webm' %}
+  {% set icon_title = 'Personnaliser' %}
+{% else %}
+  {% set main_title = 'Make your New Tab feel like home' %}
+  {% set main_tagline = '<p class="t-wrapper">Create a space that’s uniquely yours. Set the mood with Firefox wallpapers, custom colors, or your own photo.</p><p>Open a new tab and click the ' + pencil_icon + ' icon to start customizing</p>' %}
+  {% set main_cta = 'Try it now' %}
+  {% set video_src = 'https://assets.mozilla.net/video/whatsnew/141/wnp-141-en.webm' %}
+  {% set icon_title = 'Customize' %}
+{% endif %}
+
+{% block wnp_content %}
+<section class="wnp-content-main">
+  <div class="mzp-l-content mzp-t-content-lg">
+    <h1 class="wnp-main-title">{{ main_title }}</h1>
+    <div class="c-video-wrapper t-wrapper">
+      <img class="c-video-background" src="{{ static('img/firefox/whatsnew/whatsnew141-customize/multi-browser-cool-colors.png') }}" alt="">
+      <div class="mzp-c-video">
+        <video
+          class="ga-video-engagement"
+          data-ga-title="wnp-141"
+          id="wnp-video"
+          preload="none"
+          controls
+          loop
+          width="847"
+          height="476"
+          poster="{{ static('img/firefox/whatsnew/whatsnew141-customize/poster-high-res.jpg') }}">
+            <source src="{{ video_src }}" type="video/webm">
+        </video>
+      </div>
+    </div>
+    <div class="wnp-main-tagline">
+      {{ main_tagline | safe | format(icon_title) }}
+    </div>
+    <p class="wnp-main-cta">
+      <button class="mzp-c-button mzp-t-product" data-cta-type="button" data-cta-text="Try it now">
+        {{ main_cta }}
+      </button>
+    </p>
+  </div>
+</section>
+
+<section class="wnp-footer">
+  <p class="wnp-sign-off">{{ ftl('whatsnew-signoff') }}</p>
+  {% include "firefox/whatsnew/includes/mofo-donate-cta.html" %}
+</section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_141') }}
+  {{ js_bundle('data_videoengagement') }}
+{% endblock %}

--- a/media/js/base/datalayer-videoengagement-init.es6.js
+++ b/media/js/base/datalayer-videoengagement-init.es6.js
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import VideoEngagement from './datalayer-videoengagement.es6';
+
+// Create namespace
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+window.Mozilla.VideoEngagement = VideoEngagement;
+
+// Init tracking on HTML videos
+// YouTube video tracking is handled automatically with GA4 enhanced measurement
+const HTMLVideos = document.querySelectorAll('.ga-video-engagement');
+for (let i = 0; i < HTMLVideos.length; ++i) {
+    const video = HTMLVideos[i];
+    video.addEventListener('play', VideoEngagement.handleStart, {
+        once: true
+    });
+    // Floor duration because we don't need precise numbers here
+    video.addEventListener('loadedmetadata', (e) => {
+        VideoEngagement.duration = Math.floor(e.target.duration);
+    });
+    // 'timeupdate' will handle both video_progress and video_complete data
+    // ('ended' not reliable: if 'loop' is true, it will not fire)
+    video.addEventListener('timeupdate', VideoEngagement.throttledProgress);
+}

--- a/media/js/base/datalayer-videoengagement.es6.js
+++ b/media/js/base/datalayer-videoengagement.es6.js
@@ -1,0 +1,151 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+if (typeof window.dataLayer === 'undefined') {
+    window.dataLayer = [];
+}
+
+// Match "Video Engagement" events from GA4:
+// https://support.google.com/analytics/answer/9216061
+const VideoEngagement = {};
+
+// Set when video starts
+VideoEngagement.title;
+VideoEngagement.url;
+// Set when metadata fully loads
+VideoEngagement.duration = null;
+// Match GA4 thresholds
+VideoEngagement.progressThresholds = [10, 25, 50, 75];
+
+// https://rahultomar092.medium.com/throttling-in-js-with-leading-and-trailing-4a60d5d99122
+VideoEngagement.throttle = (func, wait) => {
+    let waiting = false;
+    let lastArgs = null;
+    return function wrapper(...args) {
+        if (waiting === false) {
+            waiting = true;
+            // helper function to trigger a new waiting period
+            const startWaitingPeriod = () =>
+                setTimeout(() => {
+                    // if at the end of the waiting period lastArgs exist, execute the function using it
+                    if (lastArgs) {
+                        func.apply(this, lastArgs);
+                        lastArgs = null;
+                        // start another waiting period
+                        startWaitingPeriod();
+                    } else {
+                        waiting = false;
+                    }
+                }, wait);
+            func.apply(this, args);
+            startWaitingPeriod();
+        } else {
+            lastArgs = args; // store the arguments of the last function call within waiting period
+        }
+    };
+};
+
+VideoEngagement.sendEvent = (videoObject) => {
+    window.dataLayer.push({
+        event: videoObject.event,
+        visible: true,
+        video_duration: VideoEngagement.duration,
+        video_title: VideoEngagement.title,
+        video_url: VideoEngagement.url,
+        video_provider: 'self-hosted',
+        video_current_time: videoObject.currentTime,
+        video_percent: videoObject.percent
+    });
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play_event
+// NOTE: this event is configured to only fire once, does not need listener removed
+VideoEngagement.handleStart = (e) => {
+    VideoEngagement.url = e.target.currentSrc;
+    VideoEngagement.title = e.target.dataset.gaTitle || e.target.title;
+
+    VideoEngagement.sendEvent({
+        event: 'video_start',
+        currentTime: 0,
+        percent: 0
+    });
+};
+
+// Rounded because we don't need precise numbers
+VideoEngagement.getPercentageComplete = (currentTime) => {
+    return Math.round((currentTime / VideoEngagement.duration) * 100);
+};
+
+VideoEngagement.getPassedThresholds = (percentageComplete) => {
+    return VideoEngagement.progressThresholds.filter(
+        (threshold) => percentageComplete >= threshold
+    );
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/timeupdate_event
+VideoEngagement.handleProgress = (e) => {
+    const currentTime = Math.round(e.target.currentTime);
+    const percentageComplete =
+        VideoEngagement.getPercentageComplete(currentTime);
+    const lastThresholdCompleted = e.target.hasAttribute('data-ga-threshold')
+        ? parseInt(e.target.getAttribute('data-ga-threshold'), 10)
+        : 0;
+
+    // Check if video has ended
+    if (percentageComplete === 100) {
+        // Send complete event
+        VideoEngagement.sendEvent({
+            event: 'video_complete',
+            currentTime,
+            percent: 100
+        });
+
+        // Stop sending events
+        e.target.removeEventListener(
+            'timeupdate',
+            VideoEngagement.throttledProgress
+        );
+    } else if (percentageComplete < lastThresholdCompleted) {
+        // If video looped before we recorded complete event
+        VideoEngagement.sendEvent({
+            event: 'video_complete',
+            currentTime: VideoEngagement.duration,
+            percent: 100
+        });
+
+        // Stop sending events
+        e.target.removeEventListener(
+            'timeupdate',
+            VideoEngagement.throttledProgress
+        );
+    } else {
+        // Check if we have a progress event to send
+        const passedThresholds =
+            VideoEngagement.getPassedThresholds(percentageComplete);
+        if (passedThresholds.length > 0) {
+            const currentThreshold =
+                passedThresholds[passedThresholds.length - 1];
+            // Send progress event if we've passed a new threshold
+            if (currentThreshold > lastThresholdCompleted) {
+                VideoEngagement.sendEvent({
+                    event: 'video_progress',
+                    currentTime,
+                    percent: currentThreshold
+                });
+                // Store record of sent threshold data for this element
+                e.target.setAttribute('data-ga-threshold', currentThreshold);
+            }
+        }
+    }
+};
+
+// Set reference to throttle function so we can remove listener event
+VideoEngagement.throttledProgress = VideoEngagement.throttle(
+    VideoEngagement.handleProgress,
+    1000 // wait time in milliseconds
+);
+
+export default VideoEngagement;

--- a/media/js/base/video-inline-embed.es6.js
+++ b/media/js/base/video-inline-embed.es6.js
@@ -16,7 +16,6 @@ const src = 'https://www.youtube.com/iframe_api';
 let videoLink;
 let videoId;
 let videoStart;
-let title;
 
 function loadScript() {
     const tag = document.createElement('script');
@@ -46,37 +45,12 @@ function playVideo() {
             cc_load_policy: 1 // show captions.
         },
         events: {
-            onReady: onPlayerReady,
-            onStateChange: onPlayerStateChange
+            onReady: onPlayerReady
         }
     });
 
     function onPlayerReady(event) {
         event.target.playVideo();
-    }
-
-    function onPlayerStateChange(event) {
-        let state;
-
-        switch (event.data) {
-            case window.YT.PlayerState.PLAYING:
-                state = 'video play';
-                break;
-            case window.YT.PlayerState.PAUSED:
-                state = 'video paused';
-                break;
-            case window.YT.PlayerState.ENDED:
-                state = 'video complete';
-                break;
-        }
-
-        if (state) {
-            window.dataLayer.push({
-                event: 'video-interaction',
-                videoTitle: title,
-                interaction: state
-            });
-        }
     }
 }
 
@@ -102,7 +76,6 @@ function init() {
                 videoLink.getAttribute('data-video-start'),
                 10
             );
-            title = videoLink.getAttribute('data-video-title');
             initVideoPlayer();
         });
     }

--- a/media/js/base/video-modal-embed.es6.js
+++ b/media/js/base/video-modal-embed.es6.js
@@ -38,9 +38,6 @@ function isScriptLoaded() {
 }
 
 function playVideo() {
-    const title = document.querySelector(
-        '.mzp-c-modal-inner > header > h2'
-    ).innerText;
     const videoLink = document.querySelector(
         '.mzp-c-modal-inner .video-player-frame'
     );
@@ -63,37 +60,12 @@ function playVideo() {
             cc_load_policy: 1 // show captions.
         },
         events: {
-            onReady: onPlayerReady,
-            onStateChange: onPlayerStateChange
+            onReady: onPlayerReady
         }
     });
 
     function onPlayerReady(event) {
         event.target.playVideo();
-    }
-
-    function onPlayerStateChange(event) {
-        let state;
-
-        switch (event.data) {
-            case window.YT.PlayerState.PLAYING:
-                state = 'video play';
-                break;
-            case window.YT.PlayerState.PAUSED:
-                state = 'video paused';
-                break;
-            case window.YT.PlayerState.ENDED:
-                state = 'video complete';
-                break;
-        }
-
-        if (state) {
-            window.dataLayer.push({
-                event: 'video-interaction',
-                videoTitle: title,
-                interaction: state
-            });
-        }
     }
 }
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -663,6 +663,12 @@
     },
     {
       "files": [
+        "js/base/datalayer-videoengagement-init.es6.js"
+      ],
+      "name": "data_videoengagement"
+    },
+    {
+      "files": [
         "js/firefox/browsers/ios-summarizer.js"
       ],
       "name": "ios_summarizer"

--- a/tests/unit/spec/base/datalayer-videoengagement.js
+++ b/tests/unit/spec/base/datalayer-videoengagement.js
@@ -1,0 +1,193 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import VideoEngagement from '../../../../media/js/base/datalayer-videoengagement.es6.js';
+
+describe('datalayer-videoengagement.es6.js', function () {
+    const gaEventNames = ['video_start', 'video_progress', 'video_complete'];
+    const videoTitle = 'Test';
+    const videoUrl = 'https://assets.mozilla.net/video/test.webm';
+    const videoProvider = 'self-hosted';
+    const videoVisible = true;
+    const videoDuration = 100;
+    const percentage10 = 10;
+    const percentage25 = 25;
+    const percentage50 = 50;
+    const percentage75 = 75;
+    const percentage100 = 100;
+
+    const expectedEventStart = {
+        event: gaEventNames[0],
+        visible: videoVisible,
+        video_duration: videoDuration,
+        video_title: videoTitle,
+        video_url: videoUrl,
+        video_provider: videoProvider,
+        video_current_time: 0,
+        video_percent: 0
+    };
+
+    const expectedEventProgress = {
+        event: gaEventNames[1],
+        visible: videoVisible,
+        video_duration: videoDuration,
+        video_title: videoTitle,
+        video_url: videoUrl,
+        video_provider: videoProvider,
+        video_current_time: 10,
+        video_percent: percentage10
+    };
+
+    const expectedEventComplete = {
+        event: gaEventNames[2],
+        visible: videoVisible,
+        video_duration: videoDuration,
+        video_title: videoTitle,
+        video_url: videoUrl,
+        video_provider: videoProvider,
+        video_current_time: videoDuration,
+        video_percent: percentage100
+    };
+
+    beforeEach(function () {
+        window.dataLayer = [];
+        VideoEngagement.duration = videoDuration;
+    });
+
+    afterEach(function () {
+        delete window.dataLayer;
+        VideoEngagement.duration = null;
+    });
+
+    it('calculates percentage completed correctly', function () {
+        expect(
+            VideoEngagement.getPercentageComplete(percentage10) ===
+                VideoEngagement.progressThresholds[0]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage25) ===
+                VideoEngagement.progressThresholds[1]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage50) ===
+                VideoEngagement.progressThresholds[2]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage75) ===
+                VideoEngagement.progressThresholds[3]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage100) === 100
+        ).toBeTruthy();
+    });
+
+    it('correctly identifies when multiple progress thresholds have been passed', function () {
+        spyOn(VideoEngagement, 'getPercentageComplete').and.returnValue(
+            percentage50
+        );
+        const passedThresholds =
+            VideoEngagement.getPassedThresholds(percentage50);
+        expect(passedThresholds.length).toBe(3);
+    });
+
+    it('will append the start event to the dataLayer', function () {
+        VideoEngagement.sendEvent(expectedEventStart);
+        expect(window.dataLayer[0]['event'] === 'video_start').toBeTruthy();
+    });
+
+    it('will append the progress event to the dataLayer', function () {
+        VideoEngagement.sendEvent(expectedEventProgress);
+        expect(window.dataLayer[0]['event'] === 'video_progress').toBeTruthy();
+    });
+
+    it('will append the complete event to the dataLayer', function () {
+        VideoEngagement.sendEvent(expectedEventComplete);
+        expect(window.dataLayer[0]['event'] === 'video_complete').toBeTruthy();
+    });
+
+    describe('handleProgress', () => {
+        let mockEvent, sendEventSpy;
+
+        beforeEach(() => {
+            mockEvent = {
+                target: {
+                    currentTime: 0,
+                    hasAttribute: jasmine.createSpy('hasAttribute'),
+                    getAttribute: jasmine.createSpy('getAttribute'),
+                    setAttribute: jasmine.createSpy('setAttribute'),
+                    removeEventListener: jasmine.createSpy(
+                        'removeEventListener'
+                    )
+                }
+            };
+
+            sendEventSpy = spyOn(VideoEngagement, 'sendEvent');
+        });
+
+        it('should call sendEvent with "video_progress" when video is in progress', () => {
+            mockEvent.target.currentTime = 50;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('25');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith({
+                event: 'video_progress',
+                currentTime: 50,
+                percent: 50
+            });
+            expect(mockEvent.target.setAttribute).toHaveBeenCalledWith(
+                'data-ga-threshold',
+                50
+            );
+        });
+
+        it('should call sendEvent with "video_complete" when video is complete', () => {
+            mockEvent.target.currentTime = 100;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('75');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith({
+                event: 'video_complete',
+                currentTime: 100,
+                percent: 100
+            });
+            expect(mockEvent.target.removeEventListener).toHaveBeenCalled();
+        });
+
+        it('should call sendEvent with "video_complete" when video has looped', () => {
+            mockEvent.target.currentTime = 10;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('75');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith({
+                event: 'video_complete',
+                currentTime: 100,
+                percent: 100
+            });
+            expect(mockEvent.target.removeEventListener).toHaveBeenCalled();
+        });
+
+        it('should not call sendEvent when no new threshold is passed', () => {
+            mockEvent.target.currentTime = 30;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('25');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
* Add basic ga4 custom video events

Needs some form of deboucing/throttling to be more performant with 'timeupdate' event triggers

* Remove outdated video-interaction WNP events

* Remove outdated video-interaction JS, replace with custom dataLayer as needed

For YouTube JS API videos, GA4 automatically collects start/progress/complete events. We do not need custom code for these videos.

HTML videos need to include the new data_videoengagement bundle and the video must have a class with 'ga-video-engagement'.

* Adjust progress events to work for multiple elements on page

* Consistently put event property as first arg for easier debugging

* Add throttle to timeupdate events

* Add tests for new dataLayer events

## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
