### PR TITLE
Port video analytics (bedrock#16442)

### DIFF
--- a/media/js/base/datalayer-videoengagement-init.es6.js
+++ b/media/js/base/datalayer-videoengagement-init.es6.js
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import VideoEngagement from './datalayer-videoengagement.es6';
+
+// Create namespace
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+window.Mozilla.VideoEngagement = VideoEngagement;
+
+// Init tracking on HTML videos
+// YouTube video tracking is handled automatically with GA4 enhanced measurement
+const HTMLVideos = document.querySelectorAll('.ga-video-engagement');
+for (let i = 0; i < HTMLVideos.length; ++i) {
+    const video = HTMLVideos[i];
+    video.addEventListener('play', VideoEngagement.handleStart, {
+        once: true
+    });
+    // Floor duration because we don't need precise numbers here
+    video.addEventListener('loadedmetadata', (e) => {
+        VideoEngagement.duration = Math.floor(e.target.duration);
+    });
+    // 'timeupdate' will handle both video_progress and video_complete data
+    // ('ended' not reliable: if 'loop' is true, it will not fire)
+    video.addEventListener('timeupdate', VideoEngagement.throttledProgress);
+}

--- a/media/js/base/datalayer-videoengagement.es6.js
+++ b/media/js/base/datalayer-videoengagement.es6.js
@@ -1,0 +1,151 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+if (typeof window.dataLayer === 'undefined') {
+    window.dataLayer = [];
+}
+
+// Match "Video Engagement" events from GA4:
+// https://support.google.com/analytics/answer/9216061
+const VideoEngagement = {};
+
+// Set when video starts
+VideoEngagement.title;
+VideoEngagement.url;
+// Set when metadata fully loads
+VideoEngagement.duration = null;
+// Match GA4 thresholds
+VideoEngagement.progressThresholds = [10, 25, 50, 75];
+
+// https://rahultomar092.medium.com/throttling-in-js-with-leading-and-trailing-4a60d5d99122
+VideoEngagement.throttle = (func, wait) => {
+    let waiting = false;
+    let lastArgs = null;
+    return function wrapper(...args) {
+        if (waiting === false) {
+            waiting = true;
+            // helper function to trigger a new waiting period
+            const startWaitingPeriod = () =>
+                setTimeout(() => {
+                    // if at the end of the waiting period lastArgs exist, execute the function using it
+                    if (lastArgs) {
+                        func.apply(this, lastArgs);
+                        lastArgs = null;
+                        // start another waiting period
+                        startWaitingPeriod();
+                    } else {
+                        waiting = false;
+                    }
+                }, wait);
+            func.apply(this, args);
+            startWaitingPeriod();
+        } else {
+            lastArgs = args; // store the arguments of the last function call within waiting period
+        }
+    };
+};
+
+VideoEngagement.sendEvent = (videoObject) => {
+    window.dataLayer.push({
+        event: videoObject.event,
+        visible: true,
+        video_duration: VideoEngagement.duration,
+        video_title: VideoEngagement.title,
+        video_url: VideoEngagement.url,
+        video_provider: 'self-hosted',
+        video_current_time: videoObject.currentTime,
+        video_percent: videoObject.percent
+    });
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play_event
+// NOTE: this event is configured to only fire once, does not need listener removed
+VideoEngagement.handleStart = (e) => {
+    VideoEngagement.url = e.target.currentSrc;
+    VideoEngagement.title = e.target.dataset.gaTitle || e.target.title;
+
+    VideoEngagement.sendEvent({
+        event: 'video_start',
+        currentTime: 0,
+        percent: 0
+    });
+};
+
+// Rounded because we don't need precise numbers
+VideoEngagement.getPercentageComplete = (currentTime) => {
+    return Math.round((currentTime / VideoEngagement.duration) * 100);
+};
+
+VideoEngagement.getPassedThresholds = (percentageComplete) => {
+    return VideoEngagement.progressThresholds.filter(
+        (threshold) => percentageComplete >= threshold
+    );
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/timeupdate_event
+VideoEngagement.handleProgress = (e) => {
+    const currentTime = Math.round(e.target.currentTime);
+    const percentageComplete =
+        VideoEngagement.getPercentageComplete(currentTime);
+    const lastThresholdCompleted = e.target.hasAttribute('data-ga-threshold')
+        ? parseInt(e.target.getAttribute('data-ga-threshold'), 10)
+        : 0;
+
+    // Check if video has ended
+    if (percentageComplete === 100) {
+        // Send complete event
+        VideoEngagement.sendEvent({
+            event: 'video_complete',
+            currentTime,
+            percent: 100
+        });
+
+        // Stop sending events
+        e.target.removeEventListener(
+            'timeupdate',
+            VideoEngagement.throttledProgress
+        );
+    } else if (percentageComplete < lastThresholdCompleted) {
+        // If video looped before we recorded complete event
+        VideoEngagement.sendEvent({
+            event: 'video_complete',
+            currentTime: VideoEngagement.duration,
+            percent: 100
+        });
+
+        // Stop sending events
+        e.target.removeEventListener(
+            'timeupdate',
+            VideoEngagement.throttledProgress
+        );
+    } else {
+        // Check if we have a progress event to send
+        const passedThresholds =
+            VideoEngagement.getPassedThresholds(percentageComplete);
+        if (passedThresholds.length > 0) {
+            const currentThreshold =
+                passedThresholds[passedThresholds.length - 1];
+            // Send progress event if we've passed a new threshold
+            if (currentThreshold > lastThresholdCompleted) {
+                VideoEngagement.sendEvent({
+                    event: 'video_progress',
+                    currentTime,
+                    percent: currentThreshold
+                });
+                // Store record of sent threshold data for this element
+                e.target.setAttribute('data-ga-threshold', currentThreshold);
+            }
+        }
+    }
+};
+
+// Set reference to throttle function so we can remove listener event
+VideoEngagement.throttledProgress = VideoEngagement.throttle(
+    VideoEngagement.handleProgress,
+    1000 // wait time in milliseconds
+);
+
+export default VideoEngagement;

--- a/media/js/base/video-inline-embed.es6.js
+++ b/media/js/base/video-inline-embed.es6.js
@@ -16,7 +16,6 @@ const src = 'https://www.youtube.com/iframe_api';
 let videoLink;
 let videoId;
 let videoStart;
-let title;
 
 function loadScript() {
     const tag = document.createElement('script');
@@ -46,37 +45,12 @@ function playVideo() {
             cc_load_policy: 1 // show captions.
         },
         events: {
-            onReady: onPlayerReady,
-            onStateChange: onPlayerStateChange
+            onReady: onPlayerReady
         }
     });
 
     function onPlayerReady(event) {
         event.target.playVideo();
-    }
-
-    function onPlayerStateChange(event) {
-        let state;
-
-        switch (event.data) {
-            case window.YT.PlayerState.PLAYING:
-                state = 'video play';
-                break;
-            case window.YT.PlayerState.PAUSED:
-                state = 'video paused';
-                break;
-            case window.YT.PlayerState.ENDED:
-                state = 'video complete';
-                break;
-        }
-
-        if (state) {
-            window.dataLayer.push({
-                event: 'video-interaction',
-                videoTitle: title,
-                interaction: state
-            });
-        }
     }
 }
 
@@ -102,7 +76,6 @@ function init() {
                 videoLink.getAttribute('data-video-start'),
                 10
             );
-            title = videoLink.getAttribute('data-video-title');
             initVideoPlayer();
         });
     }

--- a/media/js/base/video-modal-embed.es6.js
+++ b/media/js/base/video-modal-embed.es6.js
@@ -38,9 +38,6 @@ function isScriptLoaded() {
 }
 
 function playVideo() {
-    const title = document.querySelector(
-        '.mzp-c-modal-inner > header > h2'
-    ).innerText;
     const videoLink = document.querySelector(
         '.mzp-c-modal-inner .video-player-frame'
     );
@@ -63,37 +60,12 @@ function playVideo() {
             cc_load_policy: 1 // show captions.
         },
         events: {
-            onReady: onPlayerReady,
-            onStateChange: onPlayerStateChange
+            onReady: onPlayerReady
         }
     });
 
     function onPlayerReady(event) {
         event.target.playVideo();
-    }
-
-    function onPlayerStateChange(event) {
-        let state;
-
-        switch (event.data) {
-            case window.YT.PlayerState.PLAYING:
-                state = 'video play';
-                break;
-            case window.YT.PlayerState.PAUSED:
-                state = 'video paused';
-                break;
-            case window.YT.PlayerState.ENDED:
-                state = 'video complete';
-                break;
-        }
-
-        if (state) {
-            window.dataLayer.push({
-                event: 'video-interaction',
-                videoTitle: title,
-                interaction: state
-            });
-        }
     }
 }
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -663,6 +663,12 @@
     },
     {
       "files": [
+        "js/base/datalayer-videoengagement-init.es6.js"
+      ],
+      "name": "data_videoengagement"
+    },
+    {
+      "files": [
         "js/firefox/browsers/ios-summarizer.js"
       ],
       "name": "ios_summarizer"

--- a/tests/unit/spec/base/datalayer-videoengagement.js
+++ b/tests/unit/spec/base/datalayer-videoengagement.js
@@ -1,0 +1,193 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import VideoEngagement from '../../../../media/js/base/datalayer-videoengagement.es6.js';
+
+describe('datalayer-videoengagement.es6.js', function () {
+    const gaEventNames = ['video_start', 'video_progress', 'video_complete'];
+    const videoTitle = 'Test';
+    const videoUrl = 'https://assets.mozilla.net/video/test.webm';
+    const videoProvider = 'self-hosted';
+    const videoVisible = true;
+    const videoDuration = 100;
+    const percentage10 = 10;
+    const percentage25 = 25;
+    const percentage50 = 50;
+    const percentage75 = 75;
+    const percentage100 = 100;
+
+    const expectedEventStart = {
+        event: gaEventNames[0],
+        visible: videoVisible,
+        video_duration: videoDuration,
+        video_title: videoTitle,
+        video_url: videoUrl,
+        video_provider: videoProvider,
+        video_current_time: 0,
+        video_percent: 0
+    };
+
+    const expectedEventProgress = {
+        event: gaEventNames[1],
+        visible: videoVisible,
+        video_duration: videoDuration,
+        video_title: videoTitle,
+        video_url: videoUrl,
+        video_provider: videoProvider,
+        video_current_time: 10,
+        video_percent: percentage10
+    };
+
+    const expectedEventComplete = {
+        event: gaEventNames[2],
+        visible: videoVisible,
+        video_duration: videoDuration,
+        video_title: videoTitle,
+        video_url: videoUrl,
+        video_provider: videoProvider,
+        video_current_time: videoDuration,
+        video_percent: percentage100
+    };
+
+    beforeEach(function () {
+        window.dataLayer = [];
+        VideoEngagement.duration = videoDuration;
+    });
+
+    afterEach(function () {
+        delete window.dataLayer;
+        VideoEngagement.duration = null;
+    });
+
+    it('calculates percentage completed correctly', function () {
+        expect(
+            VideoEngagement.getPercentageComplete(percentage10) ===
+                VideoEngagement.progressThresholds[0]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage25) ===
+                VideoEngagement.progressThresholds[1]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage50) ===
+                VideoEngagement.progressThresholds[2]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage75) ===
+                VideoEngagement.progressThresholds[3]
+        ).toBeTruthy();
+        expect(
+            VideoEngagement.getPercentageComplete(percentage100) === 100
+        ).toBeTruthy();
+    });
+
+    it('correctly identifies when multiple progress thresholds have been passed', function () {
+        spyOn(VideoEngagement, 'getPercentageComplete').and.returnValue(
+            percentage50
+        );
+        const passedThresholds =
+            VideoEngagement.getPassedThresholds(percentage50);
+        expect(passedThresholds.length).toBe(3);
+    });
+
+    it('will append the start event to the dataLayer', function () {
+        VideoEngagement.sendEvent(expectedEventStart);
+        expect(window.dataLayer[0]['event'] === 'video_start').toBeTruthy();
+    });
+
+    it('will append the progress event to the dataLayer', function () {
+        VideoEngagement.sendEvent(expectedEventProgress);
+        expect(window.dataLayer[0]['event'] === 'video_progress').toBeTruthy();
+    });
+
+    it('will append the complete event to the dataLayer', function () {
+        VideoEngagement.sendEvent(expectedEventComplete);
+        expect(window.dataLayer[0]['event'] === 'video_complete').toBeTruthy();
+    });
+
+    describe('handleProgress', () => {
+        let mockEvent, sendEventSpy;
+
+        beforeEach(() => {
+            mockEvent = {
+                target: {
+                    currentTime: 0,
+                    hasAttribute: jasmine.createSpy('hasAttribute'),
+                    getAttribute: jasmine.createSpy('getAttribute'),
+                    setAttribute: jasmine.createSpy('setAttribute'),
+                    removeEventListener: jasmine.createSpy(
+                        'removeEventListener'
+                    )
+                }
+            };
+
+            sendEventSpy = spyOn(VideoEngagement, 'sendEvent');
+        });
+
+        it('should call sendEvent with "video_progress" when video is in progress', () => {
+            mockEvent.target.currentTime = 50;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('25');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith({
+                event: 'video_progress',
+                currentTime: 50,
+                percent: 50
+            });
+            expect(mockEvent.target.setAttribute).toHaveBeenCalledWith(
+                'data-ga-threshold',
+                50
+            );
+        });
+
+        it('should call sendEvent with "video_complete" when video is complete', () => {
+            mockEvent.target.currentTime = 100;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('75');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith({
+                event: 'video_complete',
+                currentTime: 100,
+                percent: 100
+            });
+            expect(mockEvent.target.removeEventListener).toHaveBeenCalled();
+        });
+
+        it('should call sendEvent with "video_complete" when video has looped', () => {
+            mockEvent.target.currentTime = 10;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('75');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith({
+                event: 'video_complete',
+                currentTime: 100,
+                percent: 100
+            });
+            expect(mockEvent.target.removeEventListener).toHaveBeenCalled();
+        });
+
+        it('should not call sendEvent when no new threshold is passed', () => {
+            mockEvent.target.currentTime = 30;
+            mockEvent.target.hasAttribute.and.returnValue(true);
+            mockEvent.target.getAttribute.and.returnValue('25');
+
+            VideoEngagement.handleProgress(mockEvent);
+
+            expect(sendEventSpy).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

HTML videos need to include the new data_videoengagement bundle and the video must have a class with 'ga-video-engagement'.

note: For YouTube JS API videos, GA4 automatically collects start/progress/complete events. We do not need custom code for these videos.

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
approved in https://github.com/mozilla/bedrock/pull/16442

CI passes
Local smoke check, YT videos play as expected on http://localhost:8000/en-US/features/tips/