### PR TITLE
Add extra download link to translate feature for non-Fx visitors

### DIFF
--- a/l10n/en/firefox/features/translate.ftl
+++ b/l10n/en/firefox/features/translate.ftl
@@ -23,7 +23,7 @@ features-translate-and-more-languages-are-in = And more languages are in develop
 features-translate-firefox-speaks-your-language = { -brand-name-firefox } speaks your language
 
 # Variables:
-#   $download (url) = link to https://www.firefox.com/
+#   $download (url) = link to https://www.firefox.com/thanks/
 features-translate-the-firefox-translations-feature-v2 = The { -brand-name-firefox-translations } feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>
 
 features-translate-get-started-in-your-preferred = Get started in your preferred language by downloading { -brand-name-firefox }

--- a/springfield/firefox/templates/firefox/features/translate.html
+++ b/springfield/firefox/templates/firefox/features/translate.html
@@ -84,7 +84,7 @@
 <p>{{ ftl('features-translate-and-more-languages-are-in') }}</p>
 
 <h2>{{ ftl('features-translate-firefox-speaks-your-language') }}</h2>
-<p>{{ ftl('features-translate-the-firefox-translations-feature-v2', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox'))) }}</p>
+<p>{{ ftl('features-translate-the-firefox-translations-feature-v2', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox.download.thanks'))) }}</p>
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
## One-line summary

Adds a conditional link to trigger download in non-Firefox browsers.

## Significant changes and points to review

Uses existing mid-page CTA logic, but uses only inline link to blend in with the preceding text.

Reuses existing content in a way that doesn't have to trigger new translations in case it was a part of the second paragraph proper. (This makes it kinda ugly, and also a little breaking the contract with localizers we won't be concatenating their strings etc. — but here this bit gets conditional display nonetheless so it's less confusing than if it was a part of the string and would be disappearing compared to what's in Pontoon so I chose to be pragmatic instead.)

I also only exposed the text to l10n, not the whole anchor — in case this would be repurposed for a mid-page CTA or something else, so we're not restricted to the wrapped markup in ftl unnecessarily.

## Issue / Bugzilla link

Resolves #473

## Testing

http://localhost:8000/en-CA/features/translate/ (non-Fx vs. Fx UA)
http://localhost:8000/fy-NL/features/translate/ (l10n ftl not ready yet)

https://github.com/mozmeao/springfield/issues/473#issuecomment-3433952411