### PR TITLE
Purple CMS banner block revisions

### DIFF
--- a/media/css/cms/flare-banner.css
+++ b/media/css/cms/flare-banner.css
@@ -42,6 +42,19 @@
     position: relative;
 }
 
+.fl-banner-filled::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: url('/media/img/firefox/flare/noise-filter.svg');
+    background-size: 600px 600px;
+    background-repeat: repeat;
+    opacity: 0.3;
+    mix-blend-mode: normal;
+    pointer-events: none;
+    border-radius: inherit;
+}
+
 .fl-banner-filled .fl-body-text {
     color: var(--neutrals-white);
 }

--- a/media/css/cms/flare-theme.css
+++ b/media/css/cms/flare-theme.css
@@ -52,6 +52,8 @@ non-determinative so you need to check and adjust the results as needed.
     --blue-dark-blue: #003c6e;
     --blue-button: #0360df;
     --purple-purple: #754fe0;
+    --purple-gradient-light: #7843F0;
+    --purple-gradient-dark: #2B0D4A;
     --purple-medium-purple: #d98dfa;
     --purple-dark-purple: #210340;
     --purple-light-purple: #dcd2ff;
@@ -65,7 +67,8 @@ non-determinative so you need to check and adjust the results as needed.
     /* Gradients from Figma */
     --gradient-earth-glow: linear-gradient(90deg, var(--blue-blue) 0%, var(--purple-purple) 100%);
     --gradient-fox-fire: linear-gradient(90deg, var(var(--yellow-yellow)) 0%, var(--orange-orange) 100%);
-    --gradient-radial-purple: radial-gradient(74.06% 118.24% at 50% -18.24%, var(--purple-purple) 0%, var(--purple-dark-purple) 100%);
+    --gradient-radial-purple: radial-gradient(84% 138% at 50% -18.24%, var(--purple-gradient-light) 0%, var(--purple-gradient-dark) 100%);
+
 
     /* Scale variables from Figma */
     --scale-4: 4;

--- a/media/img/firefox/flare/noise-filter.svg
+++ b/media/img/firefox/flare/noise-filter.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+  <filter id="noiseFilter">
+    <feTurbulence type="fractalNoise" baseFrequency="1" numOctaves="5" seed="0" stitchTiles="stitch" result="noise"/>
+    <feComponentTransfer in="noise" result="thresholded">
+      <feFuncA type="discrete" tableValues="0 0 0 0 1 1 1 1"/>
+    </feComponentTransfer>
+    <feFlood flood-color="#2B0D4A" result="color"/>
+    <feComposite in="color" in2="thresholded" operator="in"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#noiseFilter)"/>
+</svg>


### PR DESCRIPTION
## One-line summary

- [x] Adds noise to the filled banner background
- [ ] Adds fox tail image option

## Significant changes and points to review

This uses an SVG overlay with a noise filter to add the noise effect to the banner, maintaining responsive flexibility in banner size, and avoiding the need to add large image file sizes to accommodate different sized banners and viewports.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-392

## Testing

http://localhost:8000/pattern-library/render-pattern/pattern-library/components/banner/banner_variants.html
