### PR TITLE
Fix logic errors in 0020 migration for link blocks

### DIFF
--- a/springfield/cms/migrations/0020_auto_20251029_1054.py
+++ b/springfield/cms/migrations/0020_auto_20251029_1054.py
@@ -117,16 +117,18 @@ def transform_button_list(buttons):
     for button in buttons:
         new_button = {**button}
         value = new_button.get("value", {})
-        new_button["value"]["link"] = {
-            "link_to": "custom_url" if value.get("link") else "page",
-            "page": value.get("page") if value.get("page") else None,
-            "custom_url": value.get("link") if value.get("link") else "",
-            "new_window": value.get("settings", {}).get("external", False),
-            "file": None,
-            "anchor": None,
-            "email": None,
-            "phone": None,
-        }
+        # If it's already in the new format, skip it
+        if not isinstance(value.get("link"), dict):
+            new_button["value"]["link"] = {
+                "link_to": "custom_url" if value.get("link") else "page",
+                "page": value.get("page") if value.get("page") else None,
+                "custom_url": value.get("link") if value.get("link") else "",
+                "new_window": value.get("settings", {}).get("external", False),
+                "file": None,
+                "anchor": None,
+                "email": None,
+                "phone": None,
+            }
         new_buttons.append(new_button)
 
     return new_buttons
@@ -135,12 +137,12 @@ def transform_button_list(buttons):
 def convert_links(apps, schema_editor):
     FreeFormPage = apps.get_model("cms", "FreeFormPage")
     WhatsNewPage = apps.get_model("cms", "WhatsNewPage")
-    for page in WhatsNewPage.objects.filter(content__icontains="banner"):
+    for page in WhatsNewPage.objects.all():
         updated_value = walk_and_transform(list(page.content.raw_data))
         page.content.raw_data = updated_value
         page.save(update_fields=["content"])
 
-    for page in FreeFormPage.objects.filter(content__icontains="banner"):
+    for page in FreeFormPage.objects.all():
         updated_value = walk_and_transform(list(page.content.raw_data))
         page.content.raw_data = updated_value
         page.save(update_fields=["content"])


### PR DESCRIPTION
## One-line summary

Fix errors in migration that led to corrupt data on the demo environment.

## Significant changes and points to review

The migration was only applied to pages that had banners due to a filter left from a copy-paste mistake. It also didn't take into account that the link blocks might already be in the right format.

## Issue / Bugzilla link

https://mozilla.sentry.io/issues/6988509155/?project=4508842391633920&query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream

## Testing

- Rename this from `springfield.txt` to `springfield.db` (GH doesn't like the `.db` extension) and copy to `data/springfield.db`.
[springfield.txt](https://github.com/user-attachments/files/23338968/springfield.txt)
- Run migrations
- Check the buttons on the WNP 142
