### PR TITLE
CMS review

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -304,6 +304,7 @@ class CTASettings(blocks.StructBlock):
 
 
 class CTABlock(blocks.StructBlock):
+    settings = CTASettings()
     label = blocks.CharBlock(label="Link Text")
     link = LinkBlock()
 

--- a/springfield/cms/templates/cms/blocks/sections/section.html
+++ b/springfield/cms/templates/cms/blocks/sections/section.html
@@ -27,7 +27,7 @@
               {% if cta.link.new_window %}target="_blank" rel="external noopener"{% endif %}
               data-cta-position="{{ block_position + ".cta" }}"
               data-cta-text="{{ block_text + " - " + cta.label }}"
-              data-cta-uid="{{ cta.analytics_id }}"
+              data-cta-uid="{{ cta.settings.analytics_id }}"
             >{{ cta.label }}</a>
           {% endfor %}
         </div>


### PR DESCRIPTION
## One-line summary

- Fixes the heading component form layout
- Adds back the CTA block settings field, probably removed in a merge conflict

## Significant changes and points to review

- When adding a new block with a heading, the text fields should be full-width
- The section's Call to Action block should have a settings block with the analytics ID field

## Issue / Bugzilla link



## Testing
