### PR TITLE
Update default params on app store helper

### DIFF
--- a/springfield/settings/appstores.py
+++ b/springfield/settings/appstores.py
@@ -11,7 +11,9 @@ GOOGLE_PLAY_FIREFOX_LINK = "https://play.google.com/store/apps/details?id=org.mo
 # campaign parameters.
 # To clarify below, 'referrer' key value must be a URL encoded string of utm_*
 # key/values (https://bugzilla.mozilla.org/show_bug.cgi?id=1099429#c0).
-GOOGLE_PLAY_FIREFOX_LINK_UTMS = GOOGLE_PLAY_FIREFOX_LINK + "&referrer=" + quote("utm_source=mozilla&utm_medium=Referral&utm_campaign=mozilla-org")
+GOOGLE_PLAY_FIREFOX_LINK_UTMS = (
+    GOOGLE_PLAY_FIREFOX_LINK + "&referrer=" + quote("utm_source=www.firefox.com&utm_medium=referral&utm_campaign=download")
+)
 
 # Link to Firefox for iOS on the Apple App Store.
 APPLE_APPSTORE_FIREFOX_LINK = "https://apps.apple.com/{country}/app/apple-store/id989804926"


### PR DESCRIPTION
## One-line summary
Make specific to `www.firefox.com` and standardize `referral` casing

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/666

## Testing
check download links on
http://localhost:8000/en-US/channel/android/
