### PR TITLE
Remove hard-coded inline notification from What's New Page template

### DIFF
--- a/springfield/cms/templates/cms/whats_new_page.html
+++ b/springfield/cms/templates/cms/whats_new_page.html
@@ -6,9 +6,3 @@
 
 {% extends "cms/free_form_page.html" %}
 
-{% block pre_content %}
-  <include:inline-notification
-    message="{{ ftl('whatsnew-update-notification') }}"
-    color="purple"
-  />
-{% endblock %}


### PR DESCRIPTION
## One-line summary
The hard-coded "Your Firefox has been updated" notification has been removed from the template, so that it can be added manually with different color options. 
(Local screenshot) 

<img width="528" height="196" alt="Screenshot 2025-11-07 at 6 30 12 AM" src="https://github.com/user-attachments/assets/08c8fe8f-c751-4fca-bcb8-41bcdfb0ce27" />


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
When looking at this on production, the WNP 145 data will only have one notification at the top after this is merged in. 