### PR TITLE
Revert "Add date available" as Kit wallpapers shipped

### DIFF
--- a/springfield/firefox/templates/firefox/landing/kit.html
+++ b/springfield/firefox/templates/firefox/landing/kit.html
@@ -18,7 +18,6 @@
   {% set main_subheading = 'Neuer Freund an Bord' %}
   {% set main_body = 'Firefox bekommt einen frischen Look und du siehst es zuerst. Kit ist unser neues Maskottchen und dein Begleiter durch ein Internet, das privat, offen und wirklich deins ist.' %}
   {% set card_1_heading = 'Hol dir ein neues Hintergrundbild' %}
-  {% set card_1_date = 'Verfügbar am 11. November.' %}
   {% set card_1_list_1 = 'Öffne einen neuen Tab.' %}
   {% set card_1_list_2 = 'Klicke unten rechts auf das ' + pencil_icon + '-Symbol.' %}
   {% set card_1_list_3 = 'Wähle dein neues Firefox-Hintergrundbild aus.' %}
@@ -33,7 +32,6 @@
   {% set main_subheading = 'Nouvelle amitié débloquée' %}
   {% set main_body = 'La marque Firefox se refait une beauté et vous offre un aperçu avant tout le monde. Kit, notre nouvelle mascotte, va accompagner votre navigation au sein d’un internet privé, ouvert et qui vous appartient.' %}
   {% set card_1_heading = 'Choisissez un nouveau fond d’écran' %}
-  {% set card_1_date = 'Disponible le 11 novembre.' %}
   {% set card_1_list_1 = 'Ouvrez un nouvel onglet.' %}
   {% set card_1_list_2 = 'Cliquez sur l’icône ' + pencil_icon + ' en bas à droite.' %}
   {% set card_1_list_3 = 'Sélectionnez votre nouveau fond d’écran Firefox.' %}
@@ -48,7 +46,6 @@
   {% set main_subheading = 'New friend unlocked' %}
   {% set main_body = 'The Firefox brand is getting a refresh and you get the first look. Kit’s our new mascot and your new companion through an internet that’s private, open and actually yours.' %}
   {% set card_1_heading = 'Grab a new wallpaper' %}
-  {% set card_1_date = 'Dropping November 11.' %}
   {% set card_1_list_1 = 'Open a new tab.' %}
   {% set card_1_list_2 = 'Click on the ' + pencil_icon + ' in the lower right.' %}
   {% set card_1_list_3 = 'Select your new Firefox wallpaper.' %}
@@ -105,7 +102,6 @@
     <section aria-labelledby="heading-2" class="c-gallery-card c-gallery-card-light c-gallery-card-type-1">
       <div class="c-gallery-card-text-container">
         <h2 id="heading-2" class="c-gallery-card-heading">{{ card_1_heading }}</h2>
-        <p>{{ card_1_date }}</p>
         <ol>
           <li>{{ card_1_list_1 }}</li>
           <li>{{ card_1_list_2 | safe | format(icon_title) }}</li>


### PR DESCRIPTION
Removes mozmeao/springfield#743 note since it seems to be available (since Thu/Fri).

According to remote settings [newtab-wallpapers-v2](https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/newtab-wallpapers-v2) collection, the last change, perhaps the "Firefox" category, was on Thursday, Nov 6 8:02:20 PM.

145.0b9:
> <img width="1280" height="326" alt="Screenshot 2025-11-10 at 1 25 48" src="https://github.com/user-attachments/assets/27c8160c-42e5-4f6f-823d-88f9d243e1fc" />

_(IIUC should be equivalently available in all channels, no matter what version?)_

> <img width="1628" height="476" alt="Screenshot 2025-11-10 at 2 04 00" src="https://github.com/user-attachments/assets/2e6f3dea-694b-485a-ae4e-f3e9e4027f13" />
> <img width="1634" height="468" alt="Screenshot 2025-11-10 at 2 04 14" src="https://github.com/user-attachments/assets/c9c0ccc1-8039-4769-8548-755f47915c59" />
