### PR TITLE
Add ftl strings into CMS newsletter fields where possible

### DIFF
--- a/springfield/cms/templates/cms/newsletter_form.html
+++ b/springfield/cms/templates/cms/newsletter_form.html
@@ -69,11 +69,11 @@
       {% endif %}
 
       {% if LANG == 'de' %}
-        {% set legal_links = '<a href="/about/legal/terms/firefox/">Nutzungsbedingungen</a> und <a href="/privacy/websites/">Datenschutzrichtlinie</a> von Firefox.' %}
+        {% set legal_links = '<a href="https://www.mozilla.org/about/legal/terms/firefox/">Nutzungsbedingungen</a> und <a href="https://www.mozilla.org/privacy/websites/">Datenschutzrichtlinie</a> von Firefox.' %}
       {% elif LANG == 'fr' %}
-        {% set legal_links = '<a href="/about/legal/terms/firefox/">Conditions d’utilisation</a> de Firefox et <a href="/privacy/websites/">Politique de confidentialité</a>.' %}
+        {% set legal_links = '<a href="https://www.mozilla.org/about/legal/terms/firefox/">Conditions d’utilisation</a> de Firefox et <a href="https://www.mozilla.org/privacy/websites/">Politique de confidentialité</a>.' %}
       {% else %}
-        {% set legal_links = 'Firefox <a href="/about/legal/terms/firefox/">Terms of Use</a> &amp; <a href="/privacy/websites/">Privacy Policy</a>.' %}
+        {% set legal_links = 'Firefox <a href="https://www.mozilla.org/about/legal/terms/firefox/">Terms of Use</a> &amp; <a href="https://www.mozilla.org/privacy/websites/">Privacy Policy</a>.' %}
       {% endif %}
       <div class="fl-newsletterform-consent">
         <label for="newsletter-privacy" class="fl-body fl-newsletterform-checkbox-label">


### PR DESCRIPTION
## One-line summary

Removes hardcoded EN in CMS newsletter form

## Significant changes and points to review

pulls over changes from https://github.com/mozilla/bedrock/pull/16545/files#diff-7fd7c09acb2a9ea647a67b8876e292216b2b26493f5e006024abecafec081bc2 where hardcoded EN was still in use

## Issue / Bugzilla link



## Testing
use prod data
- `AWS_DB_S3_BUCKET=springfield-db-prod make preflight`
- start typing email in newsletter section & check dropdown fields
- http://localhost:8000/de/whatsnew/145/
- http://localhost:8000/fr/whatsnew/145/
- confirm newsletter can be submitted successfully with `success@example.com`