### PR TITLE
Fix: Insert nbsp in FR before colon

### DIFF
--- a/springfield/firefox/templates/firefox/landing/kit.html
+++ b/springfield/firefox/templates/firefox/landing/kit.html
@@ -38,7 +38,7 @@
   {% set card_1_list_2 = 'Cliquez sur l’icône ' + pencil_icon + ' en bas à droite.' %}
   {% set card_1_list_3 = 'Sélectionnez votre nouveau fond d’écran Firefox.' %}
   {% set card_2_heading = 'Vous êtes aux premières loges pour les produits Kit' %}
-  {% set card_2_body = '<p>Nouveaux designs en édition limitée prêts à être expédiés.</p><p class="font-semibold">Recevoir mes produits:</p>' %}
+  {% set card_2_body = '<p>Nouveaux designs en édition limitée prêts à être expédiés.</p><p class="font-semibold">Recevoir mes produits&nbsp;:</p>' %}
   {% set card_2_cta_na = 'Amérique du Nord' %}
   {% set card_2_cta_eu = 'Europe' %}
 {% else %}


### PR DESCRIPTION
## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link
slack report


## Testing
http://localhost:8000/fr/kit/

<img width="255" height="62" alt="Screenshot 2025-11-11 at 10 09 25 AM" src="https://github.com/user-attachments/assets/18acc1b4-47d5-4fae-8897-f1e49c3994a5" />
