### PR TITLE
Fix kit wallpaper fallback src

### DIFF
--- a/springfield/firefox/templates/firefox/landing/kit.html
+++ b/springfield/firefox/templates/firefox/landing/kit.html
@@ -110,7 +110,7 @@
       </div>
       <div class="c-gallery-card-media-container">
         {{ resp_img(
-            url="img/firefox/kit/browser-dark.png",
+            url="img/firefox/kit/browser-dark-630.png",
             srcset={
               "img/firefox/kit/browser-dark-315.png": "315w",
               "img/firefox/kit/browser-dark-630.png": "630w",


### PR DESCRIPTION
## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link

slack report from log error: "Missing staticfiles manifest entry for 'img/l10n/en-US/firefox/kit/browser-dark.png'

## Testing
check the fallback url matches one of the srcset urls