### PR TITLE
Show placeholder for upcoming iOS release (#424)

### DIFF
--- a/springfield/releasenotes/views.py
+++ b/springfield/releasenotes/views.py
@@ -88,7 +88,7 @@ def release_notes(request, version, product="Firefox"):
         raise Http404
 
     # Show a "coming soon" page for any unpublished Firefox releases
-    include_drafts = product in ["Firefox", "Firefox for Android"]
+    include_drafts = product in ["Firefox", "Firefox for Android", "Firefox for iOS"]
 
     try:
         release = get_release_or_404(version, product, include_drafts)


### PR DESCRIPTION
Show a placeholder for upcoming iOS release when release note has set `is_public = 0`.

Tested by using `UPDATE "main"."releasenotes_productrelease" SET "is_public"='0' WHERE "_rowid_"='782373'` and visiting `http://localhost:8000/en-US/firefox/ios/145.0/releasenotes/`. This fixes issue #424.

Check the screenshot below:

<img width="1360" height="858" alt="screenshot-ios-placeholder-release-notes" src="https://github.com/user-attachments/assets/f284d5d8-c54a-4be8-af4d-53a44fee93c1" />
