### PR TITLE
Refine page titles as suggested and introduce `block page_title_region` (#385)

### DIFF
--- a/springfield/base/templates/base-protocol.html
+++ b/springfield/base/templates/base-protocol.html
@@ -28,7 +28,7 @@
     {% block extra_meta %}{% endblock %}
 
     {% block shared_meta %}
-    <title>{% filter striptags %}{% block page_title_full %}{% block page_title_prefix %}{% endblock %}{% block page_title %}{% endblock %}{% endblock page_title_full %}{% block page_title_suffix %} — Firefox{% endblock %}{% endfilter %}</title>
+    <title>{% filter striptags %}{% block page_title_full %}{% block page_title_prefix %}{% endblock %}{% block page_title %}{% endblock %}{% endblock page_title_full %}{% block page_title_suffix %} — Firefox.com{% endblock %}{% block page_title_region %}{% endblock %}{% endfilter %}</title>
     <meta name="description" content="{% filter striptags %}{% block page_desc %}{% endblock %}{% endfilter %}">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Firefox">

--- a/springfield/firefox/templates/firefox/browsers/desktop/index.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/index.html
@@ -8,13 +8,16 @@
 {% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 
 {# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_region -%}
+  {% if LANG == 'en-US' %} (US){%- endif -%}
+  {% if LANG == 'en-GB' %} (UK){%- endif -%}
+{%- endblock -%}
+
 {%- block page_title -%}
-  {%- if LANG == 'en-US' -%}
-    Firefox for Desktop — Firefox (US)
-  {%- elif LANG == 'en-GB' -%}
-    Firefox for Desktop  — Firefox (UK)
+  {%- if LANG == 'en-US' or LANG == 'en-GB' -%}
+    Firefox for Desktop available for Windows, Mac and Linux
   {%- else -%}
-    {{ ftl('firefox-browsers-page-title-v2') }} - Firefox
+    {{ ftl('firefox-browsers-page-title-v2') }}
   {%- endif -%}
 {%- endblock -%}
 

--- a/springfield/firefox/templates/firefox/browsers/mobile/index.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/index.html
@@ -16,6 +16,13 @@
 {% set _entrypoint = 'www.firefox.com-firefox-mobile' %}
 
 {% block page_title %}{{ ftl('browsers-mobile-firefox-mobile-browsers-put') }}{% endblock %}
+
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_region -%}
+  {% if LANG == 'en-US' %} (US){%- endif -%}
+  {% if LANG == 'en-GB' %} (UK){%- endif -%}
+{%- endblock -%}
+
 {% block page_desc %}{{ ftl('browsers-mobile-overview-of-all-mobile') }}{% endblock %}
 
 {% block body_class %}{{ super() }} mobile-overview{% endblock %}

--- a/springfield/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/springfield/firefox/templates/firefox/browsers/mobile/ios.html
@@ -22,15 +22,18 @@
   {% endif %}
 {% endblock %}
 
-{# Issue 13019: Avoid duplicate content for English pages. #}
 {%- block page_title_full -%}
-  {%- if LANG == 'en-US' -%}
-    Get Firefox for iOS (iPhone and iPad) — Mozilla (US)
-  {%- elif LANG == 'en-GB' -%}
-    Download Firefox for iOS (iPhone and iPad) — Mozilla (UK)
+  {%- if LANG == 'en-US' or LANG == 'en-GB' -%}
+    Get Firefox for iOS (iPhone and iPad) from Mozilla
   {%- else -%}
     {{ ftl('mobile-ios-firefox-browser-ios') }} - Mozilla
   {%- endif -%}
+{%- endblock -%}
+
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_region -%}
+  {% if LANG == 'en-US' %} (US){%- endif -%}
+  {% if LANG == 'en-GB' %} (UK){%- endif -%}
 {%- endblock -%}
 
 {% block page_desc %}{{ ftl('mobile-ios-see-your-open-tabs') }}{% endblock %}


### PR DESCRIPTION
Introduced a `block page_title_region` to cleanly append region names to selected English pages, preventing duplicate content (issue 13019). Also changed "Firefox" to "Firefox.com".

Testing:

```
$ curl --silent "http://localhost:8000/en-US/browsers/"{"mobile/ios","desktop","mobile"}"/" | grep "<title>"
    <title>Get Firefox for iOS (iPhone and iPad) from Mozilla — Firefox.com (US)</title>
    <title>Firefox for Desktop available for Windows, Mac and Linux — Firefox.com (US)</title>
    <title>Firefox mobile browsers put your privacy first — Firefox.com (US)</title>
```