### PR TITLE
Add `noindex` to pages excluded from sitemap (#370)

### DIFF
--- a/springfield/base/templates/404.html
+++ b/springfield/base/templates/404.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {# 404 pages must not include canonical and hreflang x-default: https://github.com/mozilla/bedrock/issues/5895 #}
-{% block canonical_urls %}{% endblock %}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block content %}
   <main class="mzp-l-content message-section">

--- a/springfield/firefox/templates/firefox/unsupported-systems.html
+++ b/springfield/firefox/templates/firefox/unsupported-systems.html
@@ -6,6 +6,9 @@
 
 {% extends "base-protocol.html" %}
 
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
 {% block page_title %}Unsupported Systems{% endblock %}
 {% block page_desc %}We’re sorry to report this, but your computer does not meet the minimum system requirements to run this version.{% endblock %}
 


### PR DESCRIPTION
Add `noindex` meta tag to `404` and `/browsers/unsupported-systems/` pages.