### PR TITLE
Fixes for accessibility /all

### DIFF
--- a/media/js/firefox/all/all-init.es6.js
+++ b/media/js/firefox/all/all-init.es6.js
@@ -8,7 +8,12 @@ import TrackProductDownload from '../../base/datalayer-productdownload.es6';
 import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
 
 (function (Mozilla) {
-    function onLoad() {
+    // Getter function since outerHTML replacement in fetchContent breaks existing references
+    function getPartialTargetElement() {
+        return document.getElementById('partial-target');
+    }
+
+    function setUpPartialContentListeners() {
         const browserHelpContent = document.getElementById('browser-help');
         const browserHelpIcon = document.getElementById('icon-browser-help');
         const installerHelpContent = document.getElementById('installer-help');
@@ -16,7 +21,6 @@ import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
             '.icon-installer-help'
         );
         const downloadButtons = document.querySelectorAll('.download-link');
-
         function showHelpModal(modalContent, modalTitle, eventLabel) {
             MzpModal.createModal(this, modalContent, {
                 title: modalTitle,
@@ -67,7 +71,6 @@ import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
                 );
             }
         }
-
         // event tracking for GA4
         if (downloadButtons) {
             for (let i = 0; i < downloadButtons.length; ++i) {
@@ -81,6 +84,74 @@ import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
                 );
             }
         }
+
+        // Override click events for drill-down links.
+        getPartialTargetElement().addEventListener('click', function (event) {
+            const anchor = event.target.closest('a');
+            if (anchor && anchor.matches('.load-content-partial')) {
+                event.preventDefault();
+                fetchContent(anchor.href, true);
+            }
+        });
+    }
+
+    // A fetch helper since we use this in both the on click and popstate.
+    // pushState is a boolean so we avoid pushing state if triggered from popstate.
+    function fetchContent(url, pushState = false) {
+        fetch(url, {
+            // Signifies to backend to return partial HTML.
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            // Ignore what's cached and also don't cache this response.
+            // This is so we don't get full html pages when we expect partial html, or vice versa.
+            cache: 'no-store'
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.text();
+            })
+            .then((html) => {
+                const partialTarget = getPartialTargetElement();
+                partialTarget.outerHTML = html;
+
+                // Re-attach listeners as we just replaced partialTarget
+                setUpPartialContentListeners();
+
+                if (pushState) {
+                    history.pushState({ path: url }, '', url);
+                }
+
+                const activeHeaders = document.querySelectorAll(
+                    '.c-step-name:not(.t-step-disabled)'
+                );
+                const targetHeader = activeHeaders[activeHeaders.length - 1];
+                targetHeader.focus({ preventScroll: true });
+            })
+            .catch((error) => {
+                throw new Error(
+                    'There was a problem with the fetch operation:',
+                    error
+                );
+            });
+    }
+
+    function onLoad() {
+        setUpPartialContentListeners();
+
+        // Add popstate listener so we return partial HTML with browser back button.
+        window.addEventListener('popstate', function (event) {
+            if (!event.state) {
+                return;
+            }
+            fetchContent(event.state.path, false);
+        });
+
+        // Ensure initial state is set up when the page loads so root page is in popstate.
+        window.addEventListener('DOMContentLoaded', () => {
+            const url = window.location.href;
+            history.replaceState({ path: url }, '', url);
+        });
     }
 
     Mozilla.run(onLoad);

--- a/springfield/firefox/templates/firefox/all/base.html
+++ b/springfield/firefox/templates/firefox/all/base.html
@@ -10,10 +10,6 @@
   {{ ftl('firefox-all-download-the-firefox-v2') }}
 {%- endblock -%}
 
-{%- block page_desc -%}
-  {{ ftl('firefox-all-everyone-deserves-access-v2') }}
-{%- endblock -%}
-
 {% block page_css %}
  {{ css_bundle('firefox_all') }}
 {% endblock %}
@@ -46,95 +42,7 @@
 {% endif %}
 
 {% block content %}
-<main>
-  <div class="mzp-l-content">
-    <div class="c-product-info" {% if product %} data-current="{{ product.slug }}"{% endif %}>
-      <div class="c-intro">
-        <h1 class="c-intro-heading">{{ ftl('firefox-all-choose-which-firefox') }}</h1>
-        <p>{{ self.page_desc() }}</p>
-        {% if product %}
-          {% if product.slug == "desktop-release" %}
-            <div>
-              <ul>
-                <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
-              </ul>
-            </div>
-          {% elif product.slug == "desktop-beta" %}
-            <div>
-              <ul>
-                <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
-              </ul>
-            </div>
-          {% elif product.slug == "desktop-developer" %}
-            <div>
-              <ul>
-                <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
-              </ul>
-            </div>
-          {% elif product.slug == "desktop-nightly" %}
-            <div>
-              <ul>
-                <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
-              </ul>
-            </div>
-          {% elif product.slug == "desktop-esr" %}
-            <div>
-              <ul>
-                <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
-              </ul>
-            </div>
-          {% elif product.slug == "android-beta" %}
-            <div>
-              <ul>
-                <li><a href="{{ firefox_url('android', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-              </ul>
-            </div>
-          {% elif product.slug in ["mobile-release", "android-release", "ios-release"] %}
-            <div>
-              {% if product.slug in ["android-release", "mobile-release"] %}
-              Android:
-              <ul>
-                <li><a href="{{ firefox_url('android', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('android', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-              </ul>
-              {% endif %}
-              {% if product.slug in ["ios-release", "mobile-release"] %}
-              iOS:
-              <ul>
-                <li><a href="{{ firefox_url('ios', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
-                <li><a href="{{ firefox_url('ios', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-              </ul>
-              {% endif %}
-            </div>
-          {% endif %}
-        {% endif %}
-        <div class="c-support-links">
-          <ul>
-            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/{{ params }}&utm_content=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
-          </ul>
-        </div>
-      </div>
-      <div class="c-steps">
-        {% include 'firefox/all/product.html' %}
-        {% include 'firefox/all/platform.html' %}
-        {% include 'firefox/all/lang.html' %}
-        {% include 'firefox/all/download.html' %}
-      </div>
-    </div>
-  </div>
-</main>
+  {% include 'firefox/all/includes/main.html' %}
 {% endblock %}
 
 {% block js %}

--- a/springfield/firefox/templates/firefox/all/download.html
+++ b/springfield/firefox/templates/firefox/all/download.html
@@ -9,7 +9,7 @@
 {% set icon_download ='<span class="mzp-c-button-icon-end"><svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><clipPath id="a"><path d="m0 0h16v16h-16z"/></clipPath><g clip-path="url(#a)" fill="currentColor"><path d="m7.2507 0v10.21l-3.72-3.72-1.06 1.06 5.53 5.53 5.53-5.53-1.06-1.06-3.72 3.72v-10.21z"/><path d="m16 14.5h-16v1.5h16z"/></g></svg></span>' %}
 
 {# Show download #}
-<h2 {% if not (product and platform and locale) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
+<h2 tabindex="-1" {% if not (product and platform and locale) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
   {{ ftl('firefox-all-download') }}
   {% if product and platform and locale %}
     <img alt="{{ ftl('firefox-all-down-arrow') }}" class="c-step-icon" src="{{ static('protocol/img/icons/arrow-down.svg') }}" width="30" height="30">

--- a/springfield/firefox/templates/firefox/all/includes/main.html
+++ b/springfield/firefox/templates/firefox/all/includes/main.html
@@ -1,0 +1,95 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<main id="partial-target">
+  <div class="mzp-l-content">
+    <div class="c-product-info" {% if product %} data-current="{{ product.slug }}"{% endif %}>
+      <div class="c-intro">
+        <h1 class="c-intro-heading">{{ ftl('firefox-all-choose-which-firefox') }}</h1>
+        <p>{{ ftl('firefox-all-everyone-deserves-access-v2') }}</p>
+        {% if product %}
+          {% if product.slug == "desktop-release" %}
+            <div>
+              <ul>
+                <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
+              </ul>
+            </div>
+          {% elif product.slug == "desktop-beta" %}
+            <div>
+              <ul>
+                <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
+              </ul>
+            </div>
+          {% elif product.slug == "desktop-developer" %}
+            <div>
+              <ul>
+                <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
+              </ul>
+            </div>
+          {% elif product.slug == "desktop-nightly" %}
+            <div>
+              <ul>
+                <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
+              </ul>
+            </div>
+          {% elif product.slug == "desktop-esr" %}
+            <div>
+              <ul>
+                <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+                <li><a href="https://firefox-source-docs.mozilla.org/{{ params }}">{{ ftl('firefox-all-source-code') }}</a></li>
+              </ul>
+            </div>
+          {% elif product.slug == "android-beta" %}
+            <div>
+              <ul>
+                <li><a href="{{ firefox_url('android', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+              </ul>
+            </div>
+          {% elif product.slug in ["mobile-release", "android-release", "ios-release"] %}
+            <div>
+              {% if product.slug in ["android-release", "mobile-release"] %}
+              Android:
+              <ul>
+                <li><a href="{{ firefox_url('android', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('android', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+              </ul>
+              {% endif %}
+              {% if product.slug in ["ios-release", "mobile-release"] %}
+              iOS:
+              <ul>
+                <li><a href="{{ firefox_url('ios', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+                <li><a href="{{ firefox_url('ios', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+              </ul>
+              {% endif %}
+            </div>
+          {% endif %}
+        {% endif %}
+        <div class="c-support-links">
+          <ul>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
+            <li><a href="https://support.mozilla.org/products/{{ params }}&utm_content=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="c-steps">
+        {% include 'firefox/all/product.html' %}
+        {% include 'firefox/all/platform.html' %}
+        {% include 'firefox/all/lang.html' %}
+        {% include 'firefox/all/download.html' %}
+      </div>
+    </div>
+  </div>
+</main>

--- a/springfield/firefox/templates/firefox/all/lang.html
+++ b/springfield/firefox/templates/firefox/all/lang.html
@@ -5,12 +5,12 @@
 #}
 
 {# Choose language #}
-<h2 {% if not (product and platform) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
+<h2 tabindex="-1" {% if not (product and platform) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
   {{ ftl('firefox-all-language-v2') }}
   {% if product and platform and locale %}
     <span class="c-step-choice">{{ locale_name }}</span>
     {% if product.slug.startswith('desktop') and platform != "win-store" %}
-      <a href="{{ url('firefox.all.locales', product_slug=product.slug, platform=platform) }}" class="c-step-icon"><img alt="{{ ftl('firefox-all-change-language') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
+      <a href="{{ url('firefox.all.locales', product_slug=product.slug, platform=platform) }}" class="load-content-partial c-step-icon"><img alt="{{ ftl('firefox-all-change-language') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
     {% endif %}
   {% elif product and platform %}
     <img alt="{{ ftl('firefox-all-down-arrow') }}" class="c-step-icon" src="{{ static('protocol/img/icons/arrow-down.svg') }}" width="30" height="30">
@@ -24,7 +24,7 @@
   <h3 class="c-step-prompt">{{ ftl('firefox-all-select-your-preferred-language') }}<img alt="{{ ftl('firefox-all-down-arrow') }}" class="c-step-icon" src="{{ static('protocol/img/icons/arrow-down.svg') }}" width="30" height="30"></h3>
   <ul class="c-lang-list">
     {% for locale, name in locales %}
-      <li><a href="{{ url('firefox.all.download', product_slug=product.slug, platform=platform, locale=locale) }}">{{ name }}</a></li>
+      <li><a href="{{ url('firefox.all.download', product_slug=product.slug, platform=platform, locale=locale) }}" class="load-content-partial">{{ name }}</a></li>
     {% endfor %}
   </ul>
 </div>

--- a/springfield/firefox/templates/firefox/all/platform.html
+++ b/springfield/firefox/templates/firefox/all/platform.html
@@ -7,12 +7,12 @@
 
 {# Choose platform #}
 
-<h2 {% if not product %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
+<h2 tabindex="-1" {% if not product %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
   {{ ftl('firefox-all-platform-v2') }}
   {% if product and platform %}
     <span class="c-step-choice">{{ platform_name }}</span>
     {% if product.slug.startswith('desktop') %}
-      <a href="{{ url('firefox.all.platforms', product_slug=product.slug) }}" class="c-step-icon"><img alt="{{ ftl('firefox-all-change-platform') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
+      <a href="{{ url('firefox.all.platforms', product_slug=product.slug) }}" class="load-content-partial c-step-icon"><img alt="{{ ftl('firefox-all-change-platform') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
     {% endif %}
   {% elif product %}
     <img alt="{{ ftl('firefox-all-down-arrow') }}" class="c-step-icon" src="{{ static('protocol/img/icons/arrow-down.svg') }}" width="30" height="30">
@@ -31,7 +31,7 @@
   <div class="c-step-contents">
     <ul class="c-platform-list">
       {% for platform, name in platforms %}
-        <li><a href="{{ url('firefox.all.locales', product_slug=product.slug, platform=platform) }}">{{ name }}</a></li>
+        <li><a href="{{ url('firefox.all.locales', product_slug=product.slug, platform=platform) }}" class="load-content-partial">{{ name }}</a></li>
       {% endfor %}
     </ul>
     <div id="installer-help" class="c-help mzp-u-modal-content">

--- a/springfield/firefox/templates/firefox/all/product.html
+++ b/springfield/firefox/templates/firefox/all/product.html
@@ -6,10 +6,10 @@
 
 {# Choose product #}
 
-<h2 class="c-step-name">
+<h2 tabindex="-1" class="c-step-name">
   {{ ftl('firefox-all-browser-v2') }}
   {% if product %}
-    <span class="c-step-choice">{{ product and product.name }}</span> <a href="{{ url('firefox.all') }}" class="c-step-icon"><img alt="{{ ftl('firefox-all-change-browser') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
+    <span class="c-step-choice">{{ product and product.name }}</span> <a href="{{ url('firefox.all') }}" class="load-content-partial c-step-icon"><img alt="{{ ftl('firefox-all-change-browser') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
   {% else %}
     <img alt="{{ ftl('firefox-all-down-arrow') }}" class="c-step-icon" src="{{ static('protocol/img/icons/arrow-down.svg') }}" width="30" height="30">
   {% endif %}
@@ -25,10 +25,10 @@
   <div class="c-step-contents">
     <h3 class="c-product-title"><img alt="" role="presentation" src="{{ static('protocol/img/icons/desktop.svg') }}"> {{ ftl('firefox-all-desktop') }}</h3>
     <ul class="c-product-list qa-desktop-list">
-      <li class="release"><a href="{{ url('firefox.all.platforms', product_slug='desktop-release') }}">{{ ftl('firefox-all-product-firefox') }}</a> <strong>{{ ftl('firefox-all-recommended') }}</strong></li>
+      <li class="release"><a href="{{ url('firefox.all.platforms', product_slug='desktop-release') }}" class="load-content-partial">{{ ftl('firefox-all-product-firefox') }}</a> <strong>{{ ftl('firefox-all-recommended') }}</strong></li>
       {% for p in products %}
         {% if p.slug.startswith('desktop') and not p.slug.endswith('release') %}
-          <li class="{{ p.slug }}"><a href="{{ url('firefox.all.platforms', product_slug=p.slug) }}">{{ p.name }}</a></li>
+          <li class="{{ p.slug }}"><a href="{{ url('firefox.all.platforms', product_slug=p.slug) }}" class="load-content-partial">{{ p.name }}</a></li>
         {% endif %}
       {% endfor %}
     </ul>
@@ -36,10 +36,10 @@
     <h3 class="c-product-title"><img alt="" role="presentation" src="{{ static('protocol/img/icons/mobile.svg') }}"> {{ ftl('firefox-all-mobile') }}</h3>
 
     <ul class="c-product-list qa-mobile-list">
-      <li class="release"><a href="{{ url('firefox.all.platforms', product_slug='mobile-release') }}">{{ ftl('firefox-all-product-firefox') }}</a> <strong>{{ ftl('firefox-all-recommended') }}</strong></li>
+      <li class="release"><a href="{{ url('firefox.all.platforms', product_slug='mobile-release') }}" class="load-content-partial">{{ ftl('firefox-all-product-firefox') }}</a> <strong>{{ ftl('firefox-all-recommended') }}</strong></li>
       {% for p in products %}
         {% if p.slug.startswith('android') and not p.slug.endswith('release')%}
-          <li class="{{ p.slug }}"><a href="{{ url('firefox.all.platforms', product_slug=p.slug) }}">{{ p.name }}</a></li>
+          <li class="{{ p.slug }}"><a href="{{ url('firefox.all.platforms', product_slug=p.slug) }}" class="load-content-partial">{{ p.name }}</a></li>
         {% endif %}
       {% endfor %}
       <li class="ios-testflight"><a href="{{ url('firefox.ios.testflight') }}">{{ ftl('firefox-all-product-firefox-ios-testflight') }}</a></li>

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -272,7 +272,11 @@ def firefox_all(request, product_slug=None, platform=None, locale=None):
     platform_name = None
     locale_name = None
     download_url = None
-    template_name = "firefox/all/base.html"
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        template_name = "firefox/all/includes/main.html"
+    else:
+        template_name = "firefox/all/base.html"
+
     lang_multi = ftl("firefox-all-lang-multi", ftl_files=ftl_files)
 
     if product:


### PR DESCRIPTION
## One-line summary
Original PR moved from [bedrock](https://github.com/mozilla/bedrock/pull/16172) 

My attempt at fixing the a11y issues brought up in the original issue. It extends off of https://github.com/mozilla/bedrock/pull/15293 which I thought was 99% of a solution and worth exploring further. I have not kept the history from Rob Hudson's original commit. 

## Significant changes and points to review
This change focuses the header of the active step after the innerHTML is set. This ensures the focus only occurs when the user is navigating through the steps, and not on a full page load.

In https://github.com/mozilla/bedrock/pull/15293 the #installer-help and #browser-help modals were not working, due to the innerHTML being set and losing all attached listeners. Now after the innerHTML is set the modal listeners are re-attached.

I did not bring a sr-only changes over. 

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/15082

## Testing
see https://github.com/mozilla/bedrock/pull/16172 
