### PR TITLE
[WT-434] Video embed option on media blocks

### DIFF
--- a/media/css/cms/flare-intro.css
+++ b/media/css/cms/flare-intro.css
@@ -10,6 +10,7 @@
     background-color: light-dark(var(--neutrals-ash), var(--neutrals-black));
     padding: calc(var(--scale-80) * 1px) calc(var(--scale-40) * 1px);
     max-width: 1440px;
+    width: 100%;
     margin: 0 auto;
 }
 
@@ -69,7 +70,10 @@
     width: 100%;
     height: auto;
     aspect-ratio: 16 / 9;
+}
 
+.fl-intro-media .fl-video {
+    border-radius: calc(var(--scale-16) * 1px);
 }
 
 .intro-media img {

--- a/media/css/cms/flare-media.css
+++ b/media/css/cms/flare-media.css
@@ -4,19 +4,6 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-.media img,
-.media video,
-.media iframe {
-    display: block;
-    width: 100%;
-    height: auto;
-    border-radius: calc(var(--scale-16) * 1px);
-}
-
-.media iframe {
-    aspect-ratio: 16 / 9;
-}
-
 /* Video component with click-to-play */
 .fl-video {
     position: relative;

--- a/springfield/cms/templates/cms/blocks/media-content.html
+++ b/springfield/cms/templates/cms/blocks/media-content.html
@@ -41,13 +41,14 @@
     </content:buttons>
   {% endif %}
 
-  {% if value.embed or value.image %}
+  {% if value.video or value.image %}
     <content:media>
-      {% if value.embed %}
-        {# Jinja interprets the HTML from the embed block as a string #}
-        {% autoescape false %}
-          {% include_block value.embed %}
-        {% endautoescape %}
+      {% if value.video %}
+        {% set poster = image(value.image, "width-800") %}
+        <include:video
+          url="{{ value.video }}"
+          poster="{{ poster.url }}"
+        />
       {% elif value.image %}
         <div class="light-dark-display">
           {% if value.dark_image %}

--- a/springfield/cms/templates/cms/blocks/sections/banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/banner.html
@@ -40,19 +40,27 @@
       />
     </content:heading>
 
-    {% if value.image %}
+    {% if value.image or value.video %}
       <content:media>
-        {{ srcset_image(
-            value.image,
-            "width-{200,400,600,800,1000,1200,1400}",
-            sizes="
-              (min-width: 768px) 50vw,
-              (min-width: 1440px) 680px,
-              100vw
-            ",
-            width=(value.image.width / 2)|round|int,
-            loading="lazy"
-          ) }}
+        {% if value.video %}
+          {% set poster = image(value.image, "width-800") if value.image else None %}
+          <include:video
+            url="{{ value.video }}"
+            poster="{{ poster.url if poster else None }}"
+          />
+        {% else %}
+          {{ srcset_image(
+              value.image,
+              "width-{200,400,600,800,1000,1200,1400}",
+              sizes="
+                (min-width: 768px) 50vw,
+                (min-width: 1440px) 680px,
+                100vw
+              ",
+              width=(value.image.width / 2)|round|int,
+              loading="lazy"
+            ) }}
+        {% endif %}
       </content:media>
     {% endif %}
 

--- a/springfield/cms/templates/cms/blocks/sections/intro.html
+++ b/springfield/cms/templates/cms/blocks/sections/intro.html
@@ -25,43 +25,44 @@
       {{ value.fine_print|richtext|remove_p_tag }}
     </content:fine_print>
   {% endif %}
-  {% if value.image %}
+  {% if value.video or value.image %}
     <content:media>
-      <div class="light-dark-display">
-        {% if value.dark_image %}
+      {% if value.video %}
+        {% set poster = image(value.image, "width-800") if value.image else None %}
+        <include:video
+          url="{{ value.video }}"
+          poster="{{ poster.url if poster else None }}"
+        />
+      {% else %}
+        <div class="light-dark-display">
+          {% if value.dark_image %}
+            {{ srcset_image(
+                value.dark_image,
+                "width-{200,400,600,800,1000,1200,1400}",
+                sizes="
+                  (min-width: 768px) 50vw,
+                  (min-width: 1440px) 680px,
+                  100vw
+                ",
+                width=value.dark_image.width,
+                loading="lazy",
+                class="display-dark",
+              ) }}
+          {% endif %}
           {{ srcset_image(
-              value.dark_image,
+              value.image,
               "width-{200,400,600,800,1000,1200,1400}",
               sizes="
                 (min-width: 768px) 50vw,
                 (min-width: 1440px) 680px,
                 100vw
               ",
-              width=value.dark_image.width,
+              width=value.image.width,
               loading="lazy",
-              class="display-dark",
+              class="display-light",
             ) }}
-        {% endif %}
-        {{ srcset_image(
-            value.image,
-            "width-{200,400,600,800,1000,1200,1400}",
-            sizes="
-              (min-width: 768px) 50vw,
-              (min-width: 1440px) 680px,
-              100vw
-            ",
-            width=value.image.width,
-            loading="lazy",
-            class="display-light",
-          ) }}
-      </div>
-    </content:media>
-  {% elif value.embed %}
-    <content:media>
-      {# Jinja interprets the HTML from the embed block as a string #}
-      {% autoescape false %}
-        {% include_block value.embed %}
-      {% endautoescape %}
+        </div>
+      {% endif %}
     </content:media>
   {% endif %}
 </include:intro>


### PR DESCRIPTION
## One-line summary

Add an optional video field to the Intro, Media + Content and Banner blocks.

## Significant changes and points to review

Use the new video component to add the option to embed videos to the CMS blocks that render media.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-434

## Testing

In any Free Form or What's New page, add a video URL to one of the blocks.