### PR TITLE
[WT-463] Update copy on the Enterprise page

### DIFF
--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -6,8 +6,8 @@
 
 # Page title
 firefox-enterprise-use-firefox-esr-enterprise-browser = Use { -brand-name-firefox } or { -brand-name-esr } as your enterprise browser for security at scale
-# Meta desc
-firefox-is-the-open-source-browser-with-enterprise-security = { -brand-name-firefox } is the open-source browser with enterprise-grade security, privacy, and flexibility. Use { -brand-name-firefox } for the latest features or { -brand-name-esr } for long-term stability.
+# Page description
+firefox-enterprise-open-source-browser-with-enterprise-security = { -brand-name-firefox } is the open-source browser with enterprise-grade security, privacy, and flexibility. Use { -brand-name-firefox } for the latest features or { -brand-name-esr } for long-term stability.
 
 firefox-enterprise-brand-name = { -brand-name-enterprise }
 firefox-enterprise-use-as-your-enterprise-browser = Use { -brand-name-firefox } as your enterprise browser
@@ -19,7 +19,7 @@ firefox-enterprise-open-source-transparency = { -brand-name-firefox } combines o
 
 firefox-enterprise-your-browser-your-business = Your browser, your business
 firefox-enterprise-deploy-when-and-how-you-want = Deploy when and how you want
-firefox-enterprise-install-packages-policies = With install packages and a wide expansion of group policies and features, deployment is faster and more flexible than ever — and a breeze in { -brand-name-windows } and { -brand-name-mac } environments.
+firefox-enterprise-install-packages-policies = With install packages and a wide expansion of group policies and features, deployment is faster and more flexible than ever — and a breeze for Windows, Linux, and macOS environments.
 firefox-enterprise-release-cycles = Release cycles that fit your organization
 firefox-enterprise-choose-firefox-for-features-esr-stability = Choose { -brand-name-firefox } for the latest features and stable releases every four weeks, or { -brand-name-firefox-esr } for long-term stability, regular security updates, and annual major releases.
 firefox-enterprise-enterprise-downloads = { -brand-name-enterprise } downloads

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -9,7 +9,7 @@
 {% from "macros-protocol.html" import picto, split with context %}
 
 {% block page_title %}{{ ftl('firefox-enterprise-use-firefox-esr-enterprise-browser') }}{% endblock %}
-{% block page_desc %}{{ ftl('firefox-is-the-open-source-browser-with-enterprise-security') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-enterprise-open-source-browser-with-enterprise-security') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('protocol-split') }}


### PR DESCRIPTION
## One-line summary

Refreshes some outdated terminology and copy. Some highlights:

__Removed:__
* "Rapid Release" terminology, this mentions either ESR or Firefox (rationale: confusing release channel names)
* `soon will support…` language

__Changed:__
* Both Firefox and ESR can use policies to configure browser behavior
* "Support" renamed to "Resources" under the platform-specific downloads

## Significant changes and points to review

- ✅ resolved in https://github.com/mozmeao/springfield/pull/779/files#r2530613696 <strike>I'm unsure about `{% if LANG == 'en-US' %}` block in `springfield/firefox/templates/firefox/enterprise/index.html` - please let me know if this is a good refactor / tidy, it looks redundant to me.</strike> 

## Issue / Bugzilla link

n/a

## Testing

Tested on localhost