### PR TITLE
Remove aria-hidden on ancestor of video so it will show in accessibil…

### DIFF
--- a/springfield/firefox/templates/firefox/landing/kit.html
+++ b/springfield/firefox/templates/firefox/landing/kit.html
@@ -75,9 +75,9 @@
               <p>{{ main_body }}</p>
           </div>
         </div>
-        <div class="kit-banner-brand" aria-hidden="true">
+        <div class="kit-banner-brand">
           <div class="kit-banner-media">
-            <button class="button c-animation-button" data-js-video-state="paused">
+            <button type="button" class="button c-animation-button" data-js-video-state="paused">
               <svg class="c-animation-button-play" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <title>{{ ftl('ui-play-animation')}}</title>
                 <path d="M5 18.8569V5.14289C5 3.60689 6.659 2.64489 7.992 3.40689L19.992 10.2639C21.336 11.0319 21.336 12.9689 19.992 13.7369L7.992 20.5939C6.659 21.3559 5 20.3929 5 18.8569Z" fill="currentColor"/>
@@ -88,7 +88,7 @@
                 <path d="M14.625 4.99988H16.375V18.9999H14.625V4.99988Z" fill="currentColor"/>
               </svg>
             </button>
-            <video playsinline preload="auto" loop muted poster="{{ static('img/firefox/landing/kit/kit-pop-up-poster.png') }}">
+            <video aria-labelledby="kit-banner-heading" playsinline preload="auto" loop muted poster="{{ static('img/firefox/landing/kit/kit-pop-up-poster.png') }}">
               <source media="(min-width: 1024px)" src="https://assets.mozilla.net/video/kit/pop-up-1480.webm" type="video/webm">
               <source src="https://assets.mozilla.net/video/kit/pop-up-800.webm" type="video/webm">
             </video>


### PR DESCRIPTION
…ity tree

## One-line summary

We missed an `aria-hidden="true"` on video ancestor element, which removes all descendant elements from the accessibility tree

## Significant changes and points to review

Also connects video to section heading for a localized description

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-439

> currently both the video and the play/pause buttons are focusable with keyboard but are not exposed to Accessibility API

## Testing
- [ ] http://localhost:8000/en-US/kit/

Open dev tools and check video & play/pause button are listed in Accessibility tree (ability to reach both by keyboard have been confirmed separately)
<img width="368" height="182" alt="Screenshot 2025-11-17 at 11 24 27 AM" src="https://github.com/user-attachments/assets/7e8013db-7fcf-45da-8e9b-2509405f2811" />
