### PR TITLE
Move loading animation to css, add l10n title

### DIFF
--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -37,6 +37,9 @@ newsletter-form-thanks = Thanks!
 newsletter-form-yes = Yes
 newsletter-form-no = No
 
+# Alt text for SVG animation indicating the form has submitted and is waiting for response
+newsletter-form-submit-sending = Sending
+
 multi-newsletter-form-checkboxes-legend = I want information about:
 multi-newsletter-form-checkboxes-label-mozilla = { -brand-name-mozilla-foundation }
 multi-newsletter-form-checkboxes-label-firefox = { -brand-name-firefox }

--- a/media/css/firefox/ai/waitlist.scss
+++ b/media/css/firefox/ai/waitlist.scss
@@ -320,6 +320,24 @@ body {
     display: none;
 }
 
+@keyframes pulse {
+    93.75%,
+    100% {opacity:.2}
+}
+
+.c-submit-loading circle {
+    animation: pulse .8s linear infinite;
+    animation-delay:-.8s
+}
+
+.c-submit-loading circle:nth-child(2) {
+    animation-delay:-.65s
+}
+
+.c-submit-loading circle:nth-child(3) {
+    animation-delay:-.5s
+}
+
 // show loading indicator while request is sending
 input[type="email"]:disabled + .c-submit {
     .c-submit-text {

--- a/springfield/firefox/templates/firefox/ai/waitlist.html
+++ b/springfield/firefox/templates/firefox/ai/waitlist.html
@@ -57,11 +57,10 @@
         <button data-testid="newsletter-submit-button" id="newsletter-submit" type="submit" class="c-submit">
           <span class="c-submit-text">Join the waitlist</span>
           <svg class="c-submit-loading" fill="currentColor" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <title>Sending</title>
-            <style>.s1{animation:s .8s linear infinite;animation-delay:-.8s}.s2{animation-delay:-.65s}.s3{animation-delay:-.5s}@keyframes s{93.75%,100%{opacity:.2}}</style>
-            <circle class="s1" cx="4" cy="12" r="3"/>
-            <circle class="s1 s2" cx="12" cy="12" r="3"/>
-            <circle class="s1 s3" cx="20" cy="12" r="3"/>
+            <title>{{ ftl('newsletter-form-submit-sending') }}</title>
+            <circle cx="4" cy="12" r="3"/>
+            <circle cx="12" cy="12" r="3"/>
+            <circle cx="20" cy="12" r="3"/>
           </svg>
         </button>
       </div>


### PR DESCRIPTION
## One-line summary

Fix CSP errors from inline SVG style

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/785

[Sentry error [moz only]](https://mozilla.sentry.io/issues/6608198734/events/21d449fd0a714408b04b7638d995c67d/?query=) refers to L195
from page source, this corresponds to the loading style tag
<img width="448" height="102" alt="Screenshot 2025-11-17 at 3 56 27 PM" src="https://github.com/user-attachments/assets/1ac69692-3505-4a68-bc78-ac08004d4e3f" />


## Testing
http://localhost:8000/en-US/ai/
- [ ] Open dev tools Debugger panel and set a breakpoint at the API request to freeze at the loading state to confirm animation is playing as expected


<img width="1154" height="547" alt="Screenshot 2025-11-17 at 2 52 30 PM" src="https://github.com/user-attachments/assets/a475db6b-43dd-42a4-9c49-cdcd300a2cd5" />
