### PR TITLE
fix: catch DisallowedRedirect rather than 500

### DIFF
--- a/springfield/base/tests/test_settings.py
+++ b/springfield/base/tests/test_settings.py
@@ -33,3 +33,8 @@ def test_lang_groups():
 )
 def test_get_media_cdn_hostname(media_url, expected_hostname):
     assert _get_media_cdn_hostname_for_storage_backend(media_url) == expected_hostname
+
+
+def test_catch_disallowed_redirect_middleware_enabled():
+    middleware_path = "springfield.base.middleware.CatchDisallowedRedirect"
+    assert middleware_path in settings.MIDDLEWARE

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -679,6 +679,7 @@ MIDDLEWARE = [
     "django.middleware.http.ConditionalGetMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "springfield.base.middleware.BasicAuthMiddleware",
+    "springfield.base.middleware.CatchDisallowedRedirect",
     "springfield.redirects.middleware.RedirectsMiddleware",  # must come before SpringfieldLocaleMiddleware
     "springfield.base.middleware.SpringfieldLangCodeFixupMiddleware",  # must come after RedirectsMiddleware
     "springfield.base.middleware.SpringfieldLocaleMiddleware",  # wraps django.middleware.locale.LocaleMiddleware


### PR DESCRIPTION
## One-line summary

This changeset stops our error logging getting deluged with `DisallowedRedirect` exceptions from spammy requests that feature a long querystring but no locale - our middleware that adds the locale will often cause the exception to be raised after tacking on that locale and calling `redirect()`

## Testing

Unit test scrutiny probably enough for now