### PR TITLE
fix: ensure that WNP path can only start with whatsnew/

### DIFF
--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -694,4 +694,53 @@ class TestWhatsNew(TestCase):
                 # Check that the request was processed (not 404)
                 assert response.status_code in [200, 301, 302], f"Version {version} failed with status {response.status_code}"
 
+    def test_whatsnew_path_must_start_with_whatsnew(self, render_mock):
+        """Whatsnew URL patterns only match paths starting with whatsnew/"""
+        from springfield.firefox import urls as firefox_urls
+
+        # These paths should NOT match the whatsnew patterns
+        invalid_paths = [
+            "foo/whatsnew/127/",
+            "firefox/whatsnew/139/",
+            "test/whatsnew/70.0/",
+            "a/whatsnew/100.0a1/",
+        ]
+
+        # Get the whatsnew patterns from the urlpatterns
+        whatsnew_patterns = []
+        for pattern in firefox_urls.urlpatterns:
+            if hasattr(pattern, "name") and pattern.name in ["firefox.whatsnew", "firefox.whatsnew_legacy"]:
+                whatsnew_patterns.append(pattern)
+
+        # Verify that none of the invalid paths match the whatsnew patterns
+        for path in invalid_paths:
+            with self.subTest(path=path):
+                for pattern in whatsnew_patterns:
+                    regex = pattern.pattern.regex
+                    match = regex.match(path)
+                    assert match is None, f"Path '{path}' should not match whatsnew pattern {pattern.name} but it did. Pattern: {regex.pattern}"
+
+    def test_whatsnew_valid_paths_resolve_correctly(self, render_mock):
+        """Valid whatsnew URLs that start correctly match whatsnew patterns"""
+        from springfield.firefox import urls as firefox_urls
+
+        # Get the whatsnew patterns from the urlpatterns
+        whatsnew_patterns = {}
+        for pattern in firefox_urls.urlpatterns:
+            if hasattr(pattern, "name") and pattern.name in ["firefox.whatsnew", "firefox.whatsnew_legacy"]:
+                whatsnew_patterns[pattern.name] = pattern.pattern.regex
+
+        # These paths should match the appropriate whatsnew patterns
+        valid_paths = [
+            ("whatsnew/127/", "firefox.whatsnew"),
+            ("whatsnew/139/", "firefox.whatsnew"),
+            ("whatsnew/70.0/", "firefox.whatsnew_legacy"),
+            ("whatsnew/100.0a1/", "firefox.whatsnew_legacy"),
+        ]
+        for path, expected_pattern_name in valid_paths:
+            with self.subTest(path=path):
+                regex = whatsnew_patterns[expected_pattern_name]
+                match = regex.match(path)
+                assert match is not None, f"Path '{path}' should match pattern {expected_pattern_name} but didn't. Pattern: {regex.pattern}"
+
     # end URL routing tests

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -183,9 +183,9 @@ urlpatterns = (
     page("more/faq/", "firefox/more/faq.html", ftl_files="firefox/more/faq"),
     # START What's New Page (WNP) paths
     # 1. Legacy version format: MAJ.MIN/variant.patch (127.1a, 139.0.1, etc) rather than just MAJ
-    re_path(f"whatsnew/(?P<version>{version_re})/", views.WhatsnewView.as_view(), name="firefox.whatsnew_legacy"),
+    re_path(f"^whatsnew/(?P<version>{version_re})/", views.WhatsnewView.as_view(), name="firefox.whatsnew_legacy"),
     # 2. New version format, which should be served from the CMS, but falls back to evergreen page
-    re_path(r"whatsnew/(?P<version>[1-9]\d{2})/", prefer_cms(views.WhatsnewView.as_view()), name="firefox.whatsnew"),
+    re_path(r"^whatsnew/(?P<version>[1-9]\d{2})/", prefer_cms(views.WhatsnewView.as_view()), name="firefox.whatsnew"),
     # END What's New Page (WNP) paths
     page("user-privacy/", "firefox/data.html", url_name="firefox.user-privacy"),
     path("ai/", views.firefox_ai_waitlist_page, name="firefox.ai.waitlist"),


### PR DESCRIPTION
This changeset tightens up the regex for our whatsnew pages


Testing

- [x] http://localhost:8000/whatsnew/200/ will be 200 OK
- [x] http://localhost:8000/firefox/whatsnew/200/ will be 404
- [x] http://localhost:8000/anything/whatsnew/200/ will be 404