### PR TITLE
remove youtube button

### DIFF
--- a/springfield/cms/templates/components/video.html
+++ b/springfield/cms/templates/components/video.html
@@ -21,9 +21,9 @@
         <img src="{{ poster }}" alt="" class="fl-video-poster" />
       {% endif %}
       <span class="fl-video-play-icon" aria-hidden="true">
-        <svg width="68" height="48" viewBox="0 0 68 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="#f00"/>
-          <path d="M45 24L27 14v20l18-10z" fill="#fff"/>
+        <svg height="48" width="48" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+          <circle cx="24" cy="24" r="24" fill="rgba(0,0,0,0.7)"/>
+          <path d="M17.887 13.951 35.472 24 17.887 34.049z" fill="#fff"/>
         </svg>
       </span>
     </button>
@@ -42,9 +42,9 @@
         <img src="{{ poster }}" alt="" class="fl-video-poster" />
       {% endif %}
       <span class="fl-video-play-icon" aria-hidden="true">
-        <svg width="68" height="48" viewBox="0 0 68 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="34" cy="24" r="24" fill="rgba(0,0,0,0.7)"/>
-          <path d="M27 16l14 8-14 8V16z" fill="#fff"/>
+        <svg height="48" width="48" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+          <circle cx="24" cy="24" r="24" fill="rgba(0,0,0,0.7)"/>
+          <path d="M17.887 13.951 35.472 24 17.887 34.049z" fill="#fff"/>
         </svg>
       </span>
     </button>


### PR DESCRIPTION
## One-line summary
This PR removes the youtube-branded play button in favor of a more generic translucent black button. Now from the CMS, the buttons for videos from youtube and assets.mozilla.com are identical. 

<img width="650" height="383" alt="Screenshot 2025-12-02 at 11 53 09 PM" src="https://github.com/user-attachments/assets/4434a7a9-cdda-499f-8225-a1bb3ee9d126" />