### PR TITLE
Add en-CA to Wagtail

### DIFF
--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1289,6 +1289,7 @@ def lazy_wagtail_langs():
         # Smartling-specific ones in the WAGTAIL_LOCALIZE_SMARTLING settings, below
         ("en-US", "English (US)"),
         ("en-GB", "English (Great Britain)"),
+        ("en-CA", "English (Canada)"),
         ("de", "German"),
         ("fr", "French"),
         ("es-ES", "Spanish (Spain)"),


### PR DESCRIPTION
## One-line summary
From this conversation in Slack: https://lincolnloop.slack.com/archives/C019N6J8FGA/p1764733859801539?thread_ts=1764682073.430049&cid=C019N6J8FGA

Brad requested a Canadian variation. Technically, this ought to be all that is required to add a Canadian locale to wagtail. However, I'm not sure of the business implications and/or other considerations of tucking this in right now. 

I'm adding Steve to the PR, but I'll mention it in the slack channel as well. 

Once this is added, the locale will need to be added in the Wagtail database itself, here: 

https://prod.cms.springfield.prod.webservices.mozgcp.net/cms-admin/locales/


