### PR TITLE
Pattern library: Add page titles to full page view. 

### DIFF
--- a/springfield/cms/pattern_library_urls.py
+++ b/springfield/cms/pattern_library_urls.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.urls import path, re_path
+
+from pattern_library import get_pattern_template_suffix, views
+
+from springfield.cms.pattern_library_views import RenderPatternView
+
+app_name = "pattern_library"
+urlpatterns = [
+    # UI
+    path("", views.IndexView.as_view(), name="index"),
+    re_path(
+        r"^pattern/(?P<pattern_template_name>[\w./\-]+%s)$" % (get_pattern_template_suffix()),
+        views.IndexView.as_view(),
+        name="display_pattern",
+    ),
+    # iframe rendering - using our custom view
+    re_path(
+        r"^render-pattern/(?P<pattern_template_name>[\w./\-]+%s)$" % (get_pattern_template_suffix()),
+        RenderPatternView.as_view(),  # Our custom view
+        name="render_pattern",
+    ),
+    # API rendering
+    path("api/v1/render-pattern", views.render_pattern_api, name="render_pattern_api"),
+]

--- a/springfield/cms/pattern_library_views.py
+++ b/springfield/cms/pattern_library_views.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.http import Http404, HttpResponse
+from django.utils.safestring import mark_safe
+
+from pattern_library import get_base_template_names
+from pattern_library.exceptions import TemplateIsNotPattern
+from pattern_library.utils import (
+    get_pattern_config,
+    get_pattern_context,
+    get_renderer,
+    render_pattern,
+)
+from pattern_library.views import RenderPatternView as BaseRenderPatternView
+
+
+class RenderPatternView(BaseRenderPatternView):
+    """
+    Extended RenderPatternView that passes pattern metadata (name)
+    to the base template context.
+    """
+
+    def get(self, request, pattern_template_name=None):
+        renderer = get_renderer()
+        pattern_template_ancestors = renderer.get_template_ancestors(
+            pattern_template_name,
+            context=get_pattern_context(pattern_template_name),
+        )
+        pattern_is_fragment = set(pattern_template_ancestors).isdisjoint(set(get_base_template_names()))
+
+        try:
+            rendered_pattern = render_pattern(request, pattern_template_name)
+        except TemplateIsNotPattern:
+            raise Http404
+
+        if pattern_is_fragment:
+            context = self.get_context_data()
+            context["pattern_library_rendered_pattern"] = mark_safe(rendered_pattern)
+
+            # Add pattern config to context so name is available in base template
+            pattern_config = get_pattern_config(pattern_template_name)
+            context["pattern_config"] = pattern_config
+            context["pattern_name"] = pattern_config.get("name", "")
+
+            return self.render_to_response(context)
+
+        return HttpResponse(rendered_pattern)

--- a/springfield/cms/templates/cms/base-pattern.html
+++ b/springfield/cms/templates/cms/base-pattern.html
@@ -7,7 +7,7 @@
 {% extends "cms/base-flare.html" %}
 
 {# Avoid referencing `page` which isn't provided by the pattern library #}
-{% block page_title %}Pattern preview{% endblock %}
+{% block page_title %}{{ pattern_name }} | Pattern preview {% endblock %}
 {% block flare_header %}{% endblock %}
 
 {% block page_css %}

--- a/springfield/urls.py
+++ b/springfield/urls.py
@@ -89,7 +89,7 @@ if settings.STORAGES["default"]["BACKEND"] == "django.core.files.storage.FileSys
 
 if apps.is_installed("pattern_library"):
     urlpatterns += [
-        path("pattern-library/", include("pattern_library.urls")),
+        path("pattern-library/", include("springfield.cms.pattern_library_urls")),
     ]
 
 # Wagtail is the catch-all route, and it will raise a 404 if needed.


### PR DESCRIPTION
## One-line summary

Add page titles to full page view of pattern library patterns.

## Significant changes and points to review

- Created custom `RenderPatternView` that extends the base pattern library view to pass name to the base template context
- Added custom URL configuration to use the extended view instead of the default pattern library render view
- Updated `base-pattern.html` to display name in page title

## Issue / Bugzilla link

n/a

## Testing

Open a full page view from the pattern library e.g. http://localhost:8000/pattern-library/render-pattern/pattern-library/base-styles/typography/typography_examples.html and see if title matches the content.