### PR TITLE
fix color contrast a11y issue (Bug 2004183)

### DIFF
--- a/media/css/firefox/all.scss
+++ b/media/css/firefox/all.scss
@@ -80,12 +80,10 @@ $image-path: '/media/protocol/img';
 
     &.t-step-disabled {
         cursor: not-allowed;
-        opacity: 0.5;
 
-
-    [dir='rtl'] & .c-step-icon {
-        transform: rotate(180deg);
-    }
+        [dir='rtl'] & .c-step-icon {
+            transform: rotate(180deg);
+        }
     }
 }
 


### PR DESCRIPTION
## One-line summary

Update download step color contrast.

## Significant changes and points to review

New color 

## Issue / Bugzilla link

Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=2004183
Solution discussion: https://mozilla.slack.com/archives/C0960JM31PE/p1764943918280109?thread_ts=1764943459.327899&cid=C0960JM31PE

## Testing

http://localhost:8000/en-US/download/all/

Open Web Developer Tools (press Ctrl + Shift + I or open the hamburger menu at the top right, More tools > Web Developer Tools)
In dev tools, click the Accessibility tab.
Click the 'Pick accessible object from page' icon button to the left of 'Inspector'.
Hover over 'Platform', 'Language', or 'Download' section headings and observe the contrast issue tooltips