### PR TITLE
Preserve original query strings when adding UTM parameters

### DIFF
--- a/springfield/cms/templatetags/cms_tags.py
+++ b/springfield/cms/templatetags/cms_tags.py
@@ -64,7 +64,7 @@ def add_utm_parameters(context: dict, value: str) -> str:
             query_string = parsed_url.query
             query = parse_qs(query_string)
             query.update(utm_parameters)
-            new_query_string = urlencode(query)
+            new_query_string = urlencode(query, doseq=True)
             return urlunparse(parsed_url._replace(query=new_query_string))
     return value
 

--- a/springfield/cms/tests/test_templatetags.py
+++ b/springfield/cms/tests/test_templatetags.py
@@ -48,8 +48,7 @@ def test_remove_tags():
         ),
         (
             "https://example.mozilla.org/page?query=something#hash",
-            "https://example.mozilla.org/page"
-            "?query=%5B%27something%27%5D&utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign#hash",
+            "https://example.mozilla.org/page?query=something&utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign#hash",
         ),
         (
             "https://example.mozillafoundation.org/page",
@@ -70,6 +69,10 @@ def test_remove_tags():
         ("https://www.firefox.com/page", "https://www.firefox.com/page"),
         ("www.firefox.com/page", "www.firefox.com/page"),
         ("firefox.com/page", "firefox.com/page"),
+        (
+            "https://mozillafoundation.org/?form=25-wnp-eoy-en-CA",
+            "https://mozillafoundation.org/?form=25-wnp-eoy-en-CA&utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign",
+        ),
     ],
 )
 def test_add_utm_parameters(url, expected_url):


### PR DESCRIPTION
## One-line summary

Fix the `add_utm_parameters` template tag, preserving the original query after the UTM update.

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
