### PR TITLE
Pattern Library: Add Page Titles To Full Page View

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -652,8 +652,8 @@ django-mozilla-product-details==1.0.3 \
     --hash=sha256:1d139ba01f4484f3bb43b72864ce33f249835405449e0dc940217cfa42ce5b46 \
     --hash=sha256:a4aba6a68b296dffe8c1afb95d236cdbd402bd855cd49eef4d8a1a610105fd36
     # via -r requirements/prod.txt
-django-pattern-library @ https://github.com/lincolnloop/django-pattern-library/releases/download/v1.5.1/django_pattern_library-1.5.1.tar.gz \
-    --hash=sha256:ba3e40e5e5b39ce67feacddf52692caa3a531ff18409daf47b6b4e7148569c50
+django-pattern-library @ https://github.com/lincolnloop/django-pattern-library/releases/download/v1.5.2/django_pattern_library-1.5.2.tar.gz \
+    --hash=sha256:bd2bd69f02b89852cc83cabf12139217d641ee5bb9084f6c2e703164acacb966
     # via -r requirements/prod.txt
 django-permissionedforms==0.1 \
     --hash=sha256:4340bb20c4477fffb13b4cc5cccf9f1b1010b64f79956c291c72d2ad2ed243f8 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -448,9 +448,9 @@ django-mozilla-product-details==1.0.3 \
     --hash=sha256:1d139ba01f4484f3bb43b72864ce33f249835405449e0dc940217cfa42ce5b46 \
     --hash=sha256:a4aba6a68b296dffe8c1afb95d236cdbd402bd855cd49eef4d8a1a610105fd36
     # via -r requirements/prod.in
-django-pattern-library @ https://github.com/lincolnloop/django-pattern-library/releases/download/v1.5.1/django_pattern_library-1.5.1.tar.gz \
-    --hash=sha256:ba3e40e5e5b39ce67feacddf52692caa3a531ff18409daf47b6b4e7148569c50
-    # via -r requirements/prod.in
+django-pattern-library @ https://github.com/lincolnloop/django-pattern-library/releases/download/v1.5.2/django_pattern_library-1.5.2.tar.gz \
+    --hash=sha256:bd2bd69f02b89852cc83cabf12139217d641ee5bb9084f6c2e703164acacb966
+    # via -r requirements/prod.txt
 django-permissionedforms==0.1 \
     --hash=sha256:4340bb20c4477fffb13b4cc5cccf9f1b1010b64f79956c291c72d2ad2ed243f8 \
     --hash=sha256:d341a961a27cc77fde8cc42141c6ab55cc1f0cb886963cc2d6967b9674fa47d6

--- a/springfield/cms/templates/cms/base-pattern.html
+++ b/springfield/cms/templates/cms/base-pattern.html
@@ -7,7 +7,7 @@
 {% extends "cms/base-flare.html" %}
 
 {# Avoid referencing `page` which isn't provided by the pattern library #}
-{% block page_title %}Pattern preview{% endblock %}
+{% block page_title %}{{ pattern_name }} | Pattern preview{% endblock %}
 {% block flare_header %}{% endblock %}
 
 {% block page_css %}


### PR DESCRIPTION
## One-line summary
Add page titles to full page view of pattern library patterns, following #820 .

## Significant changes and points to review
I took the logic from #820, moved it to our fork of django-pattern-library, and made a new release. This pull request uses the newest version of django-pattern-library, and adds the `pattern_name` to the base pattern library template.

## Issue / Bugzilla link



## Testing
Open a full page view from the pattern library e.g. http://localhost:8000/pattern-library/render-pattern/pattern-library/base-styles/typography/typography_examples.html and see if title matches the content.