### PR TITLE
[WT-433] Remove Fields That Should Not Be Translated From Translation

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -146,6 +146,21 @@ class UUIDBlock(blocks.CharBlock):
 ######################################################################
 # Synchronized (not translated) blocks for wagtail-localize.         #
 # These blocks are copied from source to translation, not translated #
+#                                                                    #
+# Note: at this time, there is no way to mark StructBlock fields as  #
+# not translatable. However, there are a couple pull requests that   #
+# attempt to implement this feature in wagtail-localize:             #
+#   https://github.com/wagtail/wagtail-localize/pull/752             #
+#   https://github.com/wagtail/wagtail-localize/pull/882/            #
+# If they are merged and released, we may be able to simplify our    #
+# implementation and not use our Synchronized...Blocks.              #
+# For example, BaseButtonSettings may be able to define              #
+# translatable_blocks (and not use SynchronizedUUIDBlock):           #
+#                                                                    #
+# class BaseButtonSettings(blocks.StructBlock):                      #
+#     ...                                                            #
+#     translatable_blocks = ["theme", "icon", "icon_position"]       #
+#                                                                    #
 ######################################################################
 
 


### PR DESCRIPTION
## One-line summary
Fields that should not be translated (analytics ids, button link URLs, etc.) are now no longer marked as needing translation.

## Significant changes and points to review
This pull request:
 - creates synchronized fields (exactily the same as their underlying fields, except `get_translatable_segments()` returns `[]`)
 - updates relevant fields (buttons' `analytics_id`, ctas' `analytics_id`, link block destination fields) to use the synchronized fields
Note: there are no changes at the database level, so no migrations are needed to current content.
However, all existing pages will already have previously-created translation segments for these fields, so when we deploy this change, the incorrect percentages will still show for existing pages. Syncing the page in the original language (clicking "Sync translated pages") should fix this issue. If that's too long, let me know, and I can write a data migration to do so, though I'd prefer to not write more wagtail data migrations, since it's more difficult to get the structure exactly right.


## Issue / Bugzilla link



## Testing
**New Page**
1. Create a new page with buttons and links (like a WNP)
2. translate the page into another language
3. observe that the translated do NOT include the button analytics ids or the link URLs; they should still include the link text, and all other buttons

**Existing Page**
1. Find an existing page with buttons (like a WNP), observe its incorrect translation percentages on the translations dashboard (calculate what they should be by hand if you need), then click on one of its translations to see the fields that need to be translated - these currently include button analytics and link URLs.
4. go to the page in the original language and click "Sync translated pages"
5.  observe that translation percentages on the translations dashboard have changed and now no longer include the count of analytics id buttons or link URLs
6. click on one of its translations to see the fields that need to be translated - these should NOT include button analytics or link URLs.