### PR TITLE
notification color fixes

### DIFF
--- a/media/css/cms/flare-notification.css
+++ b/media/css/cms/flare-notification.css
@@ -73,11 +73,12 @@
 
 .fl-notification-orange {
     --notification-bg: var(--fl-theme-accent-orange-bg);
-    --notification-color: var(--fl-theme-color-text-on-accent);
+    --notification-color: var(--token-neutrals-charcoal);
 }
 
 .fl-notification-yellow {
     --notification-bg: var(--token-yellow-yellow);
+    --notification-color: var(--token-neutrals-charcoal);
 }
 
 .fl-notification-black {


### PR DESCRIPTION
## One-line summary

Notification colors on dark mode had a regression. 

<img width="527" height="789" alt="Screenshot 2025-12-08 at 8 58 16 AM" src="https://github.com/user-attachments/assets/0f126267-6b49-4db1-a833-4cd653e4aaf4" />

<img width="539" height="776" alt="Screenshot 2025-12-08 at 8 58 06 AM" src="https://github.com/user-attachments/assets/b3b26aea-4308-45e7-b693-8c75a79c22ce" />

