### PR TITLE
Add the groundwork for transcend consent integration

### DIFF
--- a/springfield/base/templates/base-protocol.html
+++ b/springfield/base/templates/base-protocol.html
@@ -10,6 +10,8 @@
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 
+    {% include 'includes/transcend-consent.html' %}
+
     <!--[if !IE]><!-->
     {{ js_bundle('site') }}
 

--- a/springfield/base/templates/includes/transcend-consent.html
+++ b/springfield/base/templates/includes/transcend-consent.html
@@ -1,0 +1,10 @@
+{#
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{# Transcend Consent Management - https://docs.transcend.io/docs/consent #}
+{% if settings.TRANSCEND_AIRGAP_URL and switch('transcend-consent') %}
+<script data-cfasync="false" src="{{ settings.TRANSCEND_AIRGAP_URL }}"></script>
+{% endif %}

--- a/springfield/settings/__init__.py
+++ b/springfield/settings/__init__.py
@@ -50,6 +50,8 @@ _csp_connect_src = {
     "o1069899.ingest.sentry.io",
     "o1069899.ingest.us.sentry.io",
     FXA_ENDPOINT,  # noqa: F405
+    "telemetry.transcend.io",  # Transcend Consent Management
+    "telemetry.us.transcend.io",  # Transcend Consent Management
 }
 _csp_font_src = {
     csp.constants.SELF,
@@ -100,6 +102,8 @@ _csp_script_src = {
     "tagmanager.google.com",
     "www.youtube.com",
     "s.ytimg.com",
+    "cdn.transcend.io",  # Transcend Consent Management
+    "transcend-cdn.com",  # Transcend Consent Management
 }
 _csp_style_src = {
     csp.constants.SELF,

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1023,6 +1023,9 @@ ADMINS = MANAGERS = config("ADMINS", parser=json.loads, default="[]")
 
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")
 
+# Transcend Consent Management - airgap.js script URL
+TRANSCEND_AIRGAP_URL = config("TRANSCEND_AIRGAP_URL", default="")
+
 STUB_ATTRIBUTION_HMAC_KEY = config("STUB_ATTRIBUTION_HMAC_KEY", default="")
 STUB_ATTRIBUTION_RATE = config("STUB_ATTRIBUTION_RATE", default=str(1 if DEV else 0), parser=float)
 STUB_ATTRIBUTION_MAX_LEN = config("STUB_ATTRIBUTION_MAX_LEN", default="600", parser=int)


### PR DESCRIPTION
## One-line summary
This adds the groundwork for transcend. This, by itself, does not activate transcend or any user-facing consent UI.

## Significant changes and points to review
- including a new template partial and loading the airgap.js script if configured.
- Adds TRANSCEND_AIRGAP_URL setting to base.py for script URL configuration.
- adding code that allows switch to be able to turn this on and off


## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-507?atlOrigin=eyJpIjoiZjY1MWIzZTczM2YwNDFhNWE5YjU0OGNjMGU5NmU1NWQiLCJwIjoiaiJ9
Matches this bedrock PR: https://github.com/mozilla/bedrock/pull/16938


## Testing
