### PR TITLE
fix: add more breathing space to 2025 YIR text

### DIFF
--- a/springfield/firefox/templates/firefox/landing/year-in-review-2025.html
+++ b/springfield/firefox/templates/firefox/landing/year-in-review-2025.html
@@ -73,7 +73,7 @@
 
           <h3 class="mzp-c-picto-heading">
             <div class="mzp-u-title-sm">1+ trillion</div>
-            Trackers blocked
+            trackers blocked
           </h3>
 
           <div class="mzp-c-picto-body">
@@ -101,7 +101,7 @@
 
           <h3 class="mzp-c-picto-heading">
             <div class="mzp-u-title-sm">200+ million</div>
-            People protected
+            people protected
           </h3>
 
           <div class="mzp-c-picto-body">
@@ -129,7 +129,8 @@
 
           <h3 class="mzp-c-picto-heading">
             <div class="mzp-u-title-sm">110</div>
-            New features</h3>
+            new features
+          </h3>
 
           <div class="mzp-c-picto-body">
             <p>


### PR DESCRIPTION
## One-line summary

Makes the main copy on the page easier to take in, by adding a beat between the ideas. Slightly tweak wording to boost impact of "people over profits"

## Significant changes and points to review

Compare https://www-dev.springfield.moz.works/en-US/landing/year-in-review-2025/

to 

<img width="3142" height="2552" alt="Screenshot 2025-12-16 at 12 13 46" src="https://github.com/user-attachments/assets/569819f6-8d4c-4aa2-a762-52207bf5791e" />

