### PR TITLE
Set YouTube to nocookie host

### DIFF
--- a/media/js/base/video-inline-embed.es6.js
+++ b/media/js/base/video-inline-embed.es6.js
@@ -35,6 +35,7 @@ function playVideo() {
     }
 
     new window.YT.Player(videoLink, {
+        host: 'https://www.youtube-nocookie.com', // privacy-enhanced mode
         width: 640,
         height: 360,
         videoId: videoId,

--- a/springfield/settings/__init__.py
+++ b/springfield/settings/__init__.py
@@ -101,6 +101,7 @@ _csp_script_src = {
     "www.google-analytics.com",
     "tagmanager.google.com",
     "www.youtube.com",
+    "www.youtube-nocookie.com",
     "s.ytimg.com",
     "cdn.transcend.io",  # Transcend Consent Management
     "transcend-cdn.com",  # Transcend Consent Management


### PR DESCRIPTION
## One-line summary

Update video inline embed to use `no-cookie` URL like CMS embed does

NOTE: this could be closed instead if it no longer useful!

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/846


## Testing
http://localhost:8000/sco/features/picture-in-picture/ (non-CMS video page)

<img width="295" height="683" alt="Screenshot 2025-12-16 at 3 51 56 PM" src="https://github.com/user-attachments/assets/e51ccd9e-d2d3-416f-8127-fef452e80e9f" />


You can compare with events that fire in production for the same video on `www.mozilla.org`: https://www.mozilla.org/fr/firefox/136.0/whatsnew/