### PR TITLE
Update CSP for Transcend

### DIFF
--- a/springfield/settings/__init__.py
+++ b/springfield/settings/__init__.py
@@ -113,7 +113,12 @@ _csp_style_src = {
     "cdn.transcend.io",  # Transcend Consent Management
     "transcend-cdn.com",  # Transcend Consent Management
 }
-# # TODO change settings so we don't need unsafes even in dev
+
+# Transcend Consent Management UI uses CSS-in-JS which requires inline styles.
+if TRANSCEND_AIRGAP_URL:  # noqa: F405
+    _csp_style_src.add(csp.constants.UNSAFE_INLINE)
+
+# TODO change settings so we don't need unsafes even in dev
 if config("ENABLE_DJANGO_PATTERN_LIBRARY", parser=bool, default="False"):
     _csp_style_src.add(csp.constants.UNSAFE_INLINE)
 


### PR DESCRIPTION
## One-line summary
Address CSP errors that showed up after recent transcend changes

## Significant changes and points to review
Allows 'unsafe-inline' in CSP style-src when TRANSCEND_AIRGAP_URL is set, to support Transcend Consent Management UI's CSS-in-JS usage.
