### PR TITLE
Fix base flare background color

### DIFF
--- a/media/css/cms/flare-theme.css
+++ b/media/css/cms/flare-theme.css
@@ -26,7 +26,7 @@ runtime conditions. Design tokens live in flare-tokens.css.
     --fl-theme-color-text-body: var(--token-neutrals-black);
 
     /* Core surface colors */
-    --fl-theme-surface-page: var(--token-neutrals-white);
+    --fl-theme-surface-page: var(--token-neutrals-ash);
     --fl-theme-surface-panel: var(--token-neutrals-ash);
     --fl-theme-surface-elevated: var(--token-neutrals-white);
     --fl-theme-surface-hover: var(--token-neutrals-white);


### PR DESCRIPTION
## One-line summary

Fix CSS variable that escaped revision.

## Significant changes and points to review

The variable change probably got in because the footer branch was created from a version of the flare styles when that background was changed for a moment and reverted back to the original ash color.

## Issue / Bugzilla link



## Testing

Check https://www.firefox.com/en-US/whatsnew/145/

This is how the page currently looks:
<img width="1470" height="568" alt="image" src="https://github.com/user-attachments/assets/8af628ed-cc6c-41cc-8bdd-404279a5f870" />

This is how it should look:
<img width="1470" height="568" alt="image" src="https://github.com/user-attachments/assets/02d11956-d158-4d66-b928-bde5d70df53a" />

