### PR TITLE
Update consent banner dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.28.4",
         "@babel/preset-env": "^7.28.3",
         "@mozilla-protocol/core": "^21.1.0",
-        "@mozmeao/consent-banner": "^1.1.0",
+        "@mozmeao/consent-banner": "^1.1.1",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^3.0.0",
@@ -2090,9 +2090,10 @@
       "license": "MPL-2.0"
     },
     "node_modules/@mozmeao/consent-banner": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mozmeao/consent-banner/-/consent-banner-1.1.0.tgz",
-      "integrity": "sha512-7p8ripMbe1183oTjuv8rLPVDAAiAfs/Jje8tNRMbI8W/BM1H8xV/K02naJdp2jevtWsIjryWGZf0Bv+3qyYeqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mozmeao/consent-banner/-/consent-banner-1.1.1.tgz",
+      "integrity": "sha512-pyTweF7Vd1qnPi2SCjw906JfjaPW4Tx9euzl3DBQLKNnmNkkwl2RhDEciDFBsGU8hvwEXAQ6+joM1p+2hCi+IQ==",
+      "license": "MPL-2.0",
       "peerDependencies": {
         "@mozmeao/cookie-helper": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
     "@mozilla-protocol/core": "^21.1.0",
-    "@mozmeao/consent-banner": "^1.1.0",
+    "@mozmeao/consent-banner": "^1.1.1",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^3.0.0",


### PR DESCRIPTION
## One-line summary

Updates consent banner dep to 1.1.1

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
http://localhost:8000/en-GB/landing/get/?geo=GB (or any EU geo) in a browser with no DNT or GPC and existing no analytics pref cookie

confirm consent banner shows