### PR TITLE
feat: Stop SQLite DB download on startup for PostgreSQL deployments 

### DIFF
--- a/bin/cron.py
+++ b/bin/cron.py
@@ -39,6 +39,8 @@ HOSTNAME = platform.node()
 DB_UPDATE_MINUTES = config("DB_UPDATE_MINUTES", default="5", parser=int)
 LOCAL_DB_UPDATE = config("LOCAL_DB_UPDATE", default="False", parser=bool)
 DB_DOWNLOAD_IGNORE_GIT = config("DB_DOWNLOAD_IGNORE_GIT", default="False", parser=bool)
+DATABASE_URL = config("DATABASE_URL", default="")
+USING_POSTGRES = DATABASE_URL.startswith("postgres")
 RUN_TIMES = {}
 
 # Dead Man's Snitch
@@ -157,7 +159,8 @@ def schedule_file_jobs():
     def update_locales():
         call_command("l10n_update")
 
-    if not LOCAL_DB_UPDATE:
+    # Only schedule download_database for SQLite deployments downloading from S3
+    if not LOCAL_DB_UPDATE and not USING_POSTGRES:
 
         @scheduled_job("interval", minutes=DB_UPDATE_MINUTES)
         def download_database():

--- a/bin/run-file-clock.sh
+++ b/bin/run-file-clock.sh
@@ -5,8 +5,9 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # On demos, we don't want to download the latest DB, else we'll lose CMS data
+# Also skip if using PostgreSQL (DATABASE_URL set)
 SKIP_FORCED_DB_DOWNLOAD=$(echo "${SKIP_FORCED_DB_DOWNLOAD:-false}" | tr '[:upper:]' '[:lower:]')
-if [[ "$SKIP_FORCED_DB_DOWNLOAD" == "false" ]]; then
+if [[ "$SKIP_FORCED_DB_DOWNLOAD" == "false" && -z "$DATABASE_URL" ]]; then
     bin/run-db-download.py --force
 fi
 

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -20,6 +20,7 @@ from waffle.models import Switch
 
 from lib import l10n_utils
 from lib.l10n_utils import RequireSafeMixin
+from springfield.base.config_manager import config
 from springfield.base.geo import get_country_from_request
 from springfield.base.waffle import switch
 from springfield.utils import git
@@ -47,13 +48,15 @@ class GeoTemplateView(l10n_utils.L10nTemplateView):
 
 
 SQLITE_DB_IN_USE = settings.DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
+LOCAL_DB_UPDATE = config("LOCAL_DB_UPDATE", default="False", parser=bool)
 
 HEALTH_FILES = [
     # Format: (file name, max seconds since last run)
     ("update_locales", 600),
 ]
 
-if SQLITE_DB_IN_USE:
+# Only check download_database health for SQLite deployments that download from S3
+if SQLITE_DB_IN_USE and not LOCAL_DB_UPDATE:
     HEALTH_FILES.insert(
         0,
         ("download_database", 600),


### PR DESCRIPTION
Skip downloading SQLite database files from S3 when using PostgreSQL:

  - bin/run-file-clock.sh: Skip forced DB download when DATABASE_URL is set
  - bin/cron.py: Skip download_database cron job when using PostgreSQL
  - springfield/base/views.py: Skip download_database health check when LOCAL_DB_UPDATE=True

This matches the fix applied to Bedrock in mozilla/bedrock#16988 functionally if not identically

Resolves #906