### PR TITLE
Add preditable prefix to banner cookies

### DIFF
--- a/media/js/base/banners/m24-pencil-banner-check.js
+++ b/media/js/base/banners/m24-pencil-banner-check.js
@@ -8,6 +8,6 @@ var cookiesEnabled =
     typeof window.Mozilla.Cookies !== 'undefined' &&
     window.Mozilla.Cookies.enabled();
 
-if (cookiesEnabled && window.Mozilla.Cookies.hasItem('pencil-banner')) {
+if (cookiesEnabled && window.Mozilla.Cookies.hasItem('moz-banner-pencil')) {
     document.documentElement.setAttribute('data-pencil-banner-closed', 'true');
 }

--- a/media/js/base/banners/m24-pencil-banner.es6.js
+++ b/media/js/base/banners/m24-pencil-banner.es6.js
@@ -8,7 +8,7 @@ import { getConsentCookie } from '../consent/utils.es6';
 
 let _pencilBanner;
 const M24PencilBanner = {};
-const BANNER_ID = 'pencil-banner';
+const BANNER_ID = 'moz-banner-pencil';
 
 M24PencilBanner.consentsToCookies = function () {
     const cookie = getConsentCookie();

--- a/media/js/base/banners/mozilla-banner.es6.js
+++ b/media/js/base/banners/mozilla-banner.es6.js
@@ -41,7 +41,7 @@ MozBanner.setCookie = function (id) {
     const cookieDuration = 1 * 24 * 60 * 60 * 1000; // 1 day expiration
     date.setTime(date.getTime() + cookieDuration); // 1 day expiration
     window.Mozilla.Cookies.setItem(
-        id,
+        'moz-banner-' + id,
         true,
         date.toUTCString(),
         '/',
@@ -52,7 +52,7 @@ MozBanner.setCookie = function (id) {
 };
 
 MozBanner.hasCookie = function (id) {
-    return Mozilla.Cookies.hasItem(id);
+    return Mozilla.Cookies.hasItem('moz-banner-' + id);
 };
 
 MozBanner.close = function () {

--- a/tests/unit/spec/base/m24-pencil-banner.js
+++ b/tests/unit/spec/base/m24-pencil-banner.js
@@ -71,7 +71,7 @@ describe('mozilla-banner.es6.js', function () {
             spyOn(window.Mozilla.Cookies, 'setItem');
             M24PencilBanner.setCookie();
             expect(window.Mozilla.Cookies.setItem).toHaveBeenCalledWith(
-                'pencil-banner',
+                'moz-banner-pencil',
                 true,
                 jasmine.any(String),
                 '/',

--- a/tests/unit/spec/base/mozilla-banner.js
+++ b/tests/unit/spec/base/mozilla-banner.js
@@ -94,7 +94,7 @@ describe('mozilla-banner.es6.js', function () {
             spyOn(window.Mozilla.Cookies, 'setItem');
             MozBanner.setCookie('some-id');
             expect(window.Mozilla.Cookies.setItem).toHaveBeenCalledWith(
-                'some-id',
+                'moz-banner-some-id',
                 true,
                 jasmine.any(String),
                 '/',


### PR DESCRIPTION
## One-line summary

Add predictable prefix to banner cookies.

## Significant changes and points to review

This will allow us to okay the banner cookies in Transcend with a regex instead of on a case-by-case basis.

## Issue / Bugzilla link

n/a

## Testing

Banner is set with correct cookie. 

[Companion bedrock PR.](https://github.com/mozilla/bedrock/pull/16997)