### PR TITLE
Add video option to image variants block

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -581,6 +581,7 @@ django==5.2.11 \
     #   wagtail-localize-intentional-blanks
     #   wagtail-localize-smartling
     #   wagtail-thumbnail-choice-block
+    #   wagtailmedia
 django-cors-headers==4.9.0 \
     --hash=sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449 \
     --hash=sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8
@@ -2280,6 +2281,7 @@ wagtail==7.2.2 \
     #   wagtail-localize-smartling
     #   wagtail-thumbnail-choice-block
     #   wagtaildraftsharing
+    #   wagtailmedia
 wagtail-factories==4.3.0 \
     --hash=sha256:27c19078ceade5e408aef0edfa3378b7992e5bed4d4c7e8216cbdd53f9732464 \
     --hash=sha256:6d3129244642a400462344e35168e5eb89598d5b63a4cfb7f26a5a6052f50d95
@@ -2315,6 +2317,10 @@ wagtail-thumbnail-choice-block==0.1.4 \
 wagtaildraftsharing==0.3.0 \
     --hash=sha256:2e77b46df0b164c089d25ff146e25fa3601e52de7ccaa9226925e6e6357fdeab \
     --hash=sha256:450c756f600c8d43eb0391ebb6829d554a5501b58a3e7e525349dc0409cf2bdd
+    # via -r requirements/prod.txt
+wagtailmedia==0.17.2 \
+    --hash=sha256:4457e267fc53d8db4c9eb9a48d27f4b47b0823a9f7d0820f2dd98f1ba5d58600 \
+    --hash=sha256:abe10c6341fbc41ebc30d2955fff00abf6160bc473a5f9f1106d69111045c202
     # via -r requirements/prod.txt
 wand==0.6.13 \
     --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -61,6 +61,7 @@ wagtail-localize==1.13
 wagtail-thumbnail-choice-block==0.1.4
 Wagtail==7.2.2
 wagtaildraftsharing==0.3.0
+wagtailmedia==0.17.2
 Wand==0.6.13  # For animated GIF support
 whitenoise==6.11.0
 https://github.com/lincolnloop/django-pattern-library/releases/download/v1.5.3/django_pattern_library-1.5.3.tar.gz

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -386,6 +386,7 @@ django==5.2.11 \
     #   wagtail-localize-intentional-blanks
     #   wagtail-localize-smartling
     #   wagtail-thumbnail-choice-block
+    #   wagtailmedia
 django-cors-headers==4.9.0 \
     --hash=sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449 \
     --hash=sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8
@@ -1574,6 +1575,7 @@ wagtail==7.2.2 \
     #   wagtail-localize-smartling
     #   wagtail-thumbnail-choice-block
     #   wagtaildraftsharing
+    #   wagtailmedia
 wagtail-link-block==1.1.7 \
     --hash=sha256:5b7346bd60b65b00d7bafa48ab3b54b09c97abd085c0afd8f691be3219ff7a1c \
     --hash=sha256:e2f0c9dedd8e1116fc347e8d5a28164376d121fa95b9c87a85ca408fc426846e
@@ -1605,6 +1607,10 @@ wagtail-thumbnail-choice-block==0.1.4 \
 wagtaildraftsharing==0.3.0 \
     --hash=sha256:2e77b46df0b164c089d25ff146e25fa3601e52de7ccaa9226925e6e6357fdeab \
     --hash=sha256:450c756f600c8d43eb0391ebb6829d554a5501b58a3e7e525349dc0409cf2bdd
+    # via -r requirements/prod.in
+wagtailmedia==0.17.2 \
+    --hash=sha256:4457e267fc53d8db4c9eb9a48d27f4b47b0823a9f7d0820f2dd98f1ba5d58600 \
+    --hash=sha256:abe10c6341fbc41ebc30d2955fff00abf6160bc473a5f9f1106d69111045c202
     # via -r requirements/prod.in
 wand==0.6.13 \
     --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -10,6 +10,7 @@ from wagtail import blocks
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail_link_block.blocks import LinkBlock
 from wagtail_thumbnail_choice_block import ThumbnailChoiceBlock
+from wagtailmedia.blocks import VideoChooserBlock
 
 HEADING_TEXT_FEATURES = [
     "bold",
@@ -675,6 +676,29 @@ class ImageVariantsBlockSettings(blocks.StructBlock):
         required=False,
         label="Dark Mode Mobile Image",
         help_text="Optional dark mode mobile image variant",
+    )
+    video = VideoChooserBlock(
+        required=False,
+        label="Video",
+        help_text="Optional video (mp4 or webm). When provided, displays instead of the image.",
+    )
+    video_autoplay = blocks.BooleanBlock(
+        required=False,
+        default=False,
+        label="Autoplay",
+        help_text="Automatically play the video (will be muted)",
+    )
+    video_loop = blocks.BooleanBlock(
+        required=False,
+        default=False,
+        label="Loop",
+        help_text="Loop the video continuously",
+    )
+    video_show_controls = blocks.BooleanBlock(
+        required=False,
+        default=True,
+        label="Show Controls",
+        help_text="Display video playback controls",
     )
 
     class Meta:

--- a/springfield/cms/templates/cms/blocks/image-variants.html
+++ b/springfield/cms/templates/cms/blocks/image-variants.html
@@ -9,7 +9,25 @@
 {% set break_at = break_at or "sm" %}
 
 <div class="image-variants-display">
-{# Default/desktop light mode image #}
+{% if value.settings.video %}
+  {# Video display #}
+  {% set poster_image = image(value.image, "width-800") %}
+  <video
+    {% if value.settings.video_show_controls %}controls{% endif %}
+    {% if value.settings.video_autoplay %}autoplay muted{% endif %}
+    {% if value.settings.video_loop %}loop{% endif %}
+    poster="{{ poster_image.url }}"
+    playsinline
+    preload="metadata"
+  >
+    {% for source in value.settings.video.sources %}
+      <source src="{{ source.src }}" type="{{ source.type }}">
+    {% endfor %}
+    {# Fallback image for browsers that don't support video #}
+    <img src="{{ poster_image.url }}" alt="{{ value.image.alt }}">
+  </video>
+{% else %}
+  {# Default/desktop light mode image #}
   {%- set default_display_classes -%}
     {% if value.settings.dark_mode_image %}display-light {% endif %}
     {% if value.settings.mobile_image or value.settings.dark_mode_mobile_image %}
@@ -17,67 +35,68 @@
     {% endif %}
   {%- endset -%}
 
-{{ srcset_image(
-    value.image,
-    widths,
-    sizes=sizes,
-    width=value.image.width,
-    height=value.image.height,
-    loading="lazy",
-    class=default_display_classes,
-) }}
-
-{# Light mode mobile image #}
-{% if value.settings.mobile_image %}
-  {%- set mobile_classes -%}
-    {% if value.settings.dark_mode_mobile_image %}display-light {% endif %}
-    {% if break_at == "md" %}display-xs-and-sm{% else %}display-xs{% endif %}
-  {%- endset -%}
   {{ srcset_image(
-      value.settings.mobile_image,
+      value.image,
       widths,
       sizes=sizes,
-      width=value.settings.mobile_image.width,
-      height=value.settings.mobile_image.height,
+      width=value.image.width,
+      height=value.image.height,
       loading="lazy",
-      class=mobile_classes,
+      class=default_display_classes,
   ) }}
-{% endif %}
 
-{# Dark mode mobile image #}
-{% if value.settings.dark_mode_mobile_image %}
-  {%- set dark_mobile_classes -%}
-    display-dark {% if break_at == "md" %}display-xs-and-sm{% else %}display-xs{% endif %}
-  {%- endset -%}
-
-  {{ srcset_image(
-      value.settings.dark_mode_mobile_image,
-      widths,
-      sizes=sizes,
-      width=value.settings.dark_mode_mobile_image.width,
-      height=value.settings.dark_mode_mobile_image.height,
-      loading="lazy",
-      class=dark_mobile_classes,
-  ) }}
-{% endif %}
-
-{# Dark mode desktop image #}
-{% if value.settings.dark_mode_image %}
-{%- set dark_desktop_classes -%}
-  display-dark
-  {% if value.settings.dark_mode_mobile_image %}
-    {% if break_at == "md" %}display-md-up{% else %}display-sm-up{% endif %}
+  {# Light mode mobile image #}
+  {% if value.settings.mobile_image %}
+    {%- set mobile_classes -%}
+      {% if value.settings.dark_mode_mobile_image %}display-light {% endif %}
+      {% if break_at == "md" %}display-xs-and-sm{% else %}display-xs{% endif %}
+    {%- endset -%}
+    {{ srcset_image(
+        value.settings.mobile_image,
+        widths,
+        sizes=sizes,
+        width=value.settings.mobile_image.width,
+        height=value.settings.mobile_image.height,
+        loading="lazy",
+        class=mobile_classes,
+    ) }}
   {% endif %}
-{%- endset -%}
 
-  {{ srcset_image(
-      value.settings.dark_mode_image,
-      widths,
-      sizes=sizes,
-      width=value.settings.dark_mode_image.width,
-      height=value.settings.dark_mode_image.height,
-      loading="lazy",
-      class=dark_desktop_classes,
-  ) }}
+  {# Dark mode mobile image #}
+  {% if value.settings.dark_mode_mobile_image %}
+    {%- set dark_mobile_classes -%}
+      display-dark {% if break_at == "md" %}display-xs-and-sm{% else %}display-xs{% endif %}
+    {%- endset -%}
+
+    {{ srcset_image(
+        value.settings.dark_mode_mobile_image,
+        widths,
+        sizes=sizes,
+        width=value.settings.dark_mode_mobile_image.width,
+        height=value.settings.dark_mode_mobile_image.height,
+        loading="lazy",
+        class=dark_mobile_classes,
+    ) }}
+  {% endif %}
+
+  {# Dark mode desktop image #}
+  {% if value.settings.dark_mode_image %}
+  {%- set dark_desktop_classes -%}
+    display-dark
+    {% if value.settings.dark_mode_mobile_image %}
+      {% if break_at == "md" %}display-md-up{% else %}display-sm-up{% endif %}
+    {% endif %}
+  {%- endset -%}
+
+    {{ srcset_image(
+        value.settings.dark_mode_image,
+        widths,
+        sizes=sizes,
+        width=value.settings.dark_mode_image.width,
+        height=value.settings.dark_mode_image.height,
+        loading="lazy",
+        class=dark_desktop_classes,
+    ) }}
+  {% endif %}
 {% endif %}
 </div>

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -731,6 +731,7 @@ INSTALLED_APPS = [
     "wagtail.admin",
     "wagtail",
     "wagtail_thumbnail_choice_block",
+    "wagtailmedia",
     "modelcluster",
     "taggit",
     "csp",


### PR DESCRIPTION
## One-line summary

Add a new option to the image variants block to upload a video.

## Significant changes and points to review

- Add the wagtailmedia lib
- Add new options to the Image Variants block's settings for video support

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-608

## Testing

- Run migrations
- In any page that uses the image variants block, add a video to the block's settings