### PR TITLE
Add anchor ID field to section blocks

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1228,12 +1228,16 @@ class IntroBlockSettings(blocks.StructBlock):
         label="Media Position",
         inline_form=True,
     )
+    anchor_id = blocks.CharBlock(
+        required=False,
+        help_text="Add an ID to make this section linkable from navigation (e.g., 'overview', 'features')",
+    )
 
     class Meta:
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Media Position: {media_position}"
+        label_format = "Media Position: {media_position} - Anchor ID: {anchor_id}"
         form_classname = "compact-form struct-block"
 
 
@@ -1290,12 +1294,16 @@ class SectionBlockSettings(blocks.StructBlock):
         inline_form=True,
         help_text="Control which users can see this content block",
     )
+    anchor_id = blocks.CharBlock(
+        required=False,
+        help_text="Add an ID to make this section linkable from navigation (e.g., 'overview', 'features')",
+    )
 
     class Meta:
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Show To: {show_to}"
+        label_format = "Show To: {show_to} - Anchor ID: {anchor_id}"
         form_classname = "compact-form struct-block"
 
 
@@ -1398,12 +1406,16 @@ class BannerSettings(blocks.StructBlock):
         inline_form=True,
         help_text="Control which users can see this content block",
     )
+    anchor_id = blocks.CharBlock(
+        required=False,
+        help_text="Add an ID to make this section linkable from navigation (e.g., 'overview', 'features')",
+    )
 
     class Meta:
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Theme: {theme} - Media After: {media_after} - Show To: {show_to}"
+        label_format = "Theme: {theme} - Media After: {media_after} - Show To: {show_to} - Anchor ID: {anchor_id}"
         form_classname = "compact-form struct-block"
 
 
@@ -1467,12 +1479,16 @@ class KitBannerSettings(blocks.StructBlock):
         inline_form=True,
         help_text="Control which users can see this content block",
     )
+    anchor_id = blocks.CharBlock(
+        required=False,
+        help_text="Add an ID to make this section linkable from navigation (e.g., 'overview', 'features')",
+    )
 
     class Meta:
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Theme: {theme} - Show To: {show_to}"
+        label_format = "Theme: {theme} - Show To: {show_to} - Anchor ID: {anchor_id}"
         form_classname = "compact-form struct-block"
 
 
@@ -1611,12 +1627,16 @@ class HomeKitBannerSettings(blocks.StructBlock):
         inline_form=True,
         help_text="Control which users can see this content block",
     )
+    anchor_id = blocks.CharBlock(
+        required=False,
+        help_text="Add an ID to make this section linkable from navigation (e.g., 'overview', 'features')",
+    )
 
     class Meta:
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Show To: {show_to}"
+        label_format = "Show To: {show_to} - Anchor ID: {anchor_id}"
         form_classname = "compact-form struct-block"
 
 

--- a/springfield/cms/fixtures/banner_fixtures.py
+++ b/springfield/cms/fixtures/banner_fixtures.py
@@ -16,7 +16,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "outlined", "media_after": False, "show_to": "all"},
+                "settings": {
+                    "theme": "outlined",
+                    "media_after": False,
+                    "show_to": "all",
+                    "anchor_id": "simple-outlined-banner",
+                },
                 "media": [],
                 "heading": {
                     "superheading_text": '<p data-block-key="9gmqf">Outlined Theme</p>',
@@ -31,7 +36,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "purple", "media_after": False, "show_to": "all"},
+                "settings": {
+                    "theme": "purple",
+                    "media_after": False,
+                    "show_to": "all",
+                    "anchor_id": "simple-purple-banner",
+                },
                 "media": [],
                 "heading": {
                     "superheading_text": '<p data-block-key="9gmqf">Purple Theme</p>',
@@ -46,7 +56,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "outlined", "media_after": False, "show_to": "all"},
+                "settings": {
+                    "theme": "outlined",
+                    "media_after": False,
+                    "show_to": "all",
+                    "anchor_id": "outlined-banner-with-image",
+                },
                 "media": [
                     {
                         "type": "image",
@@ -74,7 +89,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "purple", "media_after": False, "show_to": "all"},
+                "settings": {
+                    "theme": "purple",
+                    "media_after": False,
+                    "show_to": "all",
+                    "anchor_id": "purple-banner-with-image",
+                },
                 "media": [
                     {
                         "type": "image",
@@ -102,7 +122,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "outlined", "media_after": True, "show_to": "all"},
+                "settings": {
+                    "theme": "outlined",
+                    "media_after": True,
+                    "show_to": "all",
+                    "anchor_id": "outlined-banner-with-image-after",
+                },
                 "media": [
                     {
                         "type": "image",
@@ -129,7 +154,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "purple", "media_after": True, "show_to": "all"},
+                "settings": {
+                    "theme": "purple",
+                    "media_after": True,
+                    "show_to": "all",
+                    "anchor_id": "purple-banner-with-image-after",
+                },
                 "media": [
                     {
                         "type": "image",
@@ -156,7 +186,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "outlined", "media_after": True, "show_to": "all"},
+                "settings": {
+                    "theme": "outlined",
+                    "media_after": True,
+                    "show_to": "all",
+                    "anchor_id": "outlined-banner-with-qr-code",
+                },
                 "media": [
                     {
                         "type": "qr_code",
@@ -176,7 +211,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "purple", "media_after": False, "show_to": "all"},
+                "settings": {
+                    "theme": "purple",
+                    "media_after": False,
+                    "show_to": "all",
+                    "anchor_id": "purple-banner-with-qr-code",
+                },
                 "media": [
                     {
                         "type": "qr_code",
@@ -196,7 +236,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "outlined", "media_after": False, "show_to": "all"},
+                "settings": {
+                    "theme": "outlined",
+                    "media_after": False,
+                    "show_to": "all",
+                    "anchor_id": "outlined-banner-with-video",
+                },
                 "media": [videos["youtube"]],
                 "heading": {
                     "superheading_text": '<p data-block-key="9gmqf">Outlined Theme</p>',
@@ -211,7 +256,12 @@ def get_banner_variants():
         {
             "type": "banner",
             "value": {
-                "settings": {"theme": "purple", "media_after": True, "show_to": "all"},
+                "settings": {
+                    "theme": "purple",
+                    "media_after": True,
+                    "show_to": "all",
+                    "anchor_id": "purple-banner-with-video",
+                },
                 "media": [videos["cdn"]],
                 "heading": {
                     "superheading_text": '<p data-block-key="9gmqf">Purple Theme</p>',

--- a/springfield/cms/fixtures/homepage_fixtures.py
+++ b/springfield/cms/fixtures/homepage_fixtures.py
@@ -284,7 +284,7 @@ def get_kit_banner():
     return {
         "type": "kit_banner",
         "value": {
-            "settings": {"show_to": "all"},
+            "settings": {"show_to": "all", "anchor_id": "kit-banner"},
             "heading": {
                 "superheading_text": "",
                 "heading_text": '<p data-block-key="cggck">Peace of mind?</p><p data-block-key="eia38">Piece of cake.</p>',

--- a/springfield/cms/fixtures/intro_fixtures.py
+++ b/springfield/cms/fixtures/intro_fixtures.py
@@ -17,7 +17,10 @@ def get_intro_variants() -> list[dict]:
         {
             "type": "intro",
             "value": {
-                "settings": {"media_position": "after"},
+                "settings": {
+                    "media_position": "after",
+                    "anchor_id": "simple-intro-with-text-and-button",
+                },
                 "media": [],
                 "heading": {
                     "superheading_text": '<p data-block-key="ybdoh">Superheading text</p>',
@@ -33,7 +36,10 @@ def get_intro_variants() -> list[dict]:
         {
             "type": "intro",
             "value": {
-                "settings": {"media_position": "after"},
+                "settings": {
+                    "media_position": "after",
+                    "anchor_id": "intro-with-image",
+                },
                 "media": [
                     {
                         "type": "image",
@@ -62,7 +68,10 @@ def get_intro_variants() -> list[dict]:
         {
             "type": "intro",
             "value": {
-                "settings": {"media_position": "before"},
+                "settings": {
+                    "media_position": "before",
+                    "anchor_id": "intro-with-image-before",
+                },
                 "media": [
                     {
                         "type": "image",
@@ -92,7 +101,10 @@ def get_intro_variants() -> list[dict]:
         {
             "type": "intro",
             "value": {
-                "settings": {"media_position": "after"},
+                "settings": {
+                    "media_position": "after",
+                    "anchor_id": "intro-with-youtube-video",
+                },
                 "media": [videos["youtube"]],
                 "heading": {
                     "superheading_text": '<p data-block-key="ybdoh">Superheading text</p>',
@@ -107,7 +119,10 @@ def get_intro_variants() -> list[dict]:
         {
             "type": "intro",
             "value": {
-                "settings": {"media_position": "before"},
+                "settings": {
+                    "media_position": "before",
+                    "anchor_id": "intro-with-cdn-video",
+                },
                 "media": [videos["cdn"]],
                 "heading": {
                     "superheading_text": '<p data-block-key="ybdoh">Superheading text</p>',

--- a/springfield/cms/fixtures/kit_banner_fixtures.py
+++ b/springfield/cms/fixtures/kit_banner_fixtures.py
@@ -13,7 +13,11 @@ def get_kit_banner_variants():
         {
             "type": "kit_banner",
             "value": {
-                "settings": {"theme": "filled", "show_to": "all"},
+                "settings": {
+                    "theme": "filled",
+                    "show_to": "all",
+                    "anchor_id": "filled-banner-without-kit-image",
+                },
                 "heading": {
                     "superheading_text": '<p data-block-key="zg8yr">Kit Banner</p>',
                     "heading_text": '<p data-block-key="xgfrq">Filled Banner without Kit Image</p>',
@@ -26,7 +30,11 @@ def get_kit_banner_variants():
         {
             "type": "kit_banner",
             "value": {
-                "settings": {"theme": "filled-small", "show_to": "all"},
+                "settings": {
+                    "theme": "filled-small",
+                    "show_to": "all",
+                    "anchor_id": "filled-banner-small-curious-kit",
+                },
                 "heading": {
                     "superheading_text": '<p data-block-key="zg8yr">Kit Banner</p>',
                     "heading_text": '<p data-block-key="xgfrq">Filled Banner Small Curious Kit</p>',
@@ -40,7 +48,11 @@ def get_kit_banner_variants():
         {
             "type": "kit_banner",
             "value": {
-                "settings": {"theme": "filled-large", "show_to": "all"},
+                "settings": {
+                    "theme": "filled-large",
+                    "show_to": "all",
+                    "anchor_id": "filled-banner-large-curious-kit",
+                },
                 "heading": {
                     "superheading_text": '<p data-block-key="zg8yr">Kit Banner</p>',
                     "heading_text": '<p data-block-key="xgfrq">Filled Banner Large Curious Kit</p>',
@@ -54,7 +66,11 @@ def get_kit_banner_variants():
         {
             "type": "kit_banner",
             "value": {
-                "settings": {"theme": "filled-face", "show_to": "all"},
+                "settings": {
+                    "theme": "filled-face",
+                    "show_to": "all",
+                    "anchor_id": "filled-banner-sitting-kit",
+                },
                 "heading": {
                     "superheading_text": '<p data-block-key="zg8yr">Kit Banner</p>',
                     "heading_text": '<p data-block-key="xgfrq">Filled Banner Sitting Kit</p>',
@@ -68,7 +84,11 @@ def get_kit_banner_variants():
         {
             "type": "kit_banner",
             "value": {
-                "settings": {"theme": "filled-tail", "show_to": "all"},
+                "settings": {
+                    "theme": "filled-tail",
+                    "show_to": "all",
+                    "anchor_id": "filled-banner-kit-tail",
+                },
                 "heading": {
                     "superheading_text": '<p data-block-key="zg8yr">Kit Banner</p>',
                     "heading_text": '<p data-block-key="xgfrq">Filled Banner Kit Tail</p>',

--- a/springfield/cms/fixtures/media_content_fixtures.py
+++ b/springfield/cms/fixtures/media_content_fixtures.py
@@ -112,7 +112,7 @@ def get_section_with_media_content_variants() -> dict:
     return {
         "type": "section",
         "value": {
-            "settings": {"show_to": "all"},
+            "settings": {"show_to": "all", "anchor_id": "section-with-media-content"},
             "heading": {
                 "superheading_text": '<p data-block-key="d2q88">Media + Content</p>',
                 "heading_text": '<p data-block-key="w8raa">Section with Media + Content Blocks and Call To Action</p>',

--- a/springfield/cms/templates/cms/blocks/sections/banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/banner.html
@@ -18,6 +18,7 @@
     theme="{{ value.settings.theme }}"
     media_after="{{ value.settings.media_after }}"
     qr_code="{{ qr_code }}"
+    anchor_id="{{ value.settings.anchor_id }}"
   >
 
     <content:heading>

--- a/springfield/cms/templates/cms/blocks/sections/home-kit-banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/home-kit-banner.html
@@ -8,7 +8,10 @@
 {% set block_text = value.heading.heading_text|richtext|remove_tags %}
 
 <include:conditional-display condition="{{ value.settings.show_to }}">
-  <include:kit-banner theme="{{ 'with-qr' if value.qr_code else 'diving-in' }}" qr_code="{{ value.qr_code }}">
+  <include:kit-banner
+    theme="{{ 'with-qr' if value.qr_code else 'diving-in' }}"
+    qr_code="{{ value.qr_code }}"
+    anchor_id="{{ value.settings.anchor_id }}">
 
     <content:heading>
       {% set heading_level = 'h' ~ block_level if block_level else 'h2' %}

--- a/springfield/cms/templates/cms/blocks/sections/intro.html
+++ b/springfield/cms/templates/cms/blocks/sections/intro.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<include:intro media_position="{{ value.settings.media_position }}">
+<include:intro media_position="{{ value.settings.media_position }}" anchor_id="{{ value.settings.anchor_id }}">
   <content:heading>
     {% include_block value.heading %}
   </content:heading>

--- a/springfield/cms/templates/cms/blocks/sections/kit-banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/kit-banner.html
@@ -8,7 +8,7 @@
 {% set block_text = value.heading.heading_text|richtext|remove_tags %}
 
 <include:conditional-display condition="{{ value.settings.show_to }}">
-  <include:kit-banner theme="{{ value.settings.theme }}">
+  <include:kit-banner theme="{{ value.settings.theme }}" anchor_id="{{ value.settings.anchor_id }}">
 
     <content:heading>
       {% set heading_level = 'h' ~ block_level if block_level else 'h2' %}

--- a/springfield/cms/templates/cms/blocks/sections/section.html
+++ b/springfield/cms/templates/cms/blocks/sections/section.html
@@ -8,7 +8,7 @@
 {% set block_text = value.heading.heading_text|richtext|remove_tags %}
 
 <include:conditional-display condition="{{ value.settings.show_to }}">
-  <include:section>
+  <include:section anchor_id="{{ value.settings.anchor_id }}">
     <content:heading>
       {% with alignment_class="text-center" %}
         {% include_block value.heading %}

--- a/springfield/cms/templates/components/banner.html
+++ b/springfield/cms/templates/components/banner.html
@@ -4,9 +4,9 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# props theme="outlined" media_after=False qr_code=None  #}
+{# props theme="outlined" media_after=False qr_code=None anchor_id=""  #}
 
-<div class="fl-banner-container">
+<div class="fl-banner-container" {% if anchor_id %}id="{{ anchor_id }}"{% endif %}>
   <div
     class="
       fl-banner

--- a/springfield/cms/templates/components/intro.html
+++ b/springfield/cms/templates/components/intro.html
@@ -4,7 +4,12 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<div class="fl-intro{% if contents.media %} fl-intro-has-media{% endif %}{% if contents.media and media_position %} fl-intro-media-{{ media_position }}{% endif %}">
+{# props media_position="after" anchor_id=""  #}
+
+<div
+  class="fl-intro{% if contents.media %} fl-intro-has-media{% endif %}{% if contents.media and media_position %} fl-intro-media-{{ media_position }}{% endif %}"
+  {% if anchor_id %}id="{{ anchor_id }}"{% endif %}
+>
   <div class="fl-intro-content">
     {{ contents.heading }}
     {% if contents.actions %}

--- a/springfield/cms/templates/components/kit-banner.html
+++ b/springfield/cms/templates/components/kit-banner.html
@@ -4,17 +4,18 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# props theme="" qr_code=None #}
+{# props theme="" qr_code=None anchor_id="" #}
 {# themes = ["filled-small", "filled-large", "filled-face", "filled-tail", "filled-diving-in", "filled-with-qr"] #}
 {# themes_2026 = ["diving-in", "with-qr"] #}
 
-<div class="fl-banner-container">
+<div class="fl-banner-container" {% if anchor_id %}id="{{ anchor_id }}"{% endif %}>
   {% set theme = (theme or "").replace("filled-", "").replace("filled", "") %}
   <div
     class="
       fl-banner fl-banner-kit fl-banner-purple
       {% if theme %}fl-banner-kit-{{ theme }}{% endif %}"
-    aria-labelledby="fl-banner-heading">
+    aria-labelledby="fl-banner-heading"
+    >
     {% if qr_code and qr_code.strip() %}
       <div class="fl-banner-kit-qr" role="img" aria-label="QR Code">
         {{ qrcode(qr_code, 12) }}

--- a/springfield/cms/templates/components/section.html
+++ b/springfield/cms/templates/components/section.html
@@ -4,7 +4,9 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<section class="fl-section">
+{# props anchor_id=""  #}
+
+<section class="fl-section" {% if anchor_id %}id="{{ anchor_id }}"{% endif %}>
   <div class="fl-section-container">
     {% if contents.heading %}
       {{ contents.heading }}

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -422,6 +422,12 @@ def test_intro_block(index_page, placeholder_images, rf):
     for index, intro in enumerate(intros):
         intro_element = intro_divs[index]
 
+        # Settings
+        settings = intro["value"]["settings"]
+        anchor_id = settings.get("anchor_id")
+        if anchor_id:
+            assert intro_element.get("id") == anchor_id
+
         # Heading
         heading_block = intro["value"]["heading"]
         assert_section_heading_attributes(section_element=intro_element, heading_data=heading_block, index=index)
@@ -517,6 +523,12 @@ def test_media_content_block(index_page, placeholder_images, rf):
 
     section_element = soup.find("section", class_="fl-section")
     assert section_element
+
+    # Settings
+    settings = section["value"]["settings"]
+    anchor_id = settings.get("anchor_id")
+    if anchor_id:
+        assert section_element.get("id") == anchor_id
 
     # Heading
     heading_data = section["value"]["heading"]
@@ -1044,8 +1056,6 @@ def test_banner_block(index_page, placeholder_images, rf):
     banner_divs = soup.find_all("div", class_="fl-banner")
     assert len(banner_divs) == len(banners)
 
-    image, dark_image, mobile_image, dark_mobile_image = placeholder_images
-
     for index, banner in enumerate(banners):
         banner_element = banner_divs[index]
 
@@ -1053,6 +1063,9 @@ def test_banner_block(index_page, placeholder_images, rf):
         assert f"fl-banner-{settings['theme']}" in banner_element["class"]
         if settings.get("media_after"):
             assert "fl-banner-reverse" in banner_element["class"]
+        anchor_id = settings.get("anchor_id")
+        if anchor_id:
+            assert banner_element.parent.get("id") == anchor_id
 
         # Heading
         heading_block = banner["value"]["heading"]
@@ -1119,6 +1132,9 @@ def test_kit_banner_block(index_page, rf):
         theme = settings["theme"].replace("filled-", "").replace("filled", "")
         if theme:
             assert f"fl-banner-kit-{theme}" in banner_element["class"]
+        anchor_id = settings.get("anchor_id")
+        if anchor_id:
+            assert banner_element.parent.get("id") == anchor_id
 
         # Heading
         heading_block = banner["value"]["heading"]
@@ -1442,6 +1458,12 @@ def test_home_kit_banner_block(index_page, rf):
     banner_element = soup.find("div", class_="fl-banner-kit")
     assert banner_element
     assert "fl-banner-kit-diving-in" in banner_element["class"]
+
+    # Settings
+    settings = kit_banner["value"]["settings"]
+    anchor_id = settings.get("anchor_id")
+    if anchor_id:
+        assert banner_element.parent.get("id") == anchor_id
 
     assert_section_heading_attributes(
         section_element=banner_element,


### PR DESCRIPTION
## One-line summary

Add the option to set an anchor ID to section-level blocks.

## Significant changes and points to review

Add the anchor ID to the settings options for:
- Section
- Banner
- Kit Banner
- Intro
- Home Kit Banner

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-642

## Testing

- Run `./manage.py load_page_fixtures`
- Check each of the blocks on the test pages for the ids