### PR TITLE
/all fixes (fixes #946, #959)

### DIFF
--- a/media/js/firefox/all/all-init.es6.js
+++ b/media/js/firefox/all/all-init.es6.js
@@ -79,9 +79,11 @@ import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
 
         // init stub attribution & event tracking for GA4
         if (downloadButtons && downloadButtons.length > 0) {
-            // We cannot rely on DOM ready as this section is partially fetched
-            // This flow is scheduled for refactoring: https://github.com/mozmeao/springfield/issues/258
-            StubAttributionConsent.init();
+            if (StubAttributionConsent) {
+                // We cannot rely on DOM ready as this section is partially fetched
+                // This flow is scheduled for refactoring: https://github.com/mozmeao/springfield/issues/258
+                StubAttributionConsent.init();
+            }
 
             for (let i = 0; i < downloadButtons.length; ++i) {
                 const downloadButton = downloadButtons[i];


### PR DESCRIPTION
## One-line summary

Fixes to scroll focus and partial HTML stub attribution

## Significant changes and points to review

[This flow is scheduled for a refactor](https://github.com/mozmeao/springfield/issues/258), so the goal is to fix the issues and make clear what cases we are covering

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/946
https://github.com/mozmeao/springfield/issues/959

## Testing

Demo: https://www-demo3.springfield.moz.works/en-US/download/all/

For scroll focus
Go to http://localhost:8000/en-US/download/all/desktop-beta/win64/
Scroll down on the language options and select language.
This will leave you on the footer in prod. PR should move up to download section. 
- NOTE: it seems the lesser of two evils to keep the scroll even if it does cause some slight jumping on the earlier selections. It was not too obnoxious to me, but could use more opinions: https://github.com/mozmeao/springfield/pull/774/changes#r2756640243

For partial HTML stub attribution 
Ensure you are on [a browser that allows cookies](https://github.com/mozmeao/springfield/pull/774/changes#r2756640243) (stub attribution requires cookies)
Start on http://localhost:8000/en-US/download/all and go through the desktop flow to download links. You should see stub attribution params on the download link in the last step (or in dev tools > storage/application > cookies)