### PR TITLE
Hotfix build by remapping references to missing icons following shuffle

### DIFF
--- a/media/css/cms/flare-fallback-nav.css
+++ b/media/css/cms/flare-fallback-nav.css
@@ -149,7 +149,7 @@
     line-height: 0;
     width: 32px;
     height: 32px;
-    background-image: url('/media/img/firefox/flare/icons/close.svg');
+    background-image: url('/media/img/firefox/flare/2026/icons/desktop-16/close-cancel-dismiss/close-16.svg');
     background-repeat: no-repeat;
     background-position: center;
     background-size: 16px auto;

--- a/media/css/cms/flare26-fallback-nav.css
+++ b/media/css/cms/flare26-fallback-nav.css
@@ -144,7 +144,7 @@
 }
 
 .fl-show-mobile-menu .fl-show-mobile-menu-content.is-open {
-    background-image: url('/media/img/firefox/flare/icons/close.svg');
+    background-image: url('/media/img/firefox/flare/2026/icons/desktop-16/close-cancel-dismiss/close-16.svg');
     background-position: center;
     background-repeat: no-repeat;
     background-size: 16px auto;


### PR DESCRIPTION
Merging this myself but cc @kkellydesign to sense-check it after the event - i feel like i'm using a `desktop` icon for the mobile nav, which is probably not what y'all would prefer