### PR TITLE
Add id and tr Smartling locales mapping

### DIFF
--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1373,11 +1373,13 @@ WAGTAIL_LOCALIZE_SMARTLING = {
     "LOCALE_TO_SMARTLING_LOCALE": {
         "de": "de-DE",
         "fr": "fr-FR",
+        "id": "id-ID",
         "it": "it-IT",
         "ja": "ja-JP",
         "nl": "nl-NL",
         "pl": "pl-PL",
         "ru": "ru-RU",
+        "tr": "tr-TR",
     },
     "JOB_NAME_PREFIX": config(
         "WAGTAIL_LOCALIZE_JOB_NAME_PREFIX",


### PR DESCRIPTION
Add mappings for Indonesian ('id' -> 'id-ID') and Turkish ('tr' -> 'tr-TR') to WAGTAIL_LOCALIZE_SMARTLING['LOCALE_TO_SMARTLING_LOCALE'] to enable Smartling translations for these locales.
