### PR TITLE
Add back meta description to download/all

### DIFF
--- a/springfield/firefox/templates/firefox/all/base.html
+++ b/springfield/firefox/templates/firefox/all/base.html
@@ -10,6 +10,10 @@
   {{ ftl('firefox-all-download-the-firefox-v2') }}
 {%- endblock -%}
 
+{%- block page_desc -%}
+  {{ ftl('firefox-all-everyone-deserves-access-v2') }}
+{%- endblock -%}
+
 {% block page_css %}
  {{ css_bundle('firefox_all') }}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

This was left behind between various reviews as this got ported.

> <img width="1238" height="86" alt="empty" src="https://github.com/user-attachments/assets/bed3a936-9dfb-46fe-9f0e-30dfb711201e" />

## Significant changes and points to review

This string comes from page content, so is still available:

> <img width="1512" height="124" alt="original" src="https://github.com/user-attachments/assets/2d9c84a6-b057-4dfa-8b3a-eb49d3b5747f" />

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/pull/774#pullrequestreview-3770578051

## Testing

http://localhost:8000/en-US/download/all/