### PR TITLE
Add direct download template switching to ThanksPage

### DIFF
--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -299,6 +299,12 @@ class ThanksPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
     def get_utm_campaign(self):
         return "firefox-download-thanks"
 
+    def get_template(self, request, *args, **kwargs):
+        if request.GET.get("s") == "direct":
+            return "cms/thanks_page__direct.html"
+
+        return "cms/thanks_page.html"
+
 
 class ArticleIndexPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
     subpage_types = ["cms.ArticleDetailPage", "cms.ArticleThemePage"]

--- a/springfield/cms/templates/cms/thanks_page__direct.html
+++ b/springfield/cms/templates/cms/thanks_page__direct.html
@@ -1,0 +1,11 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "cms/thanks_page.html" %}
+
+{% block js %}
+  {{ js_bundle('firefox_download_thanks_direct') }}
+{% endblock %}

--- a/springfield/cms/tests/test_models.py
+++ b/springfield/cms/tests/test_models.py
@@ -17,6 +17,7 @@ from springfield.cms.models import (
     SimpleRichTextPage,
     StructuralPage,
     Tag,
+    ThanksPage,
 )
 from springfield.cms.tests.factories import (
     ArticleDetailPageFactory,
@@ -523,3 +524,26 @@ def test_springfield_locale_get_active_falls_back_to_default():
         # Should fall back to en-US
         assert active_locale.id == default_locale.id
         assert active_locale.language_code == "en-US"
+
+
+def test_thanks_page_get_template_default(rf):
+    page = ThanksPage()
+    request = rf.get("/thanks/")
+    assert page.get_template(request) == "cms/thanks_page.html"
+
+
+def test_thanks_page_get_template_direct(rf):
+    page = ThanksPage()
+    request = rf.get("/thanks/?s=direct")
+    assert page.get_template(request) == "cms/thanks_page__direct.html"
+
+
+@pytest.mark.parametrize(
+    "s_value",
+    ["other", "", "DIRECT"],
+    ids=["other", "empty", "uppercase"],
+)
+def test_thanks_page_get_template_ignores_other_s_values(rf, s_value):
+    page = ThanksPage()
+    request = rf.get(f"/thanks/?s={s_value}")
+    assert page.get_template(request) == "cms/thanks_page.html"


### PR DESCRIPTION
Switch the JS bundle on ThanksPage based on a ?s=direct query parameter, which selects an alternative template that loads a JS bundle -- firefox_download_thanks_direct -- for stub attribution instead of the standard firefox_download_thanks bundle.

This behaviour mirrors how the current non-CMS thanks.html and thanks_direct.html pages work.

## Testing

Strap together a ThanksPage and view/preview it to test:

 - Verify the regular page loads the standard JS bundle (firefox_download_thanks)
 - Verify the path with `?s=direct` loads the direct download JS bundle (firefox_download_thanks_direct)
 - Verify other `s` param values (e.g. ?s=other, ?s=DIRECT, ?s=) still load the standard bundle

