### PR TITLE
max width revisions, URL override added.

### DIFF
--- a/media/css/cms/flare26-card.css
+++ b/media/css/cms/flare26-card.css
@@ -74,12 +74,17 @@ Card Grid - Flare 2026 Design System Cards
         --fl-card-grid-columns: repeat(4, minmax(0, 1fr));
     }
 
-    /* ...unless there are only three, and then it gets a special treatment. */
-    .fl-card-grid:has(.fl-illustration-card-default:nth-child(3):last-child) {
+    /* ...unless there are only three, and then it gets a special treatment.
+       There are two selectors, one with and one without .conditional-passthrough
+       or .image-variants. */
+    .fl-card-grid:has(.fl-illustration-card-default:nth-child(3):last-child),
+    .fl-card-grid:has(
+        > *:nth-child(3):last-child .fl-illustration-card-default
+    ) {
         --fl-card-grid-columns: repeat(3, minmax(0, 1fr));
         inline-size: 100%;
         margin-inline: auto;
-        max-inline-size: 980px;
+        max-inline-size: var(--token-width-desktop-content-lg);
     }
 }
 

--- a/media/css/cms/flare26-intro.css
+++ b/media/css/cms/flare26-intro.css
@@ -32,6 +32,8 @@
     align-items: center;
     display: flex;
     justify-content: center;
+    margin: 0 auto;
+    max-inline-size: var(--token-width-desktop-content-lg);
 }
 
 .fl-intro-content .fl-buttons {

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1258,6 +1258,11 @@ class ArticleOverridesBlock(blocks.StructBlock):
         required=False,
         help_text="Optional custom link label to override the article's original call to action text.",
     )
+    link = LinkBlock(
+        required=False,
+        verbose_name="Link override",
+        help_text="Optional custom link to override the article's original call to action link. Note: This field is meant to be temporary.",
+    )
 
     class Meta:
         icon = "cog"
@@ -1342,6 +1347,15 @@ class ArticleValue(blocks.StructValue):
             if hasattr(article_page, "icon") and article_page.icon:
                 return article_page.icon
         return "globe"
+
+    def get_link_url(self) -> str:
+        overrides = self.get("overrides", {})
+        if link := overrides.get("link"):
+            url = link.get_url()
+            if url:
+                return url
+        article_page = self.get("article")
+        return article_page.url if article_page else ""
 
 
 class ArticleBlock(blocks.StructBlock):

--- a/springfield/cms/templates/cms/blocks/article-cards-list.html
+++ b/springfield/cms/templates/cms/blocks/article-cards-list.html
@@ -10,7 +10,7 @@
         title={{ card.get_title() }}
         description={{ card.get_description()|safe }}
         link_text={{ card.get_link_label() }}
-        url={{ card.article.url }}
+        url={{ card.get_link_url() }}
       >
         {% set img = card.get_sticker() %}
         <content:icon>
@@ -47,7 +47,7 @@
             {{ card.get_description()|safe }}
           </content:body>
           <content:buttons>
-            <a href="{{ card.article.url }}">
+            <a href="{{ card.get_link_url() }}">
               {{ card.get_link_label() }}
             </a>
           </content:buttons>
@@ -76,7 +76,7 @@
             {{ card.get_description()|safe }}
           </content:body>
           <content:buttons>
-            <a href="{{ card.article.url }}">
+            <a href="{{ card.get_link_url() }}">
               {{ card.get_link_label() }}
             </a>
           </content:buttons>
@@ -118,7 +118,7 @@
             {{ card.get_description()|safe }}
           </content:body>
           <content:buttons>
-            <a href="{{ card.article.url }}">
+            <a href="{{ card.get_link_url() }}">
               {{ card.get_link_label() }}
             </a>
           </content:buttons>


### PR DESCRIPTION
## One-line summary
UI/FE revisions to theme pages

## Significant changes and points to review
* I opted for the path of least resistance for what will ultimately be a little-used, hopefully temporary feature. The "overrides" section of the "article card" in "article card list" now has a URL field. If this is selected, it will override the link of the article. This is imperfect, because I didn't _also_ make the article field unrequired, or create a new card type that isn't tied to the article at all. That means you have to select an article that isn't actually used _at all_, assuming you fill out all of the overrides. The biggest reason I went with this route is LOE, as adding an additional card type would have required a data migration to work that has already been done. It's just a bit riskier than necessary at the 11th hour, for an edge-case. 

We can remove this change at a later date, but this will help us wrap up these pages in time for launch. 

Additionally, this PR includes some CSS revisions. The max width CSS for three-card layouts already existed, but didn't account for wrapper classes such as `.image-variants` and `.conditional-display`, both of which are possibilities for these cards. I added a CSS selector to account for that, and left a comment as to why, because the selector is a bit gnarly. 

I also added a max-width to the intro image. This was a global change, but it's really what the component was designed for, so I'm pretty confident there won't be any ill effects. 

<img width="1109" height="728" alt="Screenshot 2026-02-17 at 8 26 45 PM" src="https://github.com/user-attachments/assets/3643af97-d75d-41d4-b2f8-52a67ba4a061" />

<img width="964" height="468" alt="Screenshot 2026-02-17 at 8 25 39 PM" src="https://github.com/user-attachments/assets/66a95d43-1330-4618-8030-9576811d6dfe" />

<img width="1153" height="812" alt="Screenshot 2026-02-17 at 8 25 31 PM" src="https://github.com/user-attachments/assets/c313466d-b626-463e-9396-4d493757b98b" />

