### PR TITLE
Add playwright test selector to Flare26 newsletter

### DIFF
--- a/springfield/cms/templates/cms/newsletter_form_2026.html
+++ b/springfield/cms/templates/cms/newsletter_form_2026.html
@@ -84,7 +84,6 @@
     </div>
     <button
      id="newsletter-submit"
-     data-testid="newsletter-submit-button"
      class="fl-button"
      type="submit"
      disabled

--- a/tests/playwright/specs/newsletter/newsletter-embed.spec.js
+++ b/tests/playwright/specs/newsletter/newsletter-embed.spec.js
@@ -9,7 +9,7 @@
 const { test, expect } = require('@playwright/test');
 const openPage = require('../../scripts/open-page');
 const url = '/en-US/';
-const slugs = ['channel/desktop', 'channel/desktop/developer', 'newsletter'];
+const slugs = ['channel/desktop/developer', 'newsletter'];
 
 slugs.forEach((slug) => {
     test.describe(


### PR DESCRIPTION
This is using the same email_newsletter_form helper as our Protocol forms, but pointing to different HTML template.

Newsletter tests are looking for a submit button based on a test ID: https://github.com/mozmeao/springfield/blob/01f80580b2008a68cd17e7668ea83f9e5bc92e96/springfield/newsletter/templates/newsletter/includes/form.html#L106

The failure can be recreated on `main` branch by [running playwright tests locally](https://mozmeao.github.io/platform-docs/testing/playwright/?h=playw#installing-playwright):
`npx playwright test --grep @newsletter`
```
  6 failed
    [chromium] › specs/newsletter/newsletter-embed.spec.js:25:13 › /en-US/channel/desktop page › Newsletter submit success /channel/desktop/ @newsletter 
    [chromium] › specs/newsletter/newsletter-embed.spec.js:53:13 › /en-US/channel/desktop page › Newsletter submit failure /channel/desktop/ @newsletter 
    [firefox] › specs/newsletter/newsletter-embed.spec.js:25:13 › /en-US/channel/desktop page › Newsletter submit success /channel/desktop/ @newsletter 
    [firefox] › specs/newsletter/newsletter-embed.spec.js:53:13 › /en-US/channel/desktop page › Newsletter submit failure /channel/desktop/ @newsletter 
    [webkit] › specs/newsletter/newsletter-embed.spec.js:25:13 › /en-US/channel/desktop page › Newsletter submit success /channel/desktop/ @newsletter 
    [webkit] › specs/newsletter/newsletter-embed.spec.js:53:13 › /en-US/channel/desktop page › Newsletter submit failure /channel/desktop/ @newsletter 
  21 passed (1.1m)
```

With addition of expected locator, the tests still fail because of new Flare26 behaviour keeping submit button disabled until required fields are filled
```
- waiting for getByTestId('newsletter-submit-button')
        - locator resolved to <button disabled type="submit" class="fl-button" id="newsletter-submit" data-testid="newsletter-submit-button">Sign up</button>
      - attempting click action
        2 × waiting for element to be visible, enabled and stable
          - element is not enabled
```

## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
Passing locally
```
Running 21 tests using 4 workers
  21 passed (14.2s)
```

[running playwright tests locally](https://mozmeao.github.io/platform-docs/testing/playwright/?h=playw#installing-playwright):
`npx playwright test --grep @newsletter`