### PR TITLE
Register zh-CN in LANG_INFO to fix Smartling translation sync

### DIFF
--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -11,7 +11,7 @@ from os.path import abspath
 from pathlib import Path
 from urllib.parse import urlparse
 
-from django.conf.locale import LANG_INFO  # we patch this in springfield.base.apps.BaseAppConfig  # noqa: F401
+from django.conf.locale import LANG_INFO
 from django.utils.functional import lazy
 
 import dj_database_url
@@ -152,6 +152,9 @@ TEST_RUNNER = "django.test.runner.DiscoverRunner"
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = "en-US"
+
+# Add a fallback for zh-CN, which doesn't exist in core Django
+LANG_INFO["zh-CN"] = {"fallback": ["zh-hans"]}
 
 # Languages using BiDi (right-to-left) layout. Overrides/extends Django default.
 LANGUAGES_BIDI = ["ar", "ar-dz", "fa", "he", "skr", "ur"]


### PR DESCRIPTION
When `wagtail-localize-smartling` syncs completed `zh-CN` translations, Django's `get_language_info("zh-CN")` raises a `KeyError` because `LANG_INFO` uses lowercase keys `("zh-cn")` and the generic fallback `"zh"` has no entry either (only `"zh-hans"`/`"zh-hant"` exist). 

Other mixed-case locales like `es-ES` and `pt-BR` don't hit this because their base codes (es, pt) exist.

Adding a fallback entry for `"zh-CN"` pointing to `"zh-hans"` resolves the lookup. 

Fixes https://mozilla.sentry.io/issues/7274219985/events/0e87c5ae4b6a455497a9641efd284773
