### PR TITLE
Add flare26 version of the newsletter page

### DIFF
--- a/media/css/cms/flare26-newsletterform.css
+++ b/media/css/cms/flare26-newsletterform.css
@@ -321,3 +321,7 @@
     display: block;
     margin: 0 auto;
 }
+
+.newsletter-page .fl-newsletterform-cta {
+    padding-block-start: var(--token-layout-xl);
+}

--- a/springfield/cms/templates/cms/base-flare26.html
+++ b/springfield/cms/templates/cms/base-flare26.html
@@ -97,7 +97,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         {% set analytics_position = "pre-footer-cta-form" %}
         {% set analytics_id = pre_footer_cta_form.analytics_id %}
           <include:conditional-display condition="is-firefox">
-            <include:newsletter-form>
+            <include:newsletter-form theme="dark">
               <include:heading
                 level="h2"
                 heading_text="{{ pre_footer_cta_form.heading|richtext|remove_p_tag }}"

--- a/springfield/cms/templates/cms/download_page.html
+++ b/springfield/cms/templates/cms/download_page.html
@@ -111,7 +111,7 @@
     {% set analytics_text = pre_footer_cta_form.heading|richtext|remove_tags %}
     {% set analytics_position = "pre-footer-cta-form" %}
     {% set analytics_id = pre_footer_cta_form.analytics_id %}
-    <include:newsletter-form>
+    <include:newsletter-form theme="dark">
       <include:heading
         level="h2"
         heading_text="{{ pre_footer_cta_form.heading|richtext|remove_p_tag }}"

--- a/springfield/cms/templates/cms/snippets/pre-footer-cta-form-snippet-preview.html
+++ b/springfield/cms/templates/cms/snippets/pre-footer-cta-form-snippet-preview.html
@@ -8,7 +8,7 @@
 
 
 {% block pre_footer %}
-  <include:newsletter-form>
+  <include:newsletter-form theme="dark">
     <include:heading
       level="h2"
       heading_text="{{ object.heading|richtext|remove_p_tag }}"

--- a/springfield/cms/templates/cms/snippets/pre-footer-cta-form-snippet.html
+++ b/springfield/cms/templates/cms/snippets/pre-footer-cta-form-snippet.html
@@ -8,7 +8,7 @@
 {% set analytics_text = value.heading|richtext|remove_tags %}
 {% set analytics_position = "pre-footer-cta-form" %}
 {% set analytics_id = value.analytics_id %}
-<include:newsletter-form>
+<include:newsletter-form theme="dark">
   <include:heading
     level="h2"
     heading_text="{{ value.heading|richtext|remove_p_tag }}"

--- a/springfield/cms/templates/cms/thanks_page.html
+++ b/springfield/cms/templates/cms/thanks_page.html
@@ -57,7 +57,7 @@
     {% set analytics_text = pre_footer_cta_form.heading|richtext|remove_tags %}
     {% set analytics_position = "pre-footer-cta-form" %}
     {% set analytics_id = pre_footer_cta_form.analytics_id %}
-    <include:newsletter-form>
+    <include:newsletter-form theme="dark">
       <include:heading
         level="h2"
         heading_text="{{ pre_footer_cta_form.heading|richtext|remove_p_tag }}"

--- a/springfield/cms/templates/components/newsletter-form.html
+++ b/springfield/cms/templates/components/newsletter-form.html
@@ -5,7 +5,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<div class="fl-newsletterform-cta fl-force-dark-theme" data-state="default">
+<div class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
   <div class="fl-newsletterform-illustration" aria-hidden="true">
     <img alt="" loading="lazy" src="/media/img/firefox/flare/kit-on-rock.png" />
   </div>

--- a/springfield/cms/templates/pattern-library/components/pre-footer/newsletterform-cta.html
+++ b/springfield/cms/templates/pattern-library/components/pre-footer/newsletterform-cta.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<include:newsletter-form>
+<include:newsletter-form theme="dark">
   <include:heading
     level="h2"
     heading_text="Keep up with all things Firefox"

--- a/springfield/firefox/templates/firefox/channel/base-flare26.html
+++ b/springfield/firefox/templates/firefox/channel/base-flare26.html
@@ -91,7 +91,7 @@
 
 <div class="fl-section fl-force-dark-theme">
     <div class="fl-section-container">
-      <include:newsletter-form>
+      <include:newsletter-form theme="dark">
         <include:heading
           level="h2"
           heading_text="{{ ftl('newsletter-form-firefox-and-you') }}"

--- a/springfield/newsletter/templates/newsletter/index.html
+++ b/springfield/newsletter/templates/newsletter/index.html
@@ -59,6 +59,7 @@
 
 {% block content %}
 {% if switch('flare26_enabled') %}
+<main class="fl-main has-gradient-bottom newsletter-page">
   <include:newsletter-form>
     <include:heading
       level="h2"
@@ -66,6 +67,7 @@
       subheading_text="Get how-tos, advice and news to make your Firefox experience work best for you."
     />
   </include:newsletter-form>
+</main>
 {% else %}
   <main>
     <div class="section-intro">

--- a/springfield/newsletter/templatetags/helpers.py
+++ b/springfield/newsletter/templatetags/helpers.py
@@ -81,6 +81,7 @@ def email_newsletter_form(
             email_placeholder=email_placeholder,
             is_multi_newsletter_form=is_multi_newsletter,
             action=action,
+            fluent_l10n=ctx.get("fluent_l10n"),
         )
     )
 


### PR DESCRIPTION
There was no design for this, so I just used the newsletter form component we're using everywhere else.

![Screenshot 2026-02-18 at 14 51 31](https://github.com/user-attachments/assets/c0fb8713-cd64-4596-b33f-eee1c4556ccc)
