### PR TITLE
Keep original light theme divider color in global styles

### DIFF
--- a/media/css/cms/flare26-theme.css
+++ b/media/css/cms/flare26-theme.css
@@ -83,7 +83,7 @@ Contextual CSS custom properties that change based on context (e.g. layout direc
     --fl-theme-shadow-card: 0 32px 72px var(--token-color-black-4-16);
 
     /* Divider */
-    --fl-theme-divider-color: var(--token-color-light-purple);
+    --fl-theme-divider-color: var(--token-color-soft-purple);
     --fl-subtle-border-color: var(--token-color-grey-2);
     --fl-theme-divider: 1px solid var(--fl-theme-divider-color);
 
@@ -243,7 +243,7 @@ Contextual CSS custom properties that change based on context (e.g. layout direc
     --token-color-error-text-color: var(--token-color-secondary-red);
 
     /* Divider color */
-    --fl-theme-divider-color: var(--token-color-light-purple);
+    --fl-theme-divider-color: var(--token-color-soft-purple);
     --fl-subtle-border-color: var(--token-color-grey-2);
     --fl-theme-divider: 1px solid var(--fl-theme-divider-color);
 


### PR DESCRIPTION
## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
no regression on grey dividers for cookie styles light theme: http://localhost:8000/en-US/privacy/websites/cookie-settings/
restores light theme on dividers for /all: http://localhost:8000/en-US/download/all/