### PR TITLE
Add parallel PR CI including collectstatic check

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,3 +52,13 @@ jobs:
           files: python_coverage/coverage.xml
           fail_ci_if_error: false  # optional (default = false)
           verbose: true  # optional (default = false)
+
+  test-python-more:  # This is a preview `test-ci` to replace the previous `test-image` over time
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}  # Only run the extra release checks on PRs for now
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Run Python tests (on Docker) with extra release service build"
+        run: |
+            make clean test-ci
+        timeout-minutes: 60


### PR DESCRIPTION
## One-line summary

To evaluate a more comprehensive CI _make_ target I figured adding that in parallel to the current pipeline could help assess if the extra 40–60sec spent on it is worth it.

## Significant changes and points to review

This will now run both `make test-image` and `make test-ci` side by side. It's a waste of CPU cycles, but is actually great to see the difference over the span of a week or two to see the range of durations this tends to have (between 6–8mins usually), when triggered on the same event at the same time.

(The difference between the two make targets is covered in the linked tickets. TL;DR is: the added strict _collectstatic_ check is implicitly achieved by running a target including `release` service in its build.)

The idea is to move the original `make test-image` job to use `make test-ci` eventually if this proves useful.

(NB: For preview purposes, this duplicate pipeline is only run on PRs, not again on main, as it's just waste of cycles at this point, the same will be done in CD pipeline.)

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16495
https://github.com/mozilla/bedrock/issues/16918

## Testing

> <img width="1470" height="1080" alt="CI" src="https://github.com/user-attachments/assets/14df460c-0236-4b07-b9cf-2319a2f2a617" />

This actual PR already shows the modified CI run:
[/actions/runs/22188873820](https://github.com/mozmeao/springfield/actions/runs/22188873820) ✅✅✅

> <img width="942" height="232" alt="checks" src="https://github.com/user-attachments/assets/84a5c2a4-6378-48d6-902f-ee7a2d5f3b43" />

(NB: These start at the same time, so the result doesn't come 8mins later, but just less than a minute later — it only adds 40–60s to the overall CI span running in parallel, not its whole run time.)

Example of missing asset caught:
[`@janbrasna/springfield`/actions/runs/22175415059](https://github.com/janbrasna/springfield/actions/runs/22175415059/job/64122745301#step:3:7714) ❌ 

> <img width="1055" height="723" alt="fail" src="https://github.com/user-attachments/assets/d8b5cf47-21e4-47b0-9faa-818f98dee4da" />