### PR TITLE
add missing button ID for testing on enterprise page

### DIFF
--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -48,6 +48,7 @@
     </content:heading>
     <content:actions>
       <include:button
+        id="primary-download-button"
         label="{{ ftl('download-button-download') }}"
         link="#download"
         theme_class=""


### PR DESCRIPTION
## One-line summary

This PR adds back the missing button ID for testing on enterprise page

## Significant changes and points to review

Integration tests should pass now.

## Issue / Bugzilla link



## Testing


`cd tests/playwright && npm run integration-tests`