### PR TITLE
fix footer Lang selector styles - WT-716

### DIFF
--- a/media/css/cms/flare26-footer.css
+++ b/media/css/cms/flare26-footer.css
@@ -66,7 +66,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @media (--viewport-below-lg) {
     .fl-footer-section-lang-select {
-        max-width: fit-content;
+        max-inline-size: fit-content;
     }
 
     .fl-footer-sections-list-mobile {


### PR DESCRIPTION
## One-line summary

This PR fixes footer Lang styles for non-extra large screen size.

## Significant changes and points to review

Footer Lang selector width on various screen sizes.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-716

## Testing

http://localhost:8000/en-US/browsers/mobile/