### PR TITLE
Minor Blocks Improvements

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1663,6 +1663,7 @@ def IntroBlock2026(allow_uitour=False, *args, **kwargs):
         heading = HeadingBlock()
         buttons = MixedButtonsBlock(
             button_types=get_button_types(allow_uitour),
+            themes=BUTTON_THEMES_2026,
             min_num=0,
             max_num=2,
             required=False,


### PR DESCRIPTION
## One-line summary
Make small fixes to the Wagtail user experience.

## Significant changes and points to review
This pull request makes the following fixes:
 - `UITOUR_BUTTON_CHOICES` was defined twice; we remove the first (the unused one) definition
 - makes the `DownloadFirefoxButtonSettings` label visible; previously a comma was preventing it from being visible
 - removes unused `MediaContentBlock.clean()` and `BannerBlock.clean()` methods. They each have a maximum of 1 media, so checking that video media and qr code media are being used together is not meaningful.
 - makes sure that block label_format only uses fields that actually exist
 - adds `themes=BUTTON_THEMES_2026` to the `IntroBlock2026`


## Issue / Bugzilla link



## Testing
Make sure that the relevant blocks work as expected.
The only end-user-facing changes would be the button themes in the intro block, like on the article theme page. These buttons should have the same themes as other 2026 buttons on the site.