### PR TITLE
Update sticker size for card

### DIFF
--- a/media/css/cms/flare26-card.css
+++ b/media/css/cms/flare26-card.css
@@ -18,7 +18,7 @@ Card Grid - Flare 2026 Design System Cards
 
 .fl-card-grid {
     --fl-card-grid-gap: var(--token-spacing-3xl) var(--token-spacing-lg);
-    --fl-card-sticker-size: 60px;
+    --fl-card-sticker-size: 120px;
     display: grid;
     gap: var(--fl-card-grid-gap);
     grid-template-columns: var(--fl-card-grid-columns, minmax(0, 1fr));


### PR DESCRIPTION
Images on cards with stickers were too small. This corrects the image size.

Before:
<img width="1561" height="1126" alt="image" src="https://github.com/user-attachments/assets/e94c3806-c583-4d94-9f68-7a59b014e471" />

After:
<img width="1524" height="977" alt="image" src="https://github.com/user-attachments/assets/79d19504-c046-4d9e-bca2-06e0049eda96" />

