### PR TITLE
Use switch on cookie settings header

### DIFF
--- a/springfield/privacy/templates/privacy/cookie-settings.html
+++ b/springfield/privacy/templates/privacy/cookie-settings.html
@@ -20,7 +20,11 @@
 
 {% block site_header %}
   {% with hide_nav_cta=True %}
+      {% if switch('flare26_enabled') %}
       <include:flare26-header />
+      {% else %}
+        {% include 'includes/navigation/navigation.html' %}
+      {% endif %}
   {% endwith %}
 {% endblock %}
 


### PR DESCRIPTION
## One-line summary

we lost a conditional somewhere along the road (looks like here: https://github.com/mozmeao/springfield/pull/1019/changes#diff-074e0e655855f95056464db022a6800f9cbb6951bbaad34ec27d5a22286d17e1)

broken in prod: https://www.firefox.com/en-US/privacy/websites/cookie-settings/

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
http://localhost:8000/en-US/privacy/websites/cookie-settings/

current styles fine (and dropdown functionality fine)
<img width="1737" height="595" alt="Screenshot 2026-02-24 at 11 41 20 AM" src="https://github.com/user-attachments/assets/7af03556-0fca-4be0-995f-ba344441fb2b" />
<img width="1588" height="514" alt="Screenshot 2026-02-24 at 11 43 18 AM" src="https://github.com/user-attachments/assets/935ff384-8ad2-4e22-afcb-4ffd6b0555a2" />


Flare26 styles fine
<img width="1637" height="284" alt="Screenshot 2026-02-24 at 11 42 23 AM" src="https://github.com/user-attachments/assets/f6478257-4f5f-4fa5-9c83-c3a6674e906f" />

