### PR TITLE
Move flare26 logo behind switch

### DIFF
--- a/springfield/firefox/templates/firefox/releases/notes.html
+++ b/springfield/firefox/templates/firefox/releases/notes.html
@@ -111,36 +111,38 @@
 
             {% block notes_header %}
               <header class="notes-head">
-                <div class="fl-c-release-notes-logo">
-                  {% if brand_product == 'firefox' %}
+                {% if switch('flare26_enabled') %}
+                  <div class="fl-c-release-notes-logo">
+                    {% if brand_product == 'firefox' %}
+                      {{ resp_img(
+                      url='img/logos/firefox/firefox-logo.svg',
+                      optional_attributes={
+                        "width": 55,
+                        "height": 55,
+                        "loading": "eager"
+                      }
+                    ) }}
+                    {% elif brand_product == 'beta' %}
                     {{ resp_img(
-                    url='img/logos/firefox/firefox-logo.svg',
-                    optional_attributes={
-                      "width": 55,
-                      "height": 55,
-                      "loading": "eager"
-                    }
-                  ) }}
-                  {% elif brand_product == 'beta' %}
-                  {{ resp_img(
-                    url='img/logos/firefox/firefox-logo-beta.svg',
-                    optional_attributes={
-                      "width": 55,
-                      "height": 55,
-                      "loading": "eager"
-                    }
-                  ) }}
-                  {% elif brand_product == 'nightly' %}
-                  {{ resp_img(
-                    url='img/logos/firefox/firefox-logo-nightly.svg',
-                    optional_attributes={
-                      "width": 55,
-                      "height": 55,
-                      "loading": "eager"
-                    }
-                  ) }}
-                  {% endif %}
-                </div>
+                      url='img/logos/firefox/firefox-logo-beta.svg',
+                      optional_attributes={
+                        "width": 55,
+                        "height": 55,
+                        "loading": "eager"
+                      }
+                    ) }}
+                    {% elif brand_product == 'nightly' %}
+                    {{ resp_img(
+                      url='img/logos/firefox/firefox-logo-nightly.svg',
+                      optional_attributes={
+                        "width": 55,
+                        "height": 55,
+                        "loading": "eager"
+                      }
+                    ) }}
+                    {% endif %}
+                  </div>
+                {% endif %}
                 {% if not primary_heading %}
                   {% if product_name == 'Firefox Beta' %}
                       {% set primary_heading = 'Firefox Beta and Developer Edition <br> Release Notes'|safe %}


### PR DESCRIPTION
## One-line summary

We have a Flare26 logo coming through on non-Flare design. This is moved behind switch to only apply for Flare26 design
<img width="1804" height="461" alt="Screenshot 2026-02-24 at 12 35 04 PM" src="https://github.com/user-attachments/assets/b7cf49f0-a7a9-4c90-99ad-4c563d732e4c" />
visible on staging: https://www.springfield.moz.works/en-US/firefox/147.0.4/releasenotes/

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
with FLARE26_ENABLED off
http://localhost:8000/en-US/firefox/148.0/releasenotes/

There should be no extra logo
<img width="1168" height="537" alt="Screenshot 2026-02-24 at 12 39 45 PM" src="https://github.com/user-attachments/assets/2472f94c-e994-4df8-86a2-77519a05590e" />

when FLARE26_ENABLED on
Flare26 still has logo
<img width="1376" height="597" alt="Screenshot 2026-02-24 at 12 38 55 PM" src="https://github.com/user-attachments/assets/905c78ad-d45c-4d19-9844-8ee767330523" />
