### PR TITLE
Isolate heading group selector from the release notes page

### DIFF
--- a/media/css/cms/pages/flare26-release-notes.css
+++ b/media/css/cms/pages/flare26-release-notes.css
@@ -35,7 +35,7 @@
     text-align: center;
 }
 
-.fl-heading-group {
+.fl-release-notes .fl-heading-group {
     margin: 0 auto var(--token-layout-xs);
     max-inline-size: 60%;
 }


### PR DESCRIPTION
This PR fixes a heading group margin issue. It was triggered by a loose .fl-heading-group selector.

Before:
![Screenshot 2026-02-24 at 13 08 23](https://github.com/user-attachments/assets/1a3a25be-e577-4247-9fe5-6e919b46c8bb)

After:
![Screenshot 2026-02-24 at 13 07 56](https://github.com/user-attachments/assets/37815afb-1a26-4f3b-9cd0-176776dd24b9)
