### PR TITLE
Use fallback/static pages for firefox-features CTA spec test

### DIFF
--- a/tests/playwright/specs/products/firefox/firefox-features.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-features.spec.js
@@ -8,7 +8,7 @@
 
 const { test, expect } = require('@playwright/test');
 const openPage = require('../../../scripts/open-page');
-const url = '/en-US/features/';
+const url = '/sv-SE/features/';
 const slugs = [
     'adblocker',
     'add-ons',


### PR DESCRIPTION
## One-line summary

Pointing to /sv-SE/features for more stable results for now.

## Significant changes and points to review

TODO/FIXME. Might need the CMS snippet updated, tracked below:

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-781

## Testing

Shouldn't impact dev/stage, should fix prod.