### PR TITLE
WT-773 update enterprise page intro and banner spacing 

### DIFF
--- a/media/css/cms/pages/flare26-enterprise.css
+++ b/media/css/cms/pages/flare26-enterprise.css
@@ -21,8 +21,14 @@ main.fl-2026-enterprise {
     justify-content: center;
 }
 
+.fl-2026-enterprise .fl-intro.fl-intro-media-right {
+    grid-template-columns: 1fr;
+    text-align: center;
+}
+
 .fl-2026-enterprise .fl-intro-actions {
     margin-inline: auto;
+    text-align: center;
 }
 
 .fl-2026-enterprise .heading-logo {
@@ -32,6 +38,11 @@ main.fl-2026-enterprise {
     margin-inline: auto;
     max-block-size: 60px;
     max-inline-size: 100%;
+}
+
+.fl-2026-enterprise .fl-banner-kit .fl-banner-content .fl-heading,
+.fl-2026-enterprise .fl-banner-kit .fl-banner-content .fl-subheading {
+    max-inline-size: 840px;
 }
 
 .fl-2026-enterprise .fl-card {
@@ -112,13 +123,24 @@ main.fl-2026-enterprise {
 }
 
 @media (--viewport-sm-up) {
+    .fl-2026-enterprise .heading-logo {
+        margin-inline: 0;
+        max-block-size: 80px;
+    }
+
+    .fl-2026-enterprise .fl-intro-actions {
+        text-align: center;
+    }
+}
+
+@media (--viewport-md-up) {
     .fl-2026-enterprise .fl-superheading {
         justify-content: start;
     }
 
-    .fl-2026-enterprise .heading-logo {
-        margin-inline: 0;
-        max-block-size: 80px;
+    .fl-2026-enterprise .fl-intro.fl-intro-media-right {
+        grid-template-columns: 1fr 1fr;
+        text-align: start;
     }
 
     .fl-2026-enterprise .fl-intro-actions {

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -68,13 +68,12 @@
   </div>
 
 
-    <include:kit-banner>
+  <include:kit-banner>
     <content:heading>
       <include:heading
         level="h2"
         heading_text="{{ ftl('firefox-enterprise-support-for-organizations') }}"
         heading_size="fl-heading-size-2"
-        alignment_class=""
         subheading_text="{{ ftl('firefox-enterprise-early-access-is') }}"
         subheading_size="fl-subheading-4"
       />


### PR DESCRIPTION


## One-line summary

This PR updates the enterprise page intro and banner spacing.

## Significant changes and points to review

intro and banners on various screen sizes, especially mobile and tablet.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-773

## Testing

http://localhost:8000/en-US/browsers/enterprise/