### PR TITLE
WT-829 update progressive rollout image style

### DIFF
--- a/media/css/cms/pages/flare26-release-notes.css
+++ b/media/css/cms/pages/flare26-release-notes.css
@@ -367,7 +367,7 @@ video[autoplay] {
         display: flex;
 
         .release-note-progressive-rollout-indicator {
-            margin-inline-start: var(--token-spacing-lg);
+            margin: 0 var(--token-layout-2xs);
             max-inline-size: 210px;
             min-inline-size: 210px;
         }


### PR DESCRIPTION
## One-line summary

This PR fixes the progressive rollout image styles.

## Significant changes and points to review

- check mobile and desktop styles
- check `rtl` styles

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-829

## Testing

https://www.firefox.com/en-US/firefox/147.0/releasenotes/