### PR TITLE
Possible fix - card flickering in Chrome on macOS

### DIFF
--- a/media/css/cms/flare26-card.css
+++ b/media/css/cms/flare26-card.css
@@ -152,6 +152,10 @@ Basic Card
 .fl-card {
     align-items: stretch;
     backdrop-filter: blur(7.5px);
+    /* Prevents flickering in Chrome on macOS when backdrop-filter
+       is recomposited during hover transform transitions. */
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
     background: var(--fl-theme-default-card-bg);
     border: 1px solid var(--card-border-color);
     border-radius: var(--token-border-radius-sm);
@@ -224,6 +228,10 @@ Sticker Card
 .fl-sticker-card {
     align-items: stretch;
     backdrop-filter: blur(7.5px);
+    /* Prevents flickering in Chrome on macOS when backdrop-filter
+       is recomposited during hover transform transitions. */
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
     background: var(--fl-theme-surface-card-gradient);
     block-size: auto;
     border-radius: var(--token-border-radius-md);


### PR DESCRIPTION
Some users on Chrome/macOS reported visual flashing on homepage sticker cards during hover or scroll. Some optimizations have already been applied.

The issue was not reproducible by the team but was confirmed via screen shares.

A potential cause is a Chrome compositing conflict: both .fl-card and .fl-sticker-card use backdrop-filter: blur(7.5px) combined with a transform: translateY(-2px) hover transition. When the transform fires, Chrome must re-sample and re-blur the content behind the card, which can cause a single-frame flash as the GPU layer is invalidated and recomposited.

Adding backface-visibility: hidden hints to the compositor to treat each card as a flat, pre-rendered layer, which should prevent the layer invalidation flash without any visual change.

