### PR TITLE
Restore homepage card backdrop by simplifying its hover

### DIFF
--- a/media/css/cms/flare26-card.css
+++ b/media/css/cms/flare26-card.css
@@ -151,8 +151,7 @@ Basic Card
 
 .fl-card {
     align-items: stretch;
-
-    /* backdrop-filter: blur(7.5px); */
+    backdrop-filter: blur(7.5px);
     background: var(--fl-theme-default-card-bg);
     border: 1px solid var(--card-border-color);
     border-radius: var(--token-border-radius-sm);
@@ -224,8 +223,7 @@ Sticker Card
 
 .fl-sticker-card {
     align-items: stretch;
-
-    /* backdrop-filter: blur(7.5px); */
+    backdrop-filter: blur(7.5px);
     background: var(--fl-theme-surface-card-gradient);
     block-size: auto;
     border-radius: var(--token-border-radius-md);

--- a/media/css/cms/pages/flare26-homepage.css
+++ b/media/css/cms/pages/flare26-homepage.css
@@ -26,6 +26,11 @@
     padding-block-end: 0;
 }
 
+.fl-home-body .fl-split-page-upper .fl-sticker-card:hover {
+    top: -2px;
+    transform: none;
+}
+
 .fl-home-body .fl-banner-container {
     margin-block-start: calc(-1 * var(--fl-section-v-padding));
     max-inline-size: none;


### PR DESCRIPTION
## One-line summary

Simplifying the transform to just single frame position change.

## Significant changes and points to review

The hover on home can eventually be removed completely, as there are no links.

## Issue / Bugzilla link

#1073

## Testing
