### PR TITLE
Hide UI Tour buttons until UITour responds

### DIFF
--- a/media/css/cms/flare26-button.css
+++ b/media/css/cms/flare26-button.css
@@ -241,3 +241,9 @@ I propose we move to "Filled (Primary)", "Outline (Secondary)", and
 .fl-tiny-icon-button:focus {
     color: var(--fl-theme-color-link-hover);
 }
+
+/* UI Tour buttons are hidden by default and revealed via JS
+   after confirming UITour is responding (see ui-tour-buttons.js). */
+.ui-tour {
+    display: none;
+}

--- a/springfield/cms/templates/components/uitour_button.html
+++ b/springfield/cms/templates/components/uitour_button.html
@@ -5,7 +5,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
 
-<div class="ui-tour" style="display: none">
+<div class="ui-tour">
   <button
     class="fl-button {{ theme_class }}"
     type="button"


### PR DESCRIPTION
UI Tour buttons were visible but non-functional when UITour was present but not responding (e.g. permissions revoked by clearing site settings). Buttons are now hidden by default via CSS and only revealed after a successful Mozilla.UITour.ping() response. Fade-in transition respects prefers-reduced-motion.


## Testing
Stephen on the websites team is affected and could test.