### PR TITLE
adding option to open in new window for relative link button

### DIFF
--- a/media/js/cms/wagtailadmin-link-block.js
+++ b/media/js/cms/wagtailadmin-link-block.js
@@ -20,9 +20,13 @@
         if (!parent) return;
         var field = parent.querySelector('.relative_url_link_field');
         if (!field) return;
+        var newWindowField = parent.querySelector('.new_window_link_field');
 
         if (selector.value === 'relative_url') {
             field.classList.remove('link-block__hidden');
+            if (newWindowField) {
+                newWindowField.classList.remove('link-block__hidden');
+            }
         } else {
             field.classList.add('link-block__hidden');
         }


### PR DESCRIPTION
Wagtail's built-in link_block.js handles showing/hiding the new_window checkbox for its known link types (page, file, custom_url, etc.). But relative_url is a custom link type that Wagtail doesn't know about, so when you select "Relative URL", the new_window checkbox stays hidden.

This fix should add "Open in new tab" checkbox alongside the Relative URL input.