### PR TITLE
WT-785 fix WNP footer mis-aligned icon

### DIFF
--- a/media/css/cms/flare-footer.css
+++ b/media/css/cms/flare-footer.css
@@ -511,6 +511,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     text-decoration: none;
 }
 
+.fl-footer-link.fl-footer-link-has-icon {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 8px;
+}
+
 .fl-footer-link:hover {
     text-decoration: underline;
 }

--- a/springfield/cms/templates/cms/includes/wnp-footer.html
+++ b/springfield/cms/templates/cms/includes/wnp-footer.html
@@ -26,7 +26,7 @@
                 <ul>
                     <li>
                         <a
-                            class="fl-footer-link"
+                            class="fl-footer-link fl-footer-link-has-icon"
                             href="https://support.mozilla.org/"
                             >{{ ftl('footer-firefox-support')}}
                             <svg


### PR DESCRIPTION
## One-line summary

This PR fixes the WNP footer link icon alignment issue.

## Significant changes and points to review

WNP footer link icon alignment

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-785

## Testing

http://localhost:8000/en-US/whatsnew/148/