### PR TITLE
Exclude UUIDBlock from translation segments

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -434,6 +434,13 @@ class UUIDBlock(blocks.CharBlock):
     def clean(self, value):
         return super().clean(value) or str(uuid4())
 
+    def get_translatable_segments(self, value):
+        # UUIDs are analytics IDs, not user-facing content — exclude from translation.
+        return []
+
+    def restore_translated_segments(self, value, segments):
+        return value
+
 
 def BaseButtonSettings(themes=None, **kwargs):
     themes = themes or BUTTON_THEME_CHOICES.keys()

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -2164,3 +2164,10 @@ def test_springfield_link_block_page_none_returns_none():
     link_value = _springfield_link_value("page", page=None)
 
     assert link_value.get_url() is None
+
+
+def test_uuid_block_is_not_translatable():
+    """UUIDBlock stores analytics IDs, not user-facing content — it must not be sent to translators."""
+    from springfield.cms.blocks import UUIDBlock
+
+    assert UUIDBlock().get_translatable_segments("cfdf0d2c-7eee-49c2-8747-80450e22dbdd") == []


### PR DESCRIPTION
UUIDBlock extends CharBlock, so wagtail-localize was treating analytics IDs as translatable strings and sending them to Smartling. Override get_translatable_segments() to return an empty list, preventing UUIDs from appearing in translator queues.