### PR TITLE
WT-827 Add alternative mobile text to carousel slides

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1961,6 +1961,7 @@ class HomeIntroBlock(blocks.StructBlock):
 
 class HomeCarouselSlide(blocks.StructBlock):
     headline = blocks.RichTextBlock(features=HEADING_TEXT_FEATURES)
+    mobile_headline = blocks.RichTextBlock(required=False, features=HEADING_TEXT_FEATURES, help_text="Optional mobile copy")
     image = ImageVariantsBlock()
 
 

--- a/springfield/cms/fixtures/homepage_fixtures.py
+++ b/springfield/cms/fixtures/homepage_fixtures.py
@@ -137,6 +137,7 @@ def get_home_carousel():
                     "type": "item",
                     "value": {
                         "headline": '<p data-block-key="v9evz">Download Firefox</p>',
+                        "mobile_headline": '<p data-block-key="g34sa">Install Firefox</p>',
                         "image": {
                             "image": settings.PLACEHOLDER_IMAGE_ID,
                             "settings": {
@@ -152,6 +153,7 @@ def get_home_carousel():
                     "type": "item",
                     "value": {
                         "headline": '<p data-block-key="v9evz">Select what you want to bring with you</p>',
+                        "mobile_headline": "",
                         "image": {
                             "image": settings.PLACEHOLDER_IMAGE_ID,
                             "settings": {
@@ -167,6 +169,7 @@ def get_home_carousel():
                     "type": "item",
                     "value": {
                         "headline": '<p data-block-key="v9evz">Click import</p>',
+                        "mobile_headline": "",
                         "image": {
                             "image": settings.PLACEHOLDER_IMAGE_ID,
                             "settings": {

--- a/springfield/cms/templates/cms/blocks/sections/home-carousel.html
+++ b/springfield/cms/templates/cms/blocks/sections/home-carousel.html
@@ -13,6 +13,7 @@
   {% endset %}
   {% set _ = items.append({
     "headline": item.headline|richtext|remove_p_tag,
+    "mobile_headline": item.mobile_headline|richtext|remove_p_tag if item.mobile_headline else "",
     "image": image_html,
   }) %}
 {% endfor %}

--- a/springfield/cms/templates/components/carousel.html
+++ b/springfield/cms/templates/components/carousel.html
@@ -20,7 +20,14 @@
             <li
               class="fl-carousel-control-item {% if loop.first %}active{% endif %}"
             >
-              <span class="fl-carousel-control-item-text">{{ item.headline }}</span>
+              <span class="fl-carousel-control-item-text">
+                {% if item.mobile_headline %}
+                  <span class="display-xs">{{ item.mobile_headline }}</span>
+                  <span class="display-sm-up">{{ item.headline }}</span>
+                {% else %}
+                  {{ item.headline }}
+                {% endif %}
+              </span>
             </li>
           {% endfor %}
         </ol>

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -1395,7 +1395,16 @@ def test_home_carousel_block(index_page, placeholder_images, rf):
     for slide_index, slide in enumerate(slides):
         control_element = control_elements[slide_index]
         assert control_element
-        assert control_element.get_text().strip() == BeautifulSoup(slide["value"]["headline"], "html.parser").get_text().strip()
+        if slide["value"]["mobile_headline"]:
+            mobile_headline = control_element.find("span", class_="display-xs")
+            headline = control_element.find("span", class_="display-sm-up")
+            assert (
+                mobile_headline
+                and mobile_headline.get_text().strip() == BeautifulSoup(slide["value"]["mobile_headline"], "html.parser").get_text().strip()
+            )
+            assert headline and headline.get_text().strip() == BeautifulSoup(slide["value"]["headline"], "html.parser").get_text().strip()
+        else:
+            assert control_element.get_text().strip() == BeautifulSoup(slide["value"]["headline"], "html.parser").get_text().strip()
 
         slide_element = slide_elements[slide_index]
         assert slide_element


### PR DESCRIPTION
## One-line summary

Add a new mobile headline field to Home Carousel slides with an alternative mobile text.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-827

## Testing

Edit the homepage carousel and add mobile content to the slides

<img width="384" height="525" alt="image" src="https://github.com/user-attachments/assets/df07ff40-08af-4f1d-ab98-6855fe923a53" />
<img width="535" height="329" alt="image" src="https://github.com/user-attachments/assets/0c6c0f50-63ea-4155-8d59-bb9483f5583e" />
