### PR TITLE
disabled buttons revised in dark mode

### DIFF
--- a/media/css/cms/flare26-button.css
+++ b/media/css/cms/flare26-button.css
@@ -125,6 +125,15 @@ I propose we move to "Filled (Primary)", "Outline (Secondary)", and
 }
 
 /* copy of the dark query above for theme classes. */
+
+/* copy of dark mode :root */
+.fl-split-page-upper,
+.fl-force-dark-theme {
+    --button-bg-color-disabled: var(--token-color-purple);
+    --button-border-color-disabled: var(--button-bg-color-disabled);
+    --button-text-color-disabled: var(--token-color-soft-purple-4);
+}
+
 .fl-split-page-upper .fl-button.button-secondary,
 .fl-force-dark-theme .fl-button.button-secondary {
     --button-border-color-disabled: var(--token-color-light-purple);

--- a/media/css/cms/flare26-theme.css
+++ b/media/css/cms/flare26-theme.css
@@ -343,8 +343,6 @@ Contextual CSS custom properties that change based on context (e.g. layout direc
     --fl-theme-pill-bg-color-primary: var(--token-color-soft-purple-2);
     --fl-subnav-bg: var(--token-gradient-subnav-light);
     --fl-subnav-toggle-bg: var(--token-color-white);
-    --button-bg-color-disabled: var(--token-color-soft-purple-2);
-    --button-text-color-disabled: var(--token-color-link-purple);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -439,8 +437,6 @@ Contextual CSS custom properties that change based on context (e.g. layout direc
         --fl-theme-pill-bg-color-primary: var(--token-color-medium-purple);
         --fl-subnav-bg: var(--token-gradient-subnav-dark);
         --fl-subnav-toggle-bg: var(--fl-menu-hamburger-bg);
-        --button-bg-color-disabled: var(--token-color-soft-purple-2);
-        --button-text-color-disabled: var(--token-color-soft-purple-4);
     }
 }
 


### PR DESCRIPTION
## One-line summary

On light mode, the primary button disabled styles are reverting to default on light mode, even with the `.force-dark` class applied. 
<img width="847" height="520" alt="Screenshot 2026-03-02 at 12 00 33 PM" src="https://github.com/user-attachments/assets/0c827f4e-c760-4474-b321-8ff11c621004" />

This is fixed: 
<img width="714" height="579" alt="Screenshot 2026-03-02 at 12 01 52 PM" src="https://github.com/user-attachments/assets/d230ccec-4b23-43f6-a19d-1f605cdb2f6a" />


Test here: http://localhost:8000/en-US/features/control/