### PR TITLE
feat: Add database sync GHA for cascading data across environments

### DIFF
--- a/.github/workflows/db_sync.yml
+++ b/.github/workflows/db_sync.yml
@@ -181,6 +181,13 @@ jobs:
             --project="$PROJECT" \
             --quiet
 
+      - name: Delete export file from bucket
+        if: always()
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          gsutil rm "gs://$BUCKET/db-sync-$RUN_ID.sql.gz" || true
+
       # ── Sync CMS media bucket ──
 
       - name: Resolve CMS bucket names


### PR DESCRIPTION
Adds a manually-triggered workflow that exports a Cloud SQL database from a source environment (prod, stage, or dev), imports it into a target environment, and rsyncs the corresponding CMS media bucket. Authenticates via Workload Identity Federation and is gated behind the db-sync environment for approval control.

Related infra PR: https://github.com/mozilla/webservices-infra/pull/9904

Jira: https://mozilla-hub.atlassian.net/browse/WT-840