### PR TITLE
fix: grant ads consent when marketing opt-out checkbox is shown on /landing/get

### DIFF
--- a/media/js/firefox/landing/get/marketing-opt-out.es6.js
+++ b/media/js/firefox/landing/get/marketing-opt-out.es6.js
@@ -8,6 +8,7 @@ import {
     hasConsentCookie,
     getConsentCookie,
     setConsentCookie,
+    setGtagAdsConsentMode,
     consentRequired,
     dntEnabled,
     gpcEnabled
@@ -207,6 +208,7 @@ MarketingOptOut.init = () => {
     if (MarketingOptOut.shouldShowCheckbox()) {
         MarketingOptOut.showCheckbox();
         MarketingOptOut.bindEvents();
+        setGtagAdsConsentMode(true);
         return true;
     }
 

--- a/tests/unit/spec/base/gtm/gtm-snippet.js
+++ b/tests/unit/spec/base/gtm/gtm-snippet.js
@@ -241,6 +241,22 @@ describe('gtm-snippet.es6.js', function () {
             });
         });
 
+        it('should keep ads denied default on /landing/get (updated via MarketingOptOut.init)', function () {
+            // Ads defaults to denied in setGtagConsentDefaults.
+            // MarketingOptOut.init grants ads via update when checkbox is shown.
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(false);
+            spyOn(GTMSnippet, 'isFirefoxLandingGet').and.returnValue(true);
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'False');
+            GTMSnippet.setGtagConsentDefaults();
+            expect(window.gtag).toHaveBeenCalledWith('consent', 'default', {
+                ad_user_data: 'denied',
+                ad_personalization: 'denied',
+                ad_storage: 'denied'
+            });
+        });
+
         it('should deny analytics default when no consent cookie, on /landing/get, but consent is required (EU)', function () {
             spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(false);
             spyOn(GTMSnippet, 'isFirefoxLandingGet').and.returnValue(true);

--- a/tests/unit/spec/firefox/landing/marketing-opt-out.js
+++ b/tests/unit/spec/firefox/landing/marketing-opt-out.js
@@ -213,6 +213,23 @@ describe('marketing-opt-out.es6.js', function () {
             expect(checkboxes.length).toEqual(2);
         });
 
+        it('should grant ads consent when checkbox is shown', function () {
+            window.gtag = jasmine.createSpy('gtag');
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+            spyOn(MarketingOptOut, 'shouldShowCheckbox').and.returnValue(true);
+
+            MarketingOptOut.init();
+            expect(window.gtag).toHaveBeenCalledWith('consent', 'update', {
+                ad_user_data: 'granted',
+                ad_personalization: 'granted',
+                ad_storage: 'granted'
+            });
+            delete window.gtag;
+        });
+
         it('should remove attribution data and reject analytics when visitor unchecks input', function () {
             spyOn(
                 window.Mozilla.StubAttribution,


### PR DESCRIPTION
## One-line summary
Grant ads consent on /landing/get when marketing checkbox is shown

## Significant changes and points to review
PR #955 set ads consent default to denied on all pages, including /landing/get. This meant download clicks sent cookieless pings to Google Ads instead of full measurement data unless someone toggled on and off the checkbox.

When MarketingOptOut.init() confirms the checkbox should be shown (pre-checked), update ads consent to granted. This only fires for non-EU visitors who haven't set DNT/GPC and meet attribution requirements — the same conditions that gate the checkbox.


## Issue / Bugzilla link



## Testing
### Local (localhost:8000 with faux GTM container)

- [x] US, no cookie: ads default denied, ads update granted (checkbox shown)
- [x] US, cookie `analytics:true`: ads default granted, ads update granted (checkbox shown)
- [x] US, cookie `analytics:false`: ads default denied, no update (checkbox hidden)
- [x] FR (`?geo=fr`), no cookie: empty dataLayer, no GTM loaded
- [x] FR, accept banner: ads default granted (from cookie), GTM loads

### Production (firefox.com)

- [x] US, no cookie: ads default denied, checkbox shown pre-checked
- [x] Uncheck checkbox: ads consent revoked via GTM trigger (`gcs=G100` confirmed)
- [x] Re-check checkbox: ads consent granted via GTM trigger
- [x] Download click sends full measurement when ads granted

### Unit tests

- [x] 456 specs, 0 failures (Firefox + Chrome)