### PR TITLE
auto-height images by default

### DIFF
--- a/media/css/cms/flare26-base.css
+++ b/media/css/cms/flare26-base.css
@@ -201,6 +201,7 @@ video,
 canvas,
 svg {
     display: block;
+    height: auto;
     margin: 0 0 16px; /* IE 8 fallback */
     margin: 0 0 1rem;
     max-width: 100%;


### PR DESCRIPTION
The homepage looks fine, but some issues crept in with my Legacy Mode fixes today. I was able to replicate locally, and this fix takes care of it. 

<img width="1105" height="1015" alt="Screenshot 2026-03-05 at 4 55 03 PM" src="https://github.com/user-attachments/assets/13ca6f44-9ac2-4dc8-9b97-4850e25a7d7e" />

