### PR TITLE
feat: Add fbclid as a stub attribution parameter when permitted.

### DIFF
--- a/media/js/base/stub-attribution/stub-attribution.js
+++ b/media/js/base/stub-attribution/stub-attribution.js
@@ -520,6 +520,7 @@ if (typeof window.Mozilla === 'undefined') {
         var clientIDGA4 = omitNonEssentialFields
             ? null
             : StubAttribution.getGtagClientID();
+        var fbclid = omitNonEssentialFields ? null : params.get('fbclid');
 
         var data = {
             utm_source: utms.utm_source,
@@ -532,6 +533,7 @@ if (typeof window.Mozilla === 'undefined') {
             variation: variation,
             client_id_ga4: clientIDGA4,
             session_id: clientIDGA4 ? StubAttribution.createSessionID() : null,
+            fbclid: fbclid,
             dlsource: StubAttribution.DLSOURCE
         };
 

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -54,6 +54,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request({"dude": "abides"})
@@ -68,7 +69,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b85e2288e54169c8b3ffecc48ae53ffadcb899637c5d81320caaae16f25b04e",
+            "a2d38f7e968c6a4f40c75453a2ed3d0ca4ee67c131df2f698c290bc45fc20854",
         )
 
     def test_no_valid_param_data(self):
@@ -91,6 +92,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -105,7 +107,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b85e2288e54169c8b3ffecc48ae53ffadcb899637c5d81320caaae16f25b04e",
+            "a2d38f7e968c6a4f40c75453a2ed3d0ca4ee67c131df2f698c290bc45fc20854",
         )
 
     def test_some_valid_param_data(self):
@@ -120,6 +122,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -134,7 +137,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "1045ac6652da1cf26a16298192fb7c24fa7633008dd74f7b6ee70de104552cc4",
+            "f42e98baca1d36d6e7e264d2ec997b7be0f8c2cd987f313e275a4971f71baa7d",
         )
 
     def test_campaign_data_too_long(self):
@@ -157,13 +160,14 @@ class TestStubAttributionCode(TestCase):
             "campaign": "The|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in"
             "|thatThe|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe"
             "|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides"
-            "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know|about%7_",
+            "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont%_",
             "content": "A144_A000_0000000",
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
             "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -180,7 +184,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "02f2109b763e2eff09884419ce6e674761acb814d79d6e84cd2fb174f5841e71",
+            "5bc63f8502eed33a93c0ae6266614c4f85345e837101d87a3307ab76f2eefda3",
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -220,6 +224,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "chrome",
             "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -234,7 +239,45 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "f96186b4d814cfe99bf0c4d17a065535239cc0b4054534b46552bbc615598b90",
+            "a51fdfa48e39b07d1772c1924e2c5cbad1448edce079a4d61472f9f13a39e31d",
+        )
+
+    def test_returns_valid_data_with_fbclid(self):
+        params = {
+            "utm_source": "brandt",
+            "utm_medium": "aether",
+            "experiment": "firefox-download",
+            "variation": "1",
+            "ua": "chrome",
+            "client_id_ga4": "2456954538.1610960957",
+            "session_id": "1668161374",
+            "fbclid": "IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8",
+            "dlsource": "fxdotcom",
+        }
+        final_params = {
+            "source": "brandt",
+            "medium": "aether",
+            "campaign": "(not set)",
+            "content": "(not set)",
+            "experiment": "firefox-download",
+            "variation": "1",
+            "ua": "chrome",
+            "client_id_ga4": "2456954538.1610960957",
+            "session_id": "1668161374",
+            "fbclid": "IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8",
+            "dlsource": "fxdotcom",
+        }
+        req = self._get_request(params)
+        resp = views.stub_attribution_code(req)
+        self.assertEqual(resp.status_code, 200)
+        assert resp["cache-control"] == "max-age=300"
+        data = json.loads(resp.content)
+        attrs = parse_qs(querystringsafe_base64.decode(data["attribution_code"].encode()).decode())
+        attrs = {k: v[0] for k, v in attrs.items()}
+        self.assertDictEqual(attrs, final_params)
+        self.assertEqual(
+            data["attribution_sig"],
+            "cfe6b408ae8662e2b71eef33fa59d2228e33655cc466fdf52a2370a8f3fe2191",
         )
 
     def test_handles_referrer(self):
@@ -249,6 +292,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -263,7 +307,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "1045ac6652da1cf26a16298192fb7c24fa7633008dd74f7b6ee70de104552cc4",
+            "f42e98baca1d36d6e7e264d2ec997b7be0f8c2cd987f313e275a4971f71baa7d",
         )
 
     def test_handles_referrer_no_source(self):
@@ -281,6 +325,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -295,7 +340,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "1791839786fe22e61e20e570ff0860082b16527cc9f982564461d0b33afed4b8",
+            "3cfebffa78e47f8e6d8b2edc87acff376fa353c62418531b5b563bde84fa84a6",
         )
 
     def test_handles_referrer_utf8(self):
@@ -316,6 +361,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
+            "fbclid": "(not set)",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -330,7 +376,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b85e2288e54169c8b3ffecc48ae53ffadcb899637c5d81320caaae16f25b04e",
+            "a2d38f7e968c6a4f40c75453a2ed3d0ca4ee67c131df2f698c290bc45fc20854",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -52,6 +52,7 @@ STUB_VALUE_NAMES = [
     ("ua", "(not set)"),
     ("client_id_ga4", "(not set)"),
     ("session_id", "(not set)"),
+    ("fbclid", "(not set)"),
     ("dlsource", "fxdotcom"),
 ]
 STUB_VALUE_RE = re.compile(r"^[a-z0-9-.%():_]+$", flags=re.IGNORECASE)

--- a/tests/unit/spec/base/stub-attribution/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution/stub-attribution.js
@@ -730,7 +730,49 @@ describe('stub-attribution.js', function () {
             );
             spyOn(window._SearchParams.prototype, 'get').and.callFake(
                 function (key) {
-                    return key === 'experiment' ? 'firefox-download' : 1;
+                    if (key === 'experiment') return 'firefox-download';
+                    if (key === 'variation') return 1;
+                    return null;
+                }
+            );
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue(
+                'chrome'
+            );
+            const result = Mozilla.StubAttribution.getAttributionData(referrer);
+            expect(result).toEqual(data);
+        });
+
+        it('should return fbclid when present in URL params', function () {
+            const referrer = '';
+
+            const utms = {
+                utm_source: 'desktop-snippet',
+                utm_medium: 'referral',
+                utm_campaign: 'F100_4242_otherstuff_in_here',
+                utm_content: 'rel-esr'
+            };
+
+            const data = {
+                utm_source: 'desktop-snippet',
+                utm_medium: 'referral',
+                utm_campaign: 'F100_4242_otherstuff_in_here',
+                utm_content: 'rel-esr',
+                referrer: '',
+                ua: 'chrome',
+                client_id_ga4: GA4_CLIENT_ID,
+                session_id: jasmine.any(String),
+                fbclid: 'IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8',
+                dlsource: DLSOURCE
+            };
+
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue(
+                utms
+            );
+            spyOn(window._SearchParams.prototype, 'get').and.callFake(
+                function (key) {
+                    if (key === 'fbclid')
+                        return 'IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8';
+                    return null;
                 }
             );
             spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue(
@@ -765,7 +807,11 @@ describe('stub-attribution.js', function () {
             );
             spyOn(window._SearchParams.prototype, 'get').and.callFake(
                 function (key) {
-                    return key === 'experiment' ? 'firefox-download' : 1;
+                    if (key === 'experiment') return 'firefox-download';
+                    if (key === 'variation') return 1;
+                    if (key === 'fbclid')
+                        return 'IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8';
+                    return null;
                 }
             );
             spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue(


### PR DESCRIPTION
This changeset captures Meta's click identifier (`fbclid`) in the stub-attribution flow, when permitted, so it can be passed through to the telemetry backend for Meta Conversions API integration. This is analogous to how `client_id_ga4` and `session_id` are already captured for GA4.

Changes:

- Add `("fbclid", "(not set)")` to `STUB_VALUE_NAMES` in views.py
- Capture `fbclid` from URL query params in `getAttributionData()` in JS
- Treat `fbclid` as non-essential: omit when `omitNonEssentialFields=true` (EU/consent-required users), consistent with `client_id_ga4` handling
- Update all Python test assertions (`final_params` dicts, HMAC signatures, campaign truncation boundary) and add a test case with an `fbclid` value
- Add JS test for `fbclid` capture and fix `params.get` spies in existing tests to be explicit about which keys return values

Notes:

* The `fbclid` value format (alphanumeric, hyphens, underscores) already passes the existing validation regex.

* No changes needed to bouncer (opaque passthrough) or the regex. The "omit from build" filtering happens downstream in stubattribution, not here — Springfield encode all params into the signed attribution blob as before.

* If the target page for any referring links is directly `/thanks/?fbclid=something` we will need extra manual QA steps because this triggers a slightly different code path.


## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-882

## Testing

### Happy path

1. Visit https://www-demo5.springfield.moz.works/en-US/firefox/new/?fbclid=IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8&someother_param=foobarbaz
2. Open DevTools → Network tab, filter for `stub_attribution_code`
3. Verify the request query string includes `fbclid=IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8`
4. Verify the response returns a 200 with `attribution_code` and `attribution_sig`
5. Inspect a download button link — confirm `attribution_code=...&attribution_sig=...` are appended to the URL
6. Decode the attribution_code value (base64) with 
```
python -c "import querystringsafe_base64, sys; print(querystringsafe_base64.decode(sys.argv[1].encode()).decode())" "<paste attribution_code here>"
```
and confirm `fbclid=IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8` is present in the decoded string

### Verify `fbclid` is absent without the parameter

1. Visit https://www-demo5.springfield.moz.works/en-US/
2. Check the `stub_attribution_code` request happens in the Network tab (we eagerly get the SA cookies when we are allowed to)
3. Confirm fbclid is not in the request query string (or defaults to (not set) in the decoded attribution code)

### Verify fbclid is omitted for consent-required users

1. Simulate an EU/EEA visit (where omitNonEssentialFields=true is triggered)
2. Visit https://www-demo5.springfield.moz.works/en-US/?fbclid=IwAR2aCGqoEtSa5Jjbtxmszt7dQyri7Oipa_cXU8zGZGcnLkYm7JkVeVs1y8
4. Confirm `fbclid` is not included in the `stub_attribution_code/` request, consistent with `client_id_ga4` and `session_id` also being absent
