### PR TITLE
WT-739 fix sidebar highlighted item

### DIFF
--- a/media/css/cms/pages/flare26-user-privacy.css
+++ b/media/css/cms/pages/flare26-user-privacy.css
@@ -150,6 +150,7 @@ body.data-uitour #privacy-settings {
     }
 
     .fl-page-user-privacy .main-content .sidebar li a,
+    /* regular link styles should be also applied to none first current items */
     .fl-page-user-privacy .main-content .sidebar li.current + li.current a {
         align-items: center;
         color: var(--sidebar-text-color);


### PR DESCRIPTION
## One-line summary


## Significant changes and points to review

This PR fixes the user privacy sidebar highlighted item. Only the top visible item should be highlighted.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-739

## Testing

http://localhost:8000/en-US/user-privacy/