### PR TITLE
Fix bug for EU download as default

### DIFF
--- a/media/js/firefox/download/desktop/download-as-default.es6.js
+++ b/media/js/firefox/download/desktop/download-as-default.es6.js
@@ -225,13 +225,13 @@ DownloadAsDefault.meetsRequirements = () => {
         // Ensure the visitor is on Windows OS
         return false;
     } else if (DownloadAsDefault.onlyEssential()) {
-        // onlyEssential() tells us whether DNT/GPC are blocking 
-        // the cookie banner of if consent is still needed (and remember the 
+        // onlyEssential() tells us whether DNT/GPC are blocking
+        // the cookie banner of if consent is still needed (and remember the
         // banner is not shown on /thanks/ if consent is needed - we just skip
         // attribution in that case - this is a key point here).
 
-        // In this corner case (which surfaces in the EU *specifically*), there's 
-        // no point showing DaD because stubattribution will never get 
+        // In this corner case (which surfaces in the EU *specifically*), there's
+        // no point showing DaD because stubattribution will never get
         // called - and so the download-as-default param won't reach the stub
         // installer - so it's better to not show the checkbox option at all.
         return false;

--- a/tests/unit/spec/firefox/new/desktop/download-as-default.js
+++ b/tests/unit/spec/firefox/new/desktop/download-as-default.js
@@ -71,6 +71,20 @@ describe('download-as-default.es6.js', function () {
             expect(result).toBeFalse();
         });
 
+        it('should return false if analytics attribution is not allowed', function () {
+            // consent required geo with no explict analytics allowed cookie
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'True');
+
+            const result = DownloadAsDefault.meetsRequirements();
+            expect(result).toBeFalse();
+        });
+
         it('should return true if attribution requirements are satisfied', function () {
             const result = DownloadAsDefault.meetsRequirements();
             expect(result).toBeTrue();


### PR DESCRIPTION
The stub attribution cookies are being set as expected on pages with the download as default checkbox.

However, the cookies are not being added to the download links on other pages (i.e. /thanks).

This is because we have a mismatch between consent checks on download as default and stub attribution. Download as default is more permissive because it sets the omitNonEssentialFields flag. Stub attribution does not set that flag and will not be initiated if StubAttributionConsent.init() checks do not pass (DNT/GPC, deny analytics cookie, consent required geo, etc.)

## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-880


## Testing
- Pull production data to ensure you have CMS homepage and CMS thanks page
- Use windows computer or comment out the [condition on L224](https://github.com/mozmeao/springfield/blob/main/media/js/firefox/download/desktop/download-as-default.es6.js#L224) to bypass Windows condition for testing
- [ ] non-EU geo (default US in localhost): http://localhost:8000/en-US/ => You should see default checkbox in hero section
- [ ] Checking or unchecking this checkbox changes the stub attribution code cookie
- [ ] clicking through to download includes links with stub attribution code
- [ ] EU geo http://localhost:8000/en-US/?geo=FR => You should not see default checkbox (does not meet consent requirements required for stub attribution on /thanks)
- [ ] No stub attribution cookies

You will need to be on browserstack Windows or a Windows machine to test Demo
Inspect the HTML element to see if consent is required (change geo with VPN to test EU & non-EU) 
DEMO 3 link: https://www-demo3.springfield.moz.works/en-US/test-homepage-not-in-the-right-position/
(needs some CMS updates to show DaD button)