### PR TITLE
WIP landing

### DIFF
--- a/l10n/de/firefox/smart-window.ftl
+++ b/l10n/de/firefox/smart-window.ftl
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.springfield.moz.works/smart-window/
+
+# TODO Smart Window as brand variable? Include comment?
+smart-window-heading = DE Smart Window Heading
+smart-window-body = Smart Window body copy
+smart-window-enable = Enable Smart Window
+smart-window-download-and-enable = Download { -brand-name-firefox } and Enable Smart Window

--- a/l10n/en/firefox/smart-window.ftl
+++ b/l10n/en/firefox/smart-window.ftl
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.springfield.moz.works/smart-window/
+
+# TODO Smart Window as brand variable? Include comment?
+smart-window-heading = Smart Window Heading
+smart-window-body = Smart Window body copy
+smart-window-enable = Enable Smart Window
+smart-window-download-and-enable = Download { -brand-name-firefox } and Enable Smart Window

--- a/l10n/fr/firefox/smart-window.ftl
+++ b/l10n/fr/firefox/smart-window.ftl
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.springfield.moz.works/smart-window/
+
+# TODO Smart Window as brand variable? Include comment?
+smart-window-heading = FR Smart Window Heading
+smart-window-body = Smart Window body copy
+smart-window-enable = Enable Smart Window
+smart-window-download-and-enable = Download Firefox and Enable Smart Window

--- a/media/js/firefox/ai/landing-init.es6.js
+++ b/media/js/firefox/ai/landing-init.es6.js
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+if (
+    typeof window.Mozilla !== 'undefined' &&
+    typeof window.Mozilla.Client !== 'undefined' &&
+    window.Mozilla.Client.isFirefoxDesktop
+) {
+    const ctaButton = document.getElementById('js-uitour-show-account');
+    ctaButton.addEventListener('click', (e) => {
+        e.preventDefault();
+
+        if (
+            typeof window.Mozilla.UITour !== 'undefined' &&
+            typeof window.Mozilla.UITour.showFirefoxAccountsForAIWindow ===
+                'function'
+        ) {
+            window.Mozilla.UITour.showFirefoxAccountsForAIWindow();
+        }
+
+        if (window.dataLayer) {
+            window.dataLayer.push({
+                event: 'smart_window_enable',
+                cta_type: 'uitour'
+            });
+        }
+    });
+}
+// TODO: Else ensure expected campaign is associated with download

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -857,6 +857,12 @@
         "js/firefox/ai/waitlist-newsletter-init.es6.js"
       ],
       "name": "waitlist_newsletter"
+    },
+    {
+      "files": [
+        "js/firefox/ai/landing-init.es6.js"
+      ],
+      "name": "smart_window_landing"
     }
   ]
 }

--- a/springfield/firefox/templates/firefox/ai/landing.html
+++ b/springfield/firefox/templates/firefox/ai/landing.html
@@ -1,0 +1,50 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends 'cms/base-flare26.html' %}
+
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
+{% block flare_header %}
+  {% set hide_nav_cta = true %}
+  <include:flare26-header />
+{% endblock %}
+
+{% block content %}
+<main class="fl-main">
+  <include:intro>
+    <content:heading>
+      <include:heading
+        level="h1"
+        heading_text="{{ ftl('smart-window-heading')}}"
+        subheading_text="{{ ftl('smart-window-body')}}"
+      />
+    </content:heading>
+    <content:actions>
+
+      <include:conditional-display firefox_condition="is-firefox">
+        <button id="js-uitour-show-account" class="fl-button" data-cta-type="smart-window" data-cta-text="Enable Smart Window">
+          {{ ftl('smart-window-enable')}}
+        </button>
+      </include:conditional-display>
+      <include:conditional-display firefox_condition="not-firefox">
+        <include:download-firefox-button
+          analytics_id="smart-window-firefox"
+          label="{{ ftl('smart-window-download-and-enable')}}"
+          icon_name="downloads"
+          icon_position="right"
+          block_position="primary"
+          exclude_unsupported_content="True"
+        />
+      </include:conditional-display>
+    </content:actions>
+  </include:intro>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('smart_window_landing') }}
+{% endblock %}

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -208,6 +208,7 @@ urlpatterns = (
     # END What's New Page (WNP) paths
     page("user-privacy/", "firefox/data.html", url_name="firefox.user-privacy"),
     path("ai/", views.firefox_ai_waitlist_page, name="firefox.ai.waitlist"),
+    path("smart-window/", views.firefox_smart_window_landing_page, name="firefox.smart-window"),
 )
 
 if settings.ENABLE_CMS_REFRESH_REDIRECTS:

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -21,6 +21,7 @@ from lib import l10n_utils
 from lib.l10n_utils import L10nTemplateView
 from lib.l10n_utils.fluent import ftl, ftl_file_is_active
 from springfield.base import waffle
+from springfield.base.geo import get_country_from_request
 from springfield.base.urlresolvers import reverse
 from springfield.firefox.firefox_details import (
     firefox_android,
@@ -29,6 +30,9 @@ from springfield.firefox.firefox_details import (
 )
 from springfield.newsletter.forms import NewsletterFooterForm
 from springfield.releasenotes import version_re
+
+# TODO: check if this is best place to set
+SMART_WINDOW_SUPPORTED_COUNTRIES = ["US", "CA", "DE", "FR"]
 
 UA_REGEXP = re.compile(r"Firefox/(%s)" % version_re)
 
@@ -173,6 +177,20 @@ def firefox_ai_waitlist_page(request):
     ctx = {"newsletter_id": newsletter_id}
 
     return l10n_utils.render(request, template_name, ctx)
+
+
+@require_safe
+def firefox_smart_window_landing_page(request):
+    template_name = "firefox/ai/landing.html"
+    country_code = get_country_from_request(request)
+    redirect_url = reverse("firefox.ai.waitlist")
+
+    # TODO: check what unsupported locale fallback should be, redirect or EN page
+    # redirect to waitlist if country or locale is unsupported
+    if country_code not in SMART_WINDOW_SUPPORTED_COUNTRIES or not ftl_file_is_active("firefox/smart-window"):
+        return HttpResponseRedirect(redirect_url)
+
+    return l10n_utils.render(request, template_name, ftl_files="firefox/smart-window")
 
 
 @require_safe


### PR DESCRIPTION
## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-513


## Testing

http://localhost:8000/en-US/smart-window/?utm_campaign=smart_window
- Fx goes to Fx accounts with entrypoint and service set to smartwindow
- not Fx has download with stub attribution cookie that decodes to include smart_window campaign (i.e. source=(not set)&medium=(direct)&campaign=smart_window&content=(not set)&experiment=(not set)&variation=(not set)&ua=(not set)&client_id_ga4=(not set)&session_id=2443984874&dlsource=fxdotcom)

http://localhost:8000/de/smart-window/?geo=TR
- redirect to waitlist

ℹ️ For local or demo UITour use
To develop or test using Mozilla.UITour locally you need to create some custom preferences in about:config.

    browser.uitour.testingOrigins (string) (value: local address e.g. http://127.0.0.1:8000)
    browser.uitour.requireSecure (boolean) (value: false)
