### PR TITLE
WT-841 Show correct Windows download link

### DIFF
--- a/media/css/cms/pages/flare26-channels.css
+++ b/media/css/cms/pages/flare26-channels.css
@@ -176,6 +176,19 @@ ul.download-list strong {
     display: block !important;
 }
 
+.windows .force-win64 .os_win,
+.windows .force-win64-aarch64 .os_win {
+    display: none !important;
+}
+
+.windows .force-win64 .os_win64 {
+    display: block !important;
+}
+
+.windows .force-win64-aarch64 .os_win64-aarch64 {
+    display: block !important;
+}
+
 /* add spacing between displayed buttons */
 .download-list {
     display: grid;

--- a/media/css/cms/pages/flare26-channels.css
+++ b/media/css/cms/pages/flare26-channels.css
@@ -180,6 +180,19 @@
         display: block !important;
     }
 
+    .windows .force-win64 .os_win,
+    .windows .force-win64-aarch64 .os_win {
+        display: none !important;
+    }
+
+    .windows .force-win64 .os_win64 {
+        display: block !important;
+    }
+
+    .windows .force-win64-aarch64 .os_win64-aarch64 {
+        display: block !important;
+    }
+
     /* add spacing between displayed buttons */
     .download-list {
         display: grid;

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -101,6 +101,19 @@ ul.download-list {
     display: block !important;
 }
 
+.windows .force-win64 .os_win,
+.windows .force-win64-aarch64 .os_win {
+    display: none !important;
+}
+
+.windows .force-win64 .os_win64 {
+    display: block !important;
+}
+
+.windows .force-win64-aarch64 .os_win64-aarch64 {
+    display: block !important;
+}
+
 // add spacing between displayed buttons
 .download-list {
     display: grid;

--- a/springfield/firefox/templates/firefox/includes/download-button.html
+++ b/springfield/firefox/templates/firefox/includes/download-button.html
@@ -61,7 +61,7 @@
     {# ESR download buttons to display on unsupported systems: issue 13317 #}
     {% include 'firefox/includes/download-unsupported.html' %}
   {% endif %}
-  <ul class="download-list fl-download-list">
+  <ul class="download-list fl-download-list{%if force_arch %} force-{{ force_arch }}{% endif %}">
     {% for plat in builds %}
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
         <a class="download-link button {{ button_class }} fl-button mzp-c-button mzp-t-product ga-product-download"

--- a/springfield/firefox/templates/firefox/installer-help.html
+++ b/springfield/firefox/templates/firefox/installer-help.html
@@ -57,7 +57,7 @@
     <section class="installer-channel-card mzp-c-card mzp-c-card-extra-small">
       <img src="{{ static(channel_logo) }}" alt="{{ ftl('installer-help-firefox-release-title') }}" width="347" height="64">
       <div class="mzp-c-card-content">
-        {{ download_firefox(installer_channel, platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang, button_class='mzp-t-md', alt_copy=ftl('download-button-download-now')) }}
+        {{ download_firefox(installer_channel, platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang, button_class='mzp-t-md', alt_copy=ftl('download-button-download-now'), force_arch=installer_arch) }}
       </div>
     </section>
   {% else %}

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -114,6 +114,7 @@ def download_firefox(
     button_class="mzp-t-xl",
     locale_in_transition=False,
     download_location=None,
+    force_arch=None,
 ):
     """Output a "download firefox" button.
 
@@ -171,6 +172,7 @@ def download_firefox(
         "button_class": button_class,
         "download_location": download_location,
         "fluent_l10n": ctx["fluent_l10n"],
+        "force_arch": force_arch,
     }
 
     html = render_to_string("firefox/includes/download-button.html", data, request=ctx["request"])

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -41,16 +41,6 @@ def desktop_builds(
     for plat_os, plat_os_pretty in firefox_desktop.platforms(channel, classified):
         os_pretty = plat_os_pretty
 
-        # Firefox Nightly: The Windows stub installer is now universal,
-        # automatically detecting a 32-bit and 64-bit desktop, so the
-        # win64-specific entry can be skipped.
-        if channel == "nightly":
-            if plat_os == "win":
-                continue
-            if plat_os == "win64":
-                plat_os = "win"
-                os_pretty = "Windows 32/64-bit"
-
         # And generate all the info
         download_link = firefox_desktop.get_download_url(
             channel,

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -162,7 +162,7 @@ def download_firefox(
         "button_class": button_class,
         "download_location": download_location,
         "fluent_l10n": ctx["fluent_l10n"],
-        "force_arch": force_arch
+        "force_arch": force_arch,
     }
 
     html = render_to_string("firefox/includes/download-button.html", data, request=ctx["request"])

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -175,6 +175,9 @@ def download_firefox(
         "force_arch": force_arch,
     }
 
+    if force_arch is not None:
+        data["force_arch"] = force_arch
+
     html = render_to_string("firefox/includes/download-button.html", data, request=ctx["request"])
     return Markup(html)
 

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -172,7 +172,6 @@ def download_firefox(
         "button_class": button_class,
         "download_location": download_location,
         "fluent_l10n": ctx["fluent_l10n"],
-        "force_arch": force_arch,
     }
 
     if force_arch is not None:

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -172,10 +172,8 @@ def download_firefox(
         "button_class": button_class,
         "download_location": download_location,
         "fluent_l10n": ctx["fluent_l10n"],
+        "force_arch": force_arch
     }
-
-    if force_arch is not None:
-        data["force_arch"] = force_arch
 
     html = render_to_string("firefox/includes/download-button.html", data, request=ctx["request"])
     return Markup(html)

--- a/springfield/firefox/tests/test_base.py
+++ b/springfield/firefox/tests/test_base.py
@@ -186,4 +186,5 @@ class TestInstallerHelp(TestCase):
             force_full_installer=True,
             locale=None,
             platform="desktop",
+            force_arch=None,
         )

--- a/springfield/firefox/tests/test_helpers.py
+++ b/springfield/firefox/tests/test_helpers.py
@@ -170,34 +170,6 @@ class TestDownloadButtons(TestCase):
         # The 10th link is mobile and should not have the attr
         assert pq(links[9]).attr("data-direct-link") is None
 
-    def test_nightly_desktop(self):
-        """
-        The Nightly channel should have the Windows universal stub installer
-        instead of the Windows 64-bit build
-        """
-        rf = RequestFactory()
-        get_request = rf.get("/fake")
-        get_request.locale = "fr"
-        doc = pq(
-            render(
-                "{{ download_firefox('nightly', platform='desktop') }}", {"request": get_request, "fluent_l10n": self.get_l10n(get_request.locale)}
-            )
-        )
-
-        list = doc(".download-list li")
-        assert list.length == 8
-        assert pq(list[0]).attr("class") == "os_win"
-        assert pq(list[1]).attr("class") == "os_win64-msi"
-        assert pq(list[2]).attr("class") == "os_win64-aarch64"
-        assert pq(list[3]).attr("class") == "os_win-msi"
-        assert pq(list[4]).attr("class") == "os_osx"
-        assert pq(list[5]).attr("class") == "os_linux64"
-        assert pq(list[6]).attr("class") == "os_linux64-aarch64"
-        assert pq(list[7]).attr("class") == "os_linux"
-        # stub disabled for now for non-en-US locales
-        # bug 1339870
-        # assert 'stub' in pq(pq(list[1]).find('a')[0]).attr('href')
-
     def test_aurora_desktop(self):
         """The Aurora channel should have Windows 64 build"""
         rf = RequestFactory()

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -64,8 +64,12 @@ class InstallerHelpView(L10nTemplateView):
         ctx = super().get_context_data(**kwargs)
         installer_lang = self.request.GET.get("installer_lang", None)
         installer_channel = self.request.GET.get("channel", None)
+        installer_arch = self.request.GET.get("installer_arch", None)
         ctx["installer_lang"] = None
         ctx["installer_channel"] = None
+
+        if installer_arch is not None:
+            ctx["installer_arch"] = {"1": "win", "2": "win64", "3": "win64-aarch64"}[installer_arch]
 
         if installer_lang and installer_lang in firefox_desktop.languages:
             ctx["installer_lang"] = installer_lang

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -67,6 +67,7 @@ class InstallerHelpView(L10nTemplateView):
         installer_arch = self.request.GET.get("installer_arch", None)
         ctx["installer_lang"] = None
         ctx["installer_channel"] = None
+        ctx["installer_arch"] = None
 
         if installer_arch is not None:
             ctx["installer_arch"] = {"1": "win", "2": "win64", "3": "win64-aarch64"}[installer_arch]

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -84,6 +84,7 @@ class InstallerHelpView(L10nTemplateView):
         installer_arch = self.request.GET.get("installer_arch", None)
         ctx["installer_lang"] = None
         ctx["installer_channel"] = None
+        ctx["installer_arch"] = None
 
         if installer_arch is not None:
             ctx["installer_arch"] = {"1": "win", "2": "win64", "3": "win64-aarch64"}[installer_arch]

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -81,8 +81,12 @@ class InstallerHelpView(L10nTemplateView):
         ctx = super().get_context_data(**kwargs)
         installer_lang = self.request.GET.get("installer_lang", None)
         installer_channel = self.request.GET.get("channel", None)
+        installer_arch = self.request.GET.get("installer_arch", None)
         ctx["installer_lang"] = None
         ctx["installer_channel"] = None
+
+        if installer_arch is not None:
+            ctx["installer_arch"] = {"1": "win", "2": "win64", "3": "win64-aarch64"}[installer_arch]
 
         if installer_lang and installer_lang in firefox_desktop.languages:
             ctx["installer_lang"] = installer_lang

--- a/tests/playwright/specs/products/firefox/firefox-installer-help.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-installer-help.spec.js
@@ -160,5 +160,68 @@ test.describe(
             await expect(downloadButtonBeta).not.toBeVisible();
             await expect(downloadButtonDeveloper).not.toBeVisible();
         });
+
+        test('Download Firefox (Windows) forced win architecture', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(
+                url + '?channel=release&installer_arch=1',
+                page,
+                browserName
+            );
+            await expect(downloadButtonRelease).toBeVisible();
+        });
+
+        test('Download Firefox (Windows) forced win64 architecture', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win64'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(
+                url + '?channel=release&installer_arch=2',
+                page,
+                browserName
+            );
+            await expect(downloadButtonRelease).toBeVisible();
+        });
+
+        test('Download Firefox (Windows) forced win64-aarch64 architecture', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win64-aarch64'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(
+                url + '?channel=release&installer_arch=3',
+                page,
+                browserName
+            );
+            await expect(downloadButtonRelease).toBeVisible();
+        });
     }
 );


### PR DESCRIPTION
## One-line summary
Windows users are shown the 32 bit download link on https://www.mozilla.org/firefox/installer-help/?channel=release regardless of their current architecture.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1564333

## Testing

Before each step remember to change the HTML class OS to "windows"
The x64 doesn't matter as it doesn't affect the shown download button. Only "win" is ever displayed

- [x] Checkout this PR
- [x] Visit http://localhost:8000/en-US/download/installer-help/?channel=release
- [x] Remove the x64 class from HTML if it exists
- [x] The download link should be `https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US`
- [x] Add the x64 class back to HTML
- [x] The download link should still be `https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US`
- [x] Visit http://localhost:8000/en-US/download/installer-help/?channel=release&installer_arch=1
- [x] The download link should be `https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US`
- [x] Visit http://localhost:8000/en-US/download/installer-help/?channel=release&installer_arch=2
- [x] The download link should be `https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US`
- [x] Visit http://localhost:8000/en-US/download/installer-help/?channel=release&installer_arch=3
- [x] The download link should be `https://download.mozilla.org/?product=firefox-latest-ssl&os=win64-aarch64&lang=en-US`