### PR TITLE
Mirror icons for RTL languages

### DIFF
--- a/media/css/cms/flare26-footer.css
+++ b/media/css/cms/flare26-footer.css
@@ -206,6 +206,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     vertical-align: baseline;
 }
 
+[dir='rtl'] .fl-footer-section a[href^='http']::after {
+    transform: scaleX(-1);
+}
+
 /* -------------------------------------------------------------------------- */
 
 /* Secondary Section */

--- a/media/css/cms/flare26-icon.css
+++ b/media/css/cms/flare26-icon.css
@@ -410,6 +410,10 @@
     --icon-src: url('/media/img/firefox/flare/2026/icons/desktop-16/arrows-and-chevrons/forward-16.svg');
 }
 
+[dir='rtl'] .fl-icon-forward {
+    transform: scaleX(-1);
+}
+
 .fl-icon-forward-small {
     --icon-src: url('/media/img/firefox/flare/2026/icons/desktop-16/arrows-and-chevrons/forward-small-16.svg');
 }

--- a/media/css/cms/flare26-navigation.css
+++ b/media/css/cms/flare26-navigation.css
@@ -123,6 +123,10 @@
     vertical-align: baseline;
 }
 
+[dir='rtl'] .fl-nav a[href^='http']::after {
+    transform: scaleX(-1);
+}
+
 .fl-nav-menu {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## One-line summary
Various icons are displayed the same for both LTR and RTL languages. They should be reversed for RTL.

## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/1075

## Testing
- [x] Checkout this PR
- [x] Notice each dropdown menu contains right pointing and up right pointing arrows
- [x] Scroll down the footer and notice the external links consist of a box and an arrow pointing up right
- [x] Change the `lang` class on HTML to "rtl"
- [x] Arrow icons in the drop downs should now point left or up left depending on the icon
- [x] Scroll down to the footer
- [x] External links should consist of a box with an arrow pointing up left.