### PR TITLE
Remove whitespace underline in navigation

### DIFF
--- a/media/css/cms/flare26-navigation.css
+++ b/media/css/cms/flare26-navigation.css
@@ -32,7 +32,7 @@
     text-decoration: none;
 }
 
-.fl-header a:hover .fl-menu-heading {
+.fl-header a:hover {
     text-decoration: underline;
 }
 
@@ -151,6 +151,11 @@
 /* ================================================
    Menu Panel Styles
    ================================================ */
+
+.fl-menu-heading {
+    display: flex;
+    gap: var(--token-spacing-xs);
+}
 
 .fl-menu-title,
 .fl-menu-title h2,

--- a/springfield/cms/templates/cms/includes/flare26-menus/browser.html
+++ b/springfield/cms/templates/cms/includes/flare26-menus/browser.html
@@ -14,8 +14,8 @@
     aria-controls="fl-menu-panel-browser"
     data-testid="navigation-link-browser"
   >
-    <h2>
-      <span class="fl-menu-heading">{{ ftl('navigation-browser')}}</span>
+    <h2 class="fl-menu-heading">
+      {{ ftl('navigation-browser')}}
       <span class="fl-icon fl-icon-chevron-down"></span>
     </h2>
   </a>

--- a/springfield/cms/templates/cms/includes/flare26-menus/features.html
+++ b/springfield/cms/templates/cms/includes/flare26-menus/features.html
@@ -11,8 +11,8 @@
     aria-haspopup="true"
     aria-controls="fl-menu-panel-features"
   >
-    <h2>
-      <span class="fl-menu-heading">{{ ftl('navigation-features') }}</span>
+    <h2 class="fl-menu-heading">
+      {{ ftl('navigation-features') }}
       <span class="fl-icon fl-icon-chevron-down"></span>
     </h2>
   </a>

--- a/springfield/cms/templates/cms/includes/flare26-menus/resources.html
+++ b/springfield/cms/templates/cms/includes/flare26-menus/resources.html
@@ -14,8 +14,8 @@
     aria-controls="fl-menu-panel-resources"
     data-testid="navigation-link-resources"
   >
-    <h2>
-      <span class="fl-menu-heading">{{ ftl('navigation-resources') }}</span>
+    <h2 class="fl-menu-heading">
+      {{ ftl('navigation-resources') }}
       <span class="fl-icon fl-icon-chevron-down"></span>
     </h2>
   </a>


### PR DESCRIPTION
## One-line summary
The navigation elements (Browser, Features, Resources) underline a whitespace which doesn't match the rest of the page

## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/1149

## Testing
- [x] Checkout this PR
- [x] Hover over Browser, Features and Resources
- [x] There should no longer be an underline under the white space between the end of the text and the icon