### PR TITLE
(fix) Amend DB sync GHA to avoid dropping database with active replica connections

### DIFF
--- a/.github/workflows/db_sync.yml
+++ b/.github/workflows/db_sync.yml
@@ -18,6 +18,11 @@ on:
           - dev
           - stage
         default: dev
+      branches_in_sync:
+        description: "I confirm that the source and target branches are on the same commit"
+        type: boolean
+        required: true
+        default: false
 
 env:
   BUCKET: ${{ secrets.GCP_DB_SYNC_BUCKET }}
@@ -40,6 +45,7 @@ jobs:
         env:
           SOURCE: ${{ inputs.source }}
           TARGET: ${{ inputs.target }}
+          BRANCHES_IN_SYNC: ${{ inputs.branches_in_sync }}
         run: |
           # Reject prod as target (defense-in-depth against API triggers)
           if [ "$TARGET" = "prod" ]; then
@@ -58,6 +64,11 @@ jobs:
           # Reject same source and target
           if [ "$SOURCE" = "$TARGET" ]; then
             echo "::error::Source and target cannot be the same"
+            exit 1
+          fi
+          # Require confirmation that branches are on the same commit
+          if [ "$BRANCHES_IN_SYNC" != "true" ]; then
+            echo "::error::Please confirm that the source and target branches are on the same commit before running a sync"
             exit 1
           fi
 
@@ -126,6 +137,8 @@ jobs:
             "gs://$BUCKET/db-sync-$RUN_ID.sql.gz" \
             --database="$DATABASE" \
             --project="$PROJECT" \
+            --clean \
+            --if-exists \
             --offload
           echo "Export complete"
 
@@ -139,7 +152,7 @@ jobs:
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ steps.target.outputs.sa }}
 
-      - name: Backup target database before drop
+      - name: Backup target database
         env:
           INSTANCE: ${{ steps.target.outputs.instance }}
           PROJECT: ${{ steps.target.outputs.project }}
@@ -147,27 +160,8 @@ jobs:
           gcloud sql backups create \
             --instance="$INSTANCE" \
             --project="$PROJECT" \
-            --description="db-sync pre-drop backup (run $GITHUB_RUN_ID)"
-          echo "Backup complete — restorable via console or gcloud if import fails"
-
-      - name: Drop target database
-        env:
-          INSTANCE: ${{ steps.target.outputs.instance }}
-          PROJECT: ${{ steps.target.outputs.project }}
-        run: |
-          gcloud sql databases delete "$DATABASE" \
-            --instance="$INSTANCE" \
-            --project="$PROJECT" \
-            --quiet
-
-      - name: Recreate target database
-        env:
-          INSTANCE: ${{ steps.target.outputs.instance }}
-          PROJECT: ${{ steps.target.outputs.project }}
-        run: |
-          gcloud sql databases create "$DATABASE" \
-            --instance="$INSTANCE" \
-            --project="$PROJECT"
+            --description="db-sync pre-import backup (run $GITHUB_RUN_ID)"
+          echo "Backup complete — restorable via console or gcloud if import partially fails"
 
       - name: Import database to target
         env:
@@ -234,3 +228,6 @@ jobs:
           echo "| **Database** | \`$DATABASE\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **CMS media** | \`$CMS_SOURCE\` → \`$CMS_TARGET\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Run ID** | \`$RUN_ID\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> **Note:** Tables that exist in \`$TARGET\` but not in \`$SOURCE\` are not removed by this sync." >> "$GITHUB_STEP_SUMMARY"
+          echo "> If \`$TARGET\` has schema migrations not yet on \`$SOURCE\`, those tables survive with their existing data." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`gcloud sql databases delete` fails with HTTP 400 when read replicas hold open connections. 

This changeset replaces the drop/recreate approach with `--clean --if-exists` on the export, which bakes `DROP IF EXISTS` statements into the DB dump itself. The database is never dropped; existing objects are replaced in-place, leaving any target-only tables (e.g. migrations ahead of prod) untouched. 

To mitigate the risk of orphaned/stray tables linking to replaced tables with different data, we also add a `branches_in_sync` confirmation checkbox to prompt the person triggering the sync to verify that `main`, `stage`, and `prod` are all on the same commit before proceeding, reducing the risk of FK breakage from target-only tables. If they're all on the same commit, then they should all have the same tables, and therefore all the tables on stage or dev should be replaced with content from prod

Part of WT-840

