### PR TITLE
Add new release notes section for Labs

### DIFF
--- a/springfield/firefox/templates/firefox/releases/notes.html
+++ b/springfield/firefox/templates/firefox/releases/notes.html
@@ -495,6 +495,41 @@
                   {% endif %}
                 {% endfor %}
 
+                {% for note in release_notes if note.tag == "Labs" %}
+                  {% if loop.first %}
+                    <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left fl-l-release-notes-with-sidebar" id="{{ note.tag|lower() }}">
+                      <div class="mzp-l-sidebar">
+                        {% if switch('flare26_enabled') %}
+                          {% set tag_heading %}
+                            <span class="fl-c-release-notes-heading">
+                              <include:icon
+                                icon_name="trending"
+                                hidden="true"
+                              />
+                              {{ note.tag }}
+                            </span>
+                          {% endset %}
+                          <include:heading
+                            level="h3"
+                            heading_size="fl-heading-xs"
+                            heading_text="{{ tag_heading | safe }}"
+                          />
+                        {% else %}
+                          <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/labs.svg') }}" width="30" height="30">
+                          <h3>{{ note.tag }}</h3>
+                        {% endif %}
+                      </div>
+                      <div class="mzp-l-main mzp-l-article">
+                        <ul>
+                  {% endif %}
+                  {{ note_entry(note) }}
+                  {% if loop.last %}
+                        </ul>
+                      </div>
+                    </div>
+                  {% endif %}
+                {% endfor %}
+
                 {% for note in release_notes if not note.tag %}
                   {% if loop.first %}
                     <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-right fl-l-release-notes-with-sidebar fl-t-sidebar-end">


### PR DESCRIPTION
## One-line summary

Adds a section between Resolved and Community.

## Significant changes and points to review

Tentative icons used (Flare does not have Labs, Protocol has outdated Labs)

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-930

## Testing

`./manage.py update_release_notes`
http://localhost:8000/en-US/firefox/149.0/releasenotes/#labs