### PR TITLE
add default campaign param to /kit/

### DIFF
--- a/springfield/firefox/templates/firefox/landing/kit.html
+++ b/springfield/firefox/templates/firefox/landing/kit.html
@@ -6,6 +6,7 @@
 
 {% extends "cms/base-flare26.html" %}
 
+{% block html_attrs %}data-stub-attribution-campaign="kit"{% endblock %}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {# Don't forget to set '<title>%s</title>' content when formatting, e.g. per locale from 'icon_title'. #}


### PR DESCRIPTION
this uses new capabilities added by PR 1163.

We will allow this to be over-written if alternate campaign params are used when directing to this page.



## Testing
Can use same testing steps on #1163 