### PR TITLE
Let browser set navbar theme automatically when there's no upper content

### DIFF
--- a/springfield/cms/templates/cms/free_form_page2026.html
+++ b/springfield/cms/templates/cms/free_form_page2026.html
@@ -8,7 +8,7 @@
 
 
 {% block flare_header %}
-  {% set theme = "dark" if page.upper_content else "light" %}
+  {% set theme = "dark" if page.upper_content else None %}
   {% set hide_nav_cta = not page.show_nav_cta %}
   <include:flare26-header theme="{{ theme }}" hide_nav_cta="{{ hide_nav_cta }}" />
 {% endblock %}

--- a/springfield/cms/templates/cms/whats_new_page2026.html
+++ b/springfield/cms/templates/cms/whats_new_page2026.html
@@ -8,7 +8,7 @@
 
 
 {% block flare_header %}
-  {% set theme = "dark" if page.upper_content else "light" %}
+  {% set theme = "dark" if page.upper_content else None %}
   <include:flare26-header theme="{{ theme }}" no_menu disable_sticky/>
 {% endblock %}
 


### PR DESCRIPTION
## One-line summary

This PR fixes the forced light theme on the WPN and Free Form pages when there's no upper content.

![Screenshot 2026-03-19 at 18 14 17](https://github.com/user-attachments/assets/0c46fc9b-ac99-40b1-a2ce-89acf373d385)
