### PR TITLE
fix alignment on kit homepage banner

### DIFF
--- a/springfield/cms/templates/components/kit-banner.html
+++ b/springfield/cms/templates/components/kit-banner.html
@@ -14,7 +14,7 @@
     class="
       fl-banner fl-banner-kit fl-force-dark-theme
       {% if contents.animation %}fl-banner-kit-animation{% elif theme %}fl-banner-kit-{{ theme }}{% endif %}
-      {% if theme and theme != 'small' %}align-start-on-desktop{% else %}align-center-on-desktop{% endif %}"
+      {% if theme and theme != 'small' and theme != 'diving-in' %}align-start-on-desktop{% else %}align-center-on-desktop{% endif %}"
     aria-labelledby="fl-banner-heading"
     >
     {% if qr_code and qr_code.strip() %}


### PR DESCRIPTION
Fix for this problem: 

<img width="1910" height="901" alt="image" src="https://github.com/user-attachments/assets/561acfbf-ac99-41f0-a0f1-de229c7e6a92" />
