### PR TITLE
Display top notes_pagination only for public releases

### DIFF
--- a/springfield/firefox/templates/firefox/releases/notes.html
+++ b/springfield/firefox/templates/firefox/releases/notes.html
@@ -237,9 +237,11 @@
               {% endblock %}
             {% endif %}
 
-            {% with location = 'top' %}
-              {% include "firefox/releases/partials/notes_pagination.html" %}
-            {% endwith %}
+            {% if release.is_public %}
+              {% with location = 'top' %}
+                {% include "firefox/releases/partials/notes_pagination.html" %}
+              {% endwith %}
+            {% endif %}
 
             <section class="c-release-notes fl-c-release-notes-content fl-l-release-notes-wrapper">
               {% if release.is_public and release_notes %}


### PR DESCRIPTION
## One-line summary

Display the previous relnotes reference at the top of the page only for public releases. If the release isn't published yet, there's no content, and the bottom reference is sufficient alone.

## Issue / Bugzilla link

Resolves #1184.