### PR TITLE
chore(transcend): updated script tag attributes to safeguard prelaunch status

### DIFF
--- a/springfield/base/templates/includes/transcend-consent.html
+++ b/springfield/base/templates/includes/transcend-consent.html
@@ -6,5 +6,5 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {# Transcend Consent Management - https://docs.transcend.io/docs/consent #}
 {% if settings.TRANSCEND_AIRGAP_URL and switch('transcend-consent') %}
-<script data-cfasync="false" src="{{ settings.TRANSCEND_AIRGAP_URL }}"></script>
+<script data-cfasync="false" data-report-only="on" data-prompt="0" src="{{ settings.TRANSCEND_AIRGAP_URL }}"></script>
 {% endif %}


### PR DESCRIPTION
## One-line summary
Add `data-report-only` and `data-prompt` attributes to the Transcend consent script tag for prelaunch safeguarding.

## Significant changes and points to review
Added `data-report-only="on"` to the Transcend airgap script tag, which puts consent tracking in report-only mode.
Added `data-prompt="0"` to suppress the consent prompt UI from appearing to users.

## Testing
Verified locally that the script tag renders with the new attributes and site does not pop a consent banner. 