### PR TITLE
Fixup firefox-default test spec

### DIFF
--- a/tests/playwright/specs/products/firefox/firefox-default.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-default.spec.js
@@ -28,9 +28,9 @@ test.describe(
                 waitUntil: 'commit'
             });
 
-            const downloadButton = page.getByTestId(
-                'download-firefox-button__download-link'
-            );
+            const downloadButton = page
+                .locator('.thanks-state-not-firefox')
+                .getByTestId('download-firefox-button__download-link');
             const defaultMessaging = page.getByTestId(
                 'firefox-not-default-message'
             );


### PR DESCRIPTION
## One-line summary

Resolves integration test failure after page changes.

## Significant changes and points to review

[/actions/runs/23623750970/](https://github.com/mozmeao/springfield/actions/runs/23623750970/job/68808367755#step:5:320) ❌

The component introduced a different testID, and in this case does not expose platform CTAs directly, so there's only one generic (plus more with the same testID currently in the header and elsewhere; so needs an extra selector with it — feel free to ticket up investigation followup in case multiple elements with the same testID is unfavorable).

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/pull/1195#pullrequestreview-4023921676

## Testing

[`@janbrasna/springfield`/actions/runs/23669905245](https://github.com/janbrasna/springfield/actions/runs/23669905245/job/68960879956#step:5:16) ✅