### PR TITLE
Add data-stub-attribution-campaign-force to clear cookie and re-attri…

### DIFF
--- a/media/js/base/stub-attribution/stub-attribution.js
+++ b/media/js/base/stub-attribution/stub-attribution.js
@@ -521,6 +521,9 @@ if (typeof window.Mozilla === 'undefined') {
             ? null
             : StubAttribution.getGtagClientID();
 
+        var campaignForce = document.documentElement.getAttribute(
+            'data-stub-attribution-campaign-force'
+        );
         var campaignOverride = document.documentElement.getAttribute(
             'data-stub-attribution-campaign-override'
         );
@@ -529,7 +532,10 @@ if (typeof window.Mozilla === 'undefined') {
         );
         var utmCampaign;
 
-        if (campaignOverride !== null) {
+        if (campaignForce !== null) {
+            // Force always wins and clears existing cookie
+            utmCampaign = campaignForce;
+        } else if (campaignOverride !== null) {
             // Explicit override via data attribute
             utmCampaign = campaignOverride;
         } else if (
@@ -692,6 +698,19 @@ if (typeof window.Mozilla === 'undefined') {
 
         if (typeof timeoutCallback === 'function') {
             StubAttribution.timeoutCallback = timeoutCallback;
+        }
+
+        /**
+         * If the page forces a campaign value, invalidate any
+         * existing cookie so the forced value is picked up.
+         */
+        if (
+            StubAttribution.hasCookie() &&
+            document.documentElement.getAttribute(
+                'data-stub-attribution-campaign-force'
+            )
+        ) {
+            StubAttribution.removeCookie();
         }
 
         /**

--- a/tests/unit/spec/base/stub-attribution/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution/stub-attribution.js
@@ -80,6 +80,50 @@ describe('stub-attribution.js', function () {
             ).toHaveBeenCalledWith(cookieData);
         });
 
+        it('should invalidate cookie and re-request when data-stub-attribution-campaign-force is set', function () {
+            const html = document.documentElement;
+            html.setAttribute(
+                'data-stub-attribution-campaign-force',
+                'forced_campaign'
+            );
+
+            spyOn(
+                Mozilla.StubAttribution,
+                'withinAttributionRate'
+            ).and.returnValue(true);
+            spyOn(Mozilla.StubAttribution, 'meetsRequirements').and.returnValue(
+                true
+            );
+            spyOn(Mozilla.StubAttribution, 'hasValidData').and.returnValue(
+                true
+            );
+            spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValues(
+                true,
+                false
+            );
+            spyOn(Mozilla.StubAttribution, 'removeCookie');
+            spyOn(
+                Mozilla.StubAttribution,
+                'isFirefoxDownloadThanks'
+            ).and.returnValue(false);
+            spyOn(
+                Mozilla.StubAttribution,
+                'getAttributionData'
+            ).and.returnValue(data);
+
+            Mozilla.StubAttribution.init();
+
+            expect(Mozilla.StubAttribution.removeCookie).toHaveBeenCalled();
+            expect(
+                Mozilla.StubAttribution.checkDataAndRequestAuth
+            ).toHaveBeenCalled();
+            expect(
+                Mozilla.StubAttribution.updateBouncerLinks
+            ).not.toHaveBeenCalled();
+
+            html.removeAttribute('data-stub-attribution-campaign-force');
+        });
+
         it('should authenticate attribution data if no session cookie exists', function () {
             spyOn(
                 Mozilla.StubAttribution,
@@ -782,6 +826,12 @@ describe('stub-attribution.js', function () {
             document.documentElement.removeAttribute(
                 'data-stub-attribution-campaign'
             );
+            document.documentElement.removeAttribute(
+                'data-stub-attribution-campaign-override'
+            );
+            document.documentElement.removeAttribute(
+                'data-stub-attribution-campaign-force'
+            );
         });
 
         it('should use data-stub-attribution-campaign as fallback when utm_campaign is not in URL params', function () {
@@ -966,6 +1016,83 @@ describe('stub-attribution.js', function () {
 
             html.removeAttribute('data-stub-attribution-campaign-override');
             html.removeAttribute('data-stub-attribution-campaign');
+        });
+
+        it('should use data-stub-attribution-campaign-force over utm_campaign from URL params', function () {
+            const html = document.documentElement;
+            html.setAttribute(
+                'data-stub-attribution-campaign-force',
+                'forced_campaign'
+            );
+
+            const referrer = '';
+
+            const utms = {
+                utm_source: 'desktop-snippet',
+                utm_medium: 'referral',
+                utm_campaign: 'F100_4242_otherstuff_in_here',
+                utm_content: 'rel-esr'
+            };
+
+            const data = {
+                utm_source: 'desktop-snippet',
+                utm_medium: 'referral',
+                utm_campaign: 'forced_campaign',
+                utm_content: 'rel-esr',
+                referrer: '',
+                ua: 'chrome',
+                client_id_ga4: GA4_CLIENT_ID,
+                session_id: jasmine.any(String),
+                dlsource: DLSOURCE
+            };
+
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue(
+                utms
+            );
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue(
+                'chrome'
+            );
+            const result = Mozilla.StubAttribution.getAttributionData(referrer);
+            expect(result).toEqual(data);
+        });
+
+        it('should use data-stub-attribution-campaign-force over data-stub-attribution-campaign-override', function () {
+            const html = document.documentElement;
+            html.setAttribute(
+                'data-stub-attribution-campaign-force',
+                'forced_campaign'
+            );
+            html.setAttribute(
+                'data-stub-attribution-campaign-override',
+                'override_campaign'
+            );
+
+            const referrer = '';
+
+            const utms = {
+                utm_source: undefined,
+                utm_medium: undefined,
+                utm_campaign: undefined,
+                utm_content: undefined
+            };
+
+            const data = {
+                utm_campaign: 'forced_campaign',
+                referrer: '',
+                ua: 'chrome',
+                client_id_ga4: GA4_CLIENT_ID,
+                session_id: jasmine.any(String),
+                dlsource: DLSOURCE
+            };
+
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue(
+                utms
+            );
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue(
+                'chrome'
+            );
+            const result = Mozilla.StubAttribution.getAttributionData(referrer);
+            expect(result).toEqual(data);
         });
 
         it('should not include campaign when neither URL param nor data attribute is set', function () {


### PR DESCRIPTION
Introduces a third data attribute option for stub attribution campaign control.

When data-stub-attribution-campaign-force is set on a page, any existing attribution cookie is invalidated and a fresh attribution request is made, ensuring the forced campaign value is always captured, even if the user visited another page first.

The three tiers are now:
- data-stub-attribution-campaign: fallback when no utm_campaign in URL
- data-stub-attribution-campaign-override: wins over URL params, respects cookie
- data-stub-attribution-campaign-force: wins over URL params AND clears cookie


