### PR TITLE
fixing superheading for homepage.

### DIFF
--- a/media/css/cms/flare26-intro.css
+++ b/media/css/cms/flare26-intro.css
@@ -153,6 +153,7 @@
 }
 
 .fl-home-intro .fl-superheading {
+    align-items: center;
     background: linear-gradient(
         180deg,
         var(--token-color-light-purple-40) 0%,
@@ -160,7 +161,6 @@
     );
     border-radius: var(--token-border-radius-xl);
     display: inline-flex;
-    align-items: center;
     font-size: var(--fl-theme-font-size-body-2xs);
     font-weight: var(--token-font-weight-medium);
     margin: 0;


### PR DESCRIPTION
Fixes for superheading when pill UI is used:

- vertical alignment
- right side of Pill

Before:
<img width="291" height="121" alt="image" src="https://github.com/user-attachments/assets/c8a33148-3952-41af-a995-0d0b818dd2c4" />

After:
<img width="287" height="110" alt="image" src="https://github.com/user-attachments/assets/e6d5ba26-a29b-410d-8aad-104b54845549" />
