### PR TITLE
Revert "Add redirects for mobile pages"

### DIFF
--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -118,10 +118,6 @@ refresh_redirects = (
     redirect(r"^browsers/mobile/android/$", "/download/android/", permanent=permanent),
     redirect(r"^browsers/mobile/ios/$", "/download/ios/", permanent=permanent),
     redirect(r"^browsers/desktop/chromebook/$", "/download/chromebook/", permanent=permanent),
-    redirect(r"^browsers/unsupported-systems/$", "/download/unsupported-systems/", permanent=permanent),
-    redirect(r"^browsers/mobile/$", "/mobile/", permanent=permanent),
-    redirect(r"^browsers/mobile/focus/$", "/mobile/focus/", permanent=permanent),
-    redirect(r"^browsers/mobile/get-app/$", "/mobile/", permanent=permanent),
 )
 
 if settings.ENABLE_CMS_REFRESH_REDIRECTS:

--- a/springfield/firefox/urls.py
+++ b/springfield/firefox/urls.py
@@ -104,6 +104,17 @@ urlpatterns = (
     page("landing/set-as-default/", "firefox/default/landing.html", ftl_files="firefox/set-as-default/landing"),
     page("analytics-tests/", "firefox/analytics-tests/ga-index.html"),
     page("browsers/desktop/", "firefox/browsers/desktop/index.html", ftl_files=["firefox/browsers"]),
+    path(
+        "browsers/mobile/",
+        prefer_cms(
+            views.MobileBrowsersView.as_view(),
+            fallback_ftl_files=["firefox/browsers/mobile/index"],
+        ),
+        name="firefox.browsers.mobile",
+    ),
+    page("browsers/mobile/focus/", "firefox/browsers/mobile/focus.html", ftl_files=["firefox/browsers/mobile/focus"]),
+    page("browsers/mobile/get-app/", "firefox/browsers/mobile/get-app.html", ftl_files=["firefox/browsers/mobile/get-app"]),
+    page("browsers/unsupported-systems/", "firefox/unsupported-systems.html"),
     # Privacy-focused download experiment: https://github.com/mozmeao/springfield/pull/919/
     path(
         "landing/get/",
@@ -225,19 +236,6 @@ if settings.ENABLE_CMS_REFRESH_REDIRECTS:
         path("download/linux/", prefer_cms(views.PlatformViewLinux.as_view()), name="firefox.browsers.desktop.linux"),
         path("download/mac/", prefer_cms(views.PlatformViewMac.as_view()), name="firefox.browsers.desktop.mac"),
         path("download/windows/", prefer_cms(views.PlatformViewWindows.as_view()), name="firefox.browsers.desktop.windows"),
-        path("download/unsupported-systems/", prefer_cms(L10nTemplateView.as_view(template_name="firefox/unsupported-systems.html"))),
-        path(
-            "mobile/",
-            prefer_cms(
-                views.MobileBrowsersView.as_view(),
-                fallback_ftl_files=["firefox/browsers/mobile/index"],
-            ),
-            name="firefox.browsers.mobile",
-        ),
-        path(
-            "mobile/focus/",
-            prefer_cms(L10nTemplateView.as_view(template_name="firefox/browsers/mobile/focus.html", ftl_files=["firefox/browsers/mobile/focus"])),
-        ),
     )
 else:
     urlpatterns += (
@@ -248,15 +246,4 @@ else:
         path("browsers/desktop/mac/", views.PlatformViewMac.as_view(), name="firefox.browsers.desktop.mac"),
         path("browsers/desktop/windows/", views.PlatformViewWindows.as_view(), name="firefox.browsers.desktop.windows"),
         page("browsers/desktop/chromebook/", "firefox/browsers/desktop/chromebook.html", ftl_files="firefox/browsers/desktop/chromebook"),
-        page("browsers/unsupported-systems/", "firefox/unsupported-systems.html"),
-        path(
-            "browsers/mobile/",
-            prefer_cms(
-                views.MobileBrowsersView.as_view(),
-                fallback_ftl_files=["firefox/browsers/mobile/index"],
-            ),
-            name="firefox.browsers.mobile",
-        ),
-        page("browsers/mobile/focus/", "firefox/browsers/mobile/focus.html", ftl_files=["firefox/browsers/mobile/focus"]),
-        page("browsers/mobile/get-app/", "firefox/browsers/mobile/get-app.html", ftl_files=["firefox/browsers/mobile/get-app"]),
     )


### PR DESCRIPTION
Reverts mozmeao/springfield#1216 until we can fix the integration tests and deal with any possibly problematic `reverse` / `url()` lookups