### PR TITLE
Include Locale In 'Get Firefox' and 'Download Firefox' Links

### DIFF
--- a/springfield/base/templates/includes/navigation/nav-cta.html
+++ b/springfield/base/templates/includes/navigation/nav-cta.html
@@ -6,7 +6,7 @@
 
 {% if not custom_nav_cta %}
   <div class="nav-cta-wrap {% if hide_nav_cta %}hide-cta-on-desktop{% endif %} {% if hide_nav_download_button %}hide-nav-download-on-desktop{% endif %}">
-    {{ download_firefox_thanks(alt_copy=ftl('navigation-download'), dom_id='nav-download-firefox', button_class='mzp-t-product mzp-t-xl', download_location='nav') }}
+    {{ download_firefox_thanks(alt_copy=ftl('navigation-download'), dom_id='nav-download-firefox', button_class='mzp-t-product mzp-t-xl', download_location='nav', locale_in_transition=True) }}
   </div>
 {% else %}
   {{ custom_nav_cta }}

--- a/springfield/cms/templates/components/download-firefox-button.html
+++ b/springfield/cms/templates/components/download-firefox-button.html
@@ -6,7 +6,7 @@
 
 {% from "macros.html" import google_play_button, apple_app_store_button with context %}
 
-{% set download_firefox_thanks_link = download_firefox_thanks_link() %}
+{% set download_firefox_thanks_link = download_firefox_thanks_link(locale_in_transition=True) %}
 
 {#
   Required selector for Stub Attribution: '.c-button-download-thanks > .download-link'

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -189,16 +189,17 @@ def assert_download_button_attributes(
     icon_position = settings["icon_position"]
     analytics_id = settings["analytics_id"]
 
+    locale = get_locale(context["request"])
+
     assert label in button_element.get_text()
     assert "download-link" in button_element["class"]
-    assert button_element["href"] == "/thanks/"
+    assert button_element["href"] == f"/{locale}/thanks/"
 
     assert "c-button-download-thanks" in button_element.parent["class"]
     assert button_data["value"]["settings"]["analytics_id"] == button_element.parent["id"]
 
     channel = "release"
     version = firefox_desktop.latest_version(channel)
-    locale = get_locale(context["request"])
     download_link_direct = firefox_desktop.get_download_url(
         channel=channel,
         version=version,
@@ -2036,7 +2037,8 @@ def test_home_pre_footer_cta(index_page, rf):
 
     # data might be pointing the link to a different host,
     # so we only validate the remainder
-    assert strip_host(link_element["href"]) == "/thanks/"
+    locale = get_locale(request)
+    assert strip_host(link_element["href"]) == f"/{locale}/thanks/"
     assert link_element["data-cta-position"] == "pre-footer-cta"
     assert link_element["data-cta-text"] == pre_footer_cta.label.strip()
     assert link_element["data-cta-uid"] == pre_footer_cta.analytics_id


### PR DESCRIPTION
## One-line summary
The 'Get Firefox' and 'Download Firefox' links should now have the current page's locale.

## Significant changes and points to review
We now pass `locale_in_transition=True` to `download_firefox_thanks` and `download_firefox_thanks_link` in the following files:
 - `springfield/base/templates/includes/navigation/nav-cta.html`
 - `springfield/cms/templates/components/download-firefox-button.html`


## Issue / Bugzilla link
Previously, links on pages would point the user to the page in the locale of the current page, except for the 'Get Firefox' and 'Download Firefox' links.


## Testing
load the homepage  (or any other page) in a locale different from your browser's locale, and observe that all links take you to a page in the current page's locale. For example (assuming your browser's locale is not es-MX),
1. load http://localhost:8000/es-MX/, and observe that the navbar link "Caracteristicas" goes to  http://localhost:8000/es-MX/features/. 
2. observe that the "Obtener Firefox" button goes to  http://localhost:8000/es-MX/thanks/
3. observe that the "Descarga Firefox" button goes to  http://localhost:8000/es-MX/thanks/