### PR TITLE
WT-851 Update navigation state correctly on click

### DIFF
--- a/media/js/cms/flare-navigation.es6.js
+++ b/media/js/cms/flare-navigation.es6.js
@@ -81,18 +81,14 @@ import Headroom from 'headroom.js';
 
     // keyboard is being used
     menuTitles.forEach(function (title) {
-        // when focusing a menu title, close all menus
-        title.addEventListener('focus', function () {
-            menuCategories.forEach(function (category) {
-                category.classList.remove('is-active');
-            });
-        });
-
-        // when leaving the last link of a menu, close all menus
         const menuLinks = title
             .closest('.fl-menu-category')
             .querySelectorAll('a');
 
+        // focus events are no good here as we mix in a click handler below
+        // which is also triggered after our focus would run
+
+        // when leaving the last link of a menu, close all menus
         menuLinks[menuLinks.length - 1].addEventListener(
             'keydown',
             function (event) {
@@ -103,6 +99,15 @@ import Headroom from 'headroom.js';
                 }
             }
         );
+
+        // when leaving the first link of a menu, close all menus
+        menuLinks[0].addEventListener('keydown', function (event) {
+            if (event.key === 'Tab' && event.shiftKey) {
+                menuCategories.forEach(function (category) {
+                    category.classList.remove('is-active');
+                });
+            }
+        });
 
         // when clicking or pressing enter, toggle the menu
         title.addEventListener('click', function (event) {

--- a/media/js/cms/flare-navigation.es6.js
+++ b/media/js/cms/flare-navigation.es6.js
@@ -78,17 +78,25 @@ import Headroom from 'headroom.js';
     });
 
     const menuTitles = document.querySelectorAll('.fl-menu-title');
+    let focusedMenu = null;
 
     // keyboard is being used
     menuTitles.forEach(function (title) {
+        // when focusing a menu title, close all menus
+        title.addEventListener('focus', function () {
+            menuCategories.forEach(function (category) {
+                if (category.classList.contains('is-active')) {
+                    focusedMenu = category;
+                }
+                category.classList.remove('is-active');
+            });
+        });
+
+        // when leaving the last link of a menu, close all menus
         const menuLinks = title
             .closest('.fl-menu-category')
             .querySelectorAll('a');
 
-        // focus events are no good here as we mix in a click handler below
-        // which is also triggered after our focus would run
-
-        // when leaving the last link of a menu, close all menus
         menuLinks[menuLinks.length - 1].addEventListener(
             'keydown',
             function (event) {
@@ -100,20 +108,18 @@ import Headroom from 'headroom.js';
             }
         );
 
-        // when leaving the first link of a menu, close all menus
-        menuLinks[0].addEventListener('keydown', function (event) {
-            if (event.key === 'Tab' && event.shiftKey) {
-                menuCategories.forEach(function (category) {
-                    category.classList.remove('is-active');
-                });
-            }
-        });
-
         // when clicking or pressing enter, toggle the menu
         title.addEventListener('click', function (event) {
             event.preventDefault();
 
             const menuPanel = event.target.closest('.fl-menu-category');
+
+            // focus runs first then click. if we click a menu that was closed
+            // by focus don't open it again immediately
+            if (focusedMenu === menuPanel) {
+                focusedMenu = null;
+                return;
+            }
 
             if (menuPanel.classList.contains('is-active')) {
                 menuPanel.classList.remove('is-active');


### PR DESCRIPTION
## One-line summary
The navigation bar closes and opens the panel when clicked instead of just closing. This is because is contains a focus handler as well as a click handler which both run when clicked.

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-851

## Testing
- [x] Checkout this PR
- [x] Hover over an item in the navigation (Browser) ensuring the drop down appears
- [x] Move around each title ensuring the menus appear and disappear correctly
- [x] Tab into a menu and hit enter. The panel should appear.
- [x] Tab into the next panel. The previous panel should disappear
- [x] Tab out of the final panel (Resources). The menu should disappear
- [x] Shift+Tab out out of the first panel (Browser). The menu should disappear