### PR TITLE
WT-823 hide current platform as a download option

### DIFF
--- a/springfield/cms/templates/cms/download_page.html
+++ b/springfield/cms/templates/cms/download_page.html
@@ -37,11 +37,13 @@
         </button>
         <ul class="fl-platform-dropdown-list" aria-role="listbox">
           {% for key, platform in platforms.items() %}
-            <li class="fl-dropdown-item" data-platform="{{ key }}" {% if key == page.platform %}aria-selected="true"{% endif %}>
-              <a class="fl-heading-md fl-heading-condensed-on-sm-up" href="{{ platform_links[key] }}">
-                {{ platform }}
-              </a>
-            </li>
+            {% if key != page.platform %}
+              <li class="fl-dropdown-item" data-platform="{{ key }}" {% if key == page.platform %}aria-selected="true"{% endif %}>
+                <a class="fl-heading-md fl-heading-condensed-on-sm-up" href="{{ platform_links[key] }}">
+                  {{ platform }}
+                </a>
+              </li>
+            {% endif %}
           {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
## One-line summary

This PR removes the current platform as a dropdown option.

## Significant changes and points to review

Dropdown list on download/{platform}

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-823

## Testing

http://localhost:8000/en-US/download/windows/
http://localhost:8000/en-US/download/mac/
http://localhost:8000/en-US/download/linux/
https://www.firefox.com/en-US/download/android/
https://www.firefox.com/en-US/download/ios/
https://www.firefox.com/en-US/download/chromebook/