### PR TITLE
Make Sure Page References In Blocks Match Locale Of Page

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -24,6 +27,9 @@ from lib.l10n_utils.fluent import ftl
 from springfield.base.i18n import normalize_language, split_path_and_normalize_language
 from springfield.cms.models.locale import SpringfieldLocale
 from springfield.cms.views import wagtail_serve_with_locale_fallback
+
+if TYPE_CHECKING:
+    from springfield.cms.models import ArticleDetailPage, ArticleThemePage, SpringfieldImage
 
 HEADING_TEXT_FEATURES = [
     "bold",
@@ -1631,7 +1637,7 @@ class BaseArticleOverridesBlock(blocks.StructBlock):
 
 
 class BaseArticleValue(blocks.StructValue):
-    def get_article(self):
+    def get_article(self) -> ArticleDetailPage | ArticleThemePage:
         return self["article"].specific.localized
 
     def get_title(self) -> str:
@@ -1663,7 +1669,7 @@ class BaseArticleValue(blocks.StructValue):
         article_page = self.get_article()
         if article_page:
             article_page = article_page.specific
-            if tag := article_page.get_tag():
+            if hasattr(article_page, "get_tag") and (tag := article_page.get_tag()):
                 return tag.name
         return ""
 
@@ -1678,7 +1684,7 @@ class BaseArticleValue(blocks.StructValue):
                 return article_page.link_text
         return ftl("ui-learn-more", ftl_files=["ui"])
 
-    def get_featured_image(self):
+    def get_featured_image(self) -> SpringfieldImage | None:
         overrides = self.get("overrides", {})
         if image := overrides.get("image"):
             return image
@@ -1689,7 +1695,7 @@ class BaseArticleValue(blocks.StructValue):
                 return article_page.featured_image
         return None
 
-    def get_sticker(self):
+    def get_sticker(self) -> SpringfieldImage | None:
         overrides = self.get("overrides", {})
         if sticker := overrides.get("sticker"):
             return sticker
@@ -1717,8 +1723,9 @@ class BaseArticleValue(blocks.StructValue):
             url = link.get_url()
             if url:
                 return url
+
         article_page = self.get_article()
-        return article_page.url if article_page else ""
+        return article_page.get_fallback_url() if article_page else ""
 
 
 class ArticleBlock(blocks.StructBlock):

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1632,7 +1632,7 @@ class BaseArticleOverridesBlock(blocks.StructBlock):
 
 class BaseArticleValue(blocks.StructValue):
     def get_article(self):
-        return self["article"].localized
+        return self["article"].specific.localized
 
     def get_title(self) -> str:
         from springfield.cms.templatetags.cms_tags import remove_p_tag

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1725,7 +1725,7 @@ class BaseArticleValue(blocks.StructValue):
                 return url
 
         article_page = self.get_article()
-        return article_page.get_fallback_url() if article_page else ""
+        return article_page.get_active_locale_url() if article_page else ""
 
 
 class ArticleBlock(blocks.StructBlock):

--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -154,6 +154,27 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
 
         return localized
 
+    def get_fallback_url(self, request=None):
+        """
+        Replace the URLs locale with the active locale if the page is a fallback
+        so that the user doesn't navigate away from it's preferred language.
+
+        If the active locale is an alias (e.g. pt-PT → pt-BR) and the page is in the
+        fallback locale (e.g. pt-BR), return a URL with the alias locale (e.g. pt-PT).
+        host/pt-BR/page/ → host/pt-PT/page/
+        """
+        url = super().get_url(request)
+
+        active_language = normalize_language(translation.get_language())
+        fallback_locales = getattr(settings, "FALLBACK_LOCALES", {})
+
+        if active_language in fallback_locales:
+            fallback_code = fallback_locales[active_language]
+            if self.locale.language_code == fallback_code:
+                url = url.replace(f"/{fallback_code}/", f"/{active_language}/", 1)
+
+        return url
+
     @property
     def og_title(self):
         return self.seo_title or self.title or "Firefox"

--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -136,6 +136,10 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
         localized = super().localized
 
         lang_code = normalize_language(translation.get_language())
+
+        if localized.locale.language_code == lang_code:
+            return localized
+
         fallback_locales = getattr(settings, "FALLBACK_LOCALES", {})
         if lang_code in fallback_locales:
             fallback_code = fallback_locales[lang_code]

--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -4,15 +4,17 @@
 
 from django.conf import settings
 from django.db import models
+from django.utils import translation
 from django.utils.cache import add_never_cache_headers
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 
 from wagtail.admin.panels import FieldPanel
-from wagtail.models import Page as WagtailBasePage
+from wagtail.models import Locale, Page as WagtailBasePage
 from wagtail_localize.fields import SynchronizedField
 
 from lib import l10n_utils
+from springfield.base.i18n import normalize_language
 from springfield.cms.utils import compute_cms_page_locales
 
 
@@ -121,6 +123,32 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
         request = self._patch_request_for_springfield(request)
         request.is_preview = True
         return self._render_with_fluent_string_support(request, *args, **kwargs)
+
+    @property
+    def localized(self):
+        """
+        Extends Wagtail's localized to handle alias locales in FALLBACK_LOCALES.
+
+        When the active locale is an alias (e.g. pt-PT → pt-BR) and the page has
+        no translation in that alias locale, returns the fallback locale's translation
+        instead of the source-locale original.
+        """
+        localized = super().localized
+
+        lang_code = normalize_language(translation.get_language())
+        fallback_locales = getattr(settings, "FALLBACK_LOCALES", {})
+        if lang_code in fallback_locales:
+            fallback_code = fallback_locales[lang_code]
+            try:
+                fallback_locale = Locale.objects.get(language_code=fallback_code)
+                if localized.locale_id != fallback_locale.id:
+                    fallback_page = self.get_translation_or_none(fallback_locale)
+                    if fallback_page:
+                        return fallback_page
+            except Locale.DoesNotExist:
+                pass
+
+        return localized
 
     @property
     def og_title(self):

--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -154,7 +154,7 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
 
         return localized
 
-    def get_fallback_url(self, request=None):
+    def get_active_locale_url(self, request=None):
         """
         Replace the URLs locale with the active locale if the page is a fallback
         so that the user doesn't navigate away from it's preferred language.

--- a/springfield/cms/models/locale.py
+++ b/springfield/cms/models/locale.py
@@ -47,11 +47,20 @@ class SpringfieldLocale(WagtailLocale):
                 logger.warning(f"[SpringfieldLocale.get_active] Normalization returned None, using original: {language_code}")
                 return cls.objects.get(language_code=language_code)
         except cls.DoesNotExist:
-            # Fall back to default locale
             from django.conf import settings
 
-            logger.warning(
-                f"[SpringfieldLocale.get_active] Locale not found for '{normalized_code or language_code}', "
-                f"falling back to default: {settings.LANGUAGE_CODE}"
-            )
+            code = normalized_code or language_code
+            # Before falling back all the way to the default locale, check if
+            # this language code has a configured fallback (e.g. pt-PT → pt-BR).
+            # This ensures that page.localized resolves to the fallback locale's
+            # pages rather than the en-US originals when the alias locale has no
+            # Locale DB record.
+            fallback_locales = getattr(settings, "FALLBACK_LOCALES", {})
+            if code in fallback_locales:
+                try:
+                    return cls.objects.get(language_code=fallback_locales[code])
+                except cls.DoesNotExist:
+                    pass
+
+            logger.warning(f"[SpringfieldLocale.get_active] Locale not found for '{code}', falling back to default: {settings.LANGUAGE_CODE}")
             return cls.objects.get(language_code=settings.LANGUAGE_CODE)

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -44,6 +48,10 @@ from springfield.cms.blocks import (
 from springfield.cms.fields import StreamField
 
 from .base import AbstractSpringfieldCMSPage
+
+if TYPE_CHECKING:
+    from springfield.cms.models import Tag
+
 
 BASE_UTM_PARAMETERS = {
     "utm_source": "www.firefox.com",
@@ -600,7 +608,10 @@ class ArticleDetailPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
         FieldPanel("related_articles"),
     ]
 
-    def get_tag(self):
+    if TYPE_CHECKING:
+        tag: Tag | None
+
+    def get_tag(self) -> Tag | None:
         if self.tag:
             return self.tag.get_localized()
         return None

--- a/springfield/cms/models/snippets.py
+++ b/springfield/cms/models/snippets.py
@@ -55,11 +55,24 @@ class BaseDraftTranslatableSnippetMixin(TranslatableMixin, DraftStateMixin, Revi
         return SpringfieldLocale.get_active()
 
     def get_localized(self):
-        """Get the localized instance of this snippet for the active locale, or None if not available in the active locale."""
-        instance = self.localized
-        if instance and (instance.locale_id != self.active_locale.id or not instance.live):
-            return None
-        return instance
+        """Get the localized instance of this snippet for the active locale or for the fallback locale,
+        or None if not available in the active locale."""
+        localized = self.localized
+
+        active_lang_code = self.active_locale.language_code
+
+        if localized.locale.language_code != active_lang_code:
+            fallback_locales = getattr(settings, "FALLBACK_LOCALES", {})
+            if fallback_code := fallback_locales.get(active_lang_code):
+                if fallback_locale := SpringfieldLocale.objects.filter(language_code=fallback_code).first():
+                    if fallback_snippet := self.get_translation_or_none(fallback_locale):
+                        localized = fallback_snippet
+            else:
+                return None
+
+        if localized.live:
+            return localized
+        return None
 
 
 class PreFooterCTASnippet(FluentPreviewableMixin, BaseDraftTranslatableSnippetMixin, models.Model):

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -13,10 +13,10 @@ from bs4 import BeautifulSoup
 from wagtail.blocks import StreamBlockValidationError
 from wagtail.documents.models import Document
 from wagtail.images.jinja2tags import image, srcset_image
-from wagtail.models import Locale, Page
+from wagtail.models import Locale, Page, Site
 
 from lib.l10n_utils import get_locale
-from springfield.cms.blocks import SpringfieldLinkBlock
+from springfield.cms.blocks import ArticleBlock, BaseArticleValue, SpringfieldLinkBlock
 from springfield.cms.fixtures.article_page_fixtures import (
     get_article_pages,
     get_article_theme_hub_page,
@@ -93,7 +93,7 @@ from springfield.cms.fixtures.topic_list_fixtures import get_topic_list_2026_tes
 from springfield.cms.models import ArticleDetailPage, SpringfieldImage
 from springfield.cms.models.locale import SpringfieldLocale
 from springfield.cms.templatetags.cms_tags import add_utm_parameters
-from springfield.cms.tests.factories import LocaleFactory
+from springfield.cms.tests.factories import ArticleDetailPageFactory, LocaleFactory
 from springfield.firefox.firefox_details import firefox_desktop
 from springfield.firefox.templatetags.misc import app_store_url, fxa_button, play_store_url
 
@@ -3530,3 +3530,53 @@ def test_uuid_block_is_not_translatable():
     from springfield.cms.blocks import UUIDBlock
 
     assert UUIDBlock().get_translatable_segments("cfdf0d2c-7eee-49c2-8747-80450e22dbdd") == []
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_base_article_value_get_article_returns_fallback_translation_via_multi_target_page_chooser():
+    """
+    get_article() must return the fallback locale's translation even when the
+    article chooser returns a base Page instance (not the specific type).
+
+    ArticleBlock uses target_model=("cms.ArticleDetailPage", "cms.ArticleThemePage").
+    Wagtail returns a base Page instance for multi-target choosers, so
+    self["article"].localized calls Page.localized (Wagtail's implementation),
+    which does not know about our AbstractSpringfieldCMSPage.localized override.
+    The fix is self["article"].specific.localized, which routes through our override.
+
+    This test reproduces the production bug: without .specific, get_article()
+    returns the en-US source page for pt-PT requests even when a pt-BR
+    translation exists.
+    """
+
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    _pt_pt_locale = LocaleFactory(language_code="pt-PT")
+
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+    root_page.copy_for_translation(pt_br_locale)
+
+    en_us_article = ArticleDetailPageFactory(
+        title="en-US Article",
+        slug="en-us-article-chooser-test",
+        parent=root_page,
+    )
+    pt_br_article = en_us_article.copy_for_translation(pt_br_locale)
+    pt_br_article.title = "pt-BR Article"
+    pt_br_article.save_revision().publish()
+
+    # Simulate what Wagtail's multi-target PageChooserBlock returns: a base Page
+    # instance, not ArticleDetailPage. This is the root cause of the production bug.
+    article_as_base_page = Page.objects.get(pk=en_us_article.pk)
+    assert type(article_as_base_page) is Page, "Precondition: must be base Page, not specific subclass"
+
+    article_value = BaseArticleValue(
+        ArticleBlock(),
+        {"article": article_as_base_page, "overrides": {}},
+    )
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        result = article_value.get_article()
+
+    assert result.id == pt_br_article.id
+    assert result.locale == pt_br_locale

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -3580,3 +3580,38 @@ def test_base_article_value_get_article_returns_fallback_translation_via_multi_t
 
     assert result.id == pt_br_article.id
     assert result.locale == pt_br_locale
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_base_article_value_get_link_url_returns_url_with_current_locale():
+    """
+    get_link_url() must return a URL with the current active locale, not the fallback article's locale.
+
+    If the user is browsing in pt-PT, and clicks a link to an article that only exists in pt-BR,
+    they should see the URL change to /pt-PT/article-slug/, not /pt-BR/article-slug/.
+    """
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    _pt_pt_locale = LocaleFactory(language_code="pt-PT")
+
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+    root_page.copy_for_translation(pt_br_locale)
+
+    en_us_article = ArticleDetailPageFactory(
+        title="en-US Article",
+        slug="article-url-locale-test",
+        parent=root_page,
+    )
+    pt_br_article = en_us_article.copy_for_translation(pt_br_locale)
+    pt_br_article.title = "pt-BR Article"
+    pt_br_article.save_revision().publish()
+
+    article_value = BaseArticleValue(
+        ArticleBlock(),
+        {"article": en_us_article, "overrides": {}},
+    )
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        url = article_value.get_link_url()
+
+    assert url == "/pt-PT/article-url-locale-test/"

--- a/springfield/cms/tests/test_models.py
+++ b/springfield/cms/tests/test_models.py
@@ -148,40 +148,40 @@ def test__patch_request_for_springfield_annotates_is_cms_page(tiny_localized_sit
 
 
 # ---------------------------------------------------------------------------
-# get_fallback_url
+# get_active_locale_url
 # ---------------------------------------------------------------------------
 
 
-def test_get_fallback_url_returns_original_url(tiny_localized_site):
+def test_get_active_locale_url_returns_original_url(tiny_localized_site):
     """Page in the active locale: URL is returned as-is."""
     page = Page.objects.get(locale__language_code="en-US", slug="child-page").specific
     with translation.override("en-US"):
-        url = page.get_fallback_url()
+        url = page.get_active_locale_url()
     assert url == page.get_url()
 
 
 @override_settings(FALLBACK_LOCALES={})
-def test_get_fallback_url_returns_original_url_if_no_fallback_locales(tiny_localized_site):
+def test_get_active_locale_url_returns_original_url_if_no_fallback_locales(tiny_localized_site):
     """No FALLBACK_LOCALES: URL retains the page's own locale prefix even when active lang differs."""
     fr_page = Page.objects.get(locale__language_code="fr", slug="child-page").specific
     with translation.override("en-US"):
-        url = fr_page.get_fallback_url()
+        url = fr_page.get_active_locale_url()
     assert url == fr_page.get_url()
 
 
 @override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
-def test_get_fallback_url_returns_url_with_fallback_locale(tiny_localized_site):
+def test_get_active_locale_url_returns_url_with_fallback_locale(tiny_localized_site):
     """Active language is alias (pt-PT → pt-BR): URL prefix is rewritten to pt-PT."""
     LocaleFactory(language_code="pt-PT")
     pt_br_page = Page.objects.get(locale__language_code="pt-BR", slug="child-page").specific
     with translation.override("pt-PT"):
-        url = pt_br_page.get_fallback_url()
+        url = pt_br_page.get_active_locale_url()
     assert "/pt-PT/" in url
     assert "/pt-BR/" not in url
 
 
 @override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
-def test_get_fallback_url_returns_original_url_if_same_as_active_locale(tiny_localized_site):
+def test_get_active_locale_url_returns_original_url_if_same_as_active_locale(tiny_localized_site):
     """Active language is pt-PT but page is already in pt-PT locale: no substitution."""
     pt_pt_locale = LocaleFactory(language_code="pt-PT")
     site = Site.objects.get(is_default_site=True)
@@ -190,17 +190,17 @@ def test_get_fallback_url_returns_original_url_if_same_as_active_locale(tiny_loc
     pt_pt_page = en_us_page.copy_for_translation(pt_pt_locale)
     pt_pt_page.save_revision().publish()
     with translation.override("pt-PT"):
-        url = pt_pt_page.specific.get_fallback_url()
+        url = pt_pt_page.specific.get_active_locale_url()
     assert "/pt-PT/" in url
     assert "/pt-BR/" not in url
 
 
 @override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
-def test_get_fallback_url_returns_original_url_if_active_language_not_in_fallback_locales(tiny_localized_site):
+def test_get_active_locale_url_returns_original_url_if_active_language_not_in_fallback_locales(tiny_localized_site):
     """Active language (fr) is not in FALLBACK_LOCALES: URL is unchanged."""
     fr_page = Page.objects.get(locale__language_code="fr", slug="child-page").specific
     with translation.override("fr"):
-        url = fr_page.get_fallback_url()
+        url = fr_page.get_active_locale_url()
     assert "/fr/" in url
     assert "/pt-BR/" not in url
 

--- a/springfield/cms/tests/test_models.py
+++ b/springfield/cms/tests/test_models.py
@@ -5,6 +5,7 @@
 from unittest import mock
 
 from django.test import override_settings
+from django.utils import translation
 
 import pytest
 from bs4 import BeautifulSoup
@@ -144,6 +145,64 @@ def test__patch_request_for_springfield_annotates_is_cms_page(tiny_localized_sit
 
     patched_request = en_us_test_page.specific._patch_request_for_springfield(request)
     assert patched_request.is_cms_page is True
+
+
+# ---------------------------------------------------------------------------
+# get_fallback_url
+# ---------------------------------------------------------------------------
+
+
+def test_get_fallback_url_returns_original_url(tiny_localized_site):
+    """Page in the active locale: URL is returned as-is."""
+    page = Page.objects.get(locale__language_code="en-US", slug="child-page").specific
+    with translation.override("en-US"):
+        url = page.get_fallback_url()
+    assert url == page.get_url()
+
+
+@override_settings(FALLBACK_LOCALES={})
+def test_get_fallback_url_returns_original_url_if_no_fallback_locales(tiny_localized_site):
+    """No FALLBACK_LOCALES: URL retains the page's own locale prefix even when active lang differs."""
+    fr_page = Page.objects.get(locale__language_code="fr", slug="child-page").specific
+    with translation.override("en-US"):
+        url = fr_page.get_fallback_url()
+    assert url == fr_page.get_url()
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_get_fallback_url_returns_url_with_fallback_locale(tiny_localized_site):
+    """Active language is alias (pt-PT → pt-BR): URL prefix is rewritten to pt-PT."""
+    LocaleFactory(language_code="pt-PT")
+    pt_br_page = Page.objects.get(locale__language_code="pt-BR", slug="child-page").specific
+    with translation.override("pt-PT"):
+        url = pt_br_page.get_fallback_url()
+    assert "/pt-PT/" in url
+    assert "/pt-BR/" not in url
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_get_fallback_url_returns_original_url_if_same_as_active_locale(tiny_localized_site):
+    """Active language is pt-PT but page is already in pt-PT locale: no substitution."""
+    pt_pt_locale = LocaleFactory(language_code="pt-PT")
+    site = Site.objects.get(is_default_site=True)
+    site.root_page.copy_for_translation(pt_pt_locale)
+    en_us_page = Page.objects.get(locale__language_code="en-US", slug="test-page")
+    pt_pt_page = en_us_page.copy_for_translation(pt_pt_locale)
+    pt_pt_page.save_revision().publish()
+    with translation.override("pt-PT"):
+        url = pt_pt_page.specific.get_fallback_url()
+    assert "/pt-PT/" in url
+    assert "/pt-BR/" not in url
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_get_fallback_url_returns_original_url_if_active_language_not_in_fallback_locales(tiny_localized_site):
+    """Active language (fr) is not in FALLBACK_LOCALES: URL is unchanged."""
+    fr_page = Page.objects.get(locale__language_code="fr", slug="child-page").specific
+    with translation.override("fr"):
+        url = fr_page.get_fallback_url()
+    assert "/fr/" in url
+    assert "/pt-BR/" not in url
 
 
 def test_whats_new_index_page_redirects_to_latest_whats_new(

--- a/springfield/cms/tests/test_models.py
+++ b/springfield/cms/tests/test_models.py
@@ -739,6 +739,37 @@ def test_page_localized_returns_translation_when_active_locale_has_one():
     assert result.locale == pt_br_locale
 
 
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_page_localized_returns_translation_when_fallback_locale_has_translation():
+    """
+    When the active locale (pt-PT) has a translation, localized returns the locale's translation.
+    """
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    pt_pt_locale = LocaleFactory(language_code="pt-PT")
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+    root_page.copy_for_translation(pt_br_locale)
+    root_page.copy_for_translation(pt_pt_locale)
+
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-normal-locale-test",
+        parent=root_page,
+    )
+    pt_br_page = en_us_page.copy_for_translation(pt_br_locale)
+    pt_br_page.title = "pt-BR Article"
+    pt_br_page.save_revision().publish()
+    pt_pt_page = en_us_page.copy_for_translation(pt_pt_locale)
+    pt_pt_page.title = "pt-PT Article"
+    pt_pt_page.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        result = en_us_page.localized
+
+    assert result.id == pt_pt_page.id
+    assert result.locale == pt_pt_locale
+
+
 def test_page_localized_returns_self_when_no_translation_and_locale_not_in_fallback_locales():
     """
     When the active locale (fr) is not in FALLBACK_LOCALES and the page has no

--- a/springfield/cms/tests/test_models.py
+++ b/springfield/cms/tests/test_models.py
@@ -28,6 +28,7 @@ from springfield.cms.tests.factories import (
     FreeFormPage2026Factory,
     FreeFormPageFactory,
     LocaleFactory,
+    SimpleRichTextPageFactory,
     StructuralPageFactory,
     WhatsNewIndexPageFactory,
     WhatsNewPage2026Factory,
@@ -610,6 +611,189 @@ def test_springfield_locale_get_active_falls_back_to_default():
         # Should fall back to en-US
         assert active_locale.id == default_locale.id
         assert active_locale.language_code == "en-US"
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_springfield_locale_get_active_uses_configured_fallback_locale():
+    """
+    When an alias locale (pt-PT) has no Locale DB record, get_active() should
+    return the configured fallback locale (pt-BR) rather than jumping straight
+    to en-US.
+    """
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    # Deliberately do NOT create a pt-PT Locale record
+    assert not Locale.objects.filter(language_code="pt-PT").exists()
+
+    # Django returns lowercase codes; pt-PT becomes "pt-pt"
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        active_locale = Locale.get_active()
+
+    assert active_locale.id == pt_br_locale.id
+    assert active_locale.language_code == "pt-BR"
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_springfield_locale_get_active_falls_back_to_default_when_fallback_locale_also_missing():
+    """
+    When the alias locale has no DB record and the configured fallback locale
+    also has no DB record, get_active() should still fall back safely to en-US.
+    """
+    # Neither pt-PT nor pt-BR exists
+    assert not Locale.objects.filter(language_code="pt-PT").exists()
+    assert not Locale.objects.filter(language_code="pt-BR").exists()
+
+    default_locale = Locale.objects.get(language_code="en-US")
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        active_locale = Locale.get_active()
+
+    assert active_locale.id == default_locale.id
+    assert active_locale.language_code == "en-US"
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_page_localized_returns_fallback_locale_page_when_alias_locale_has_no_db_record():
+    """
+    When Django's active language is an alias locale (pt-PT) with no Locale DB
+    record, page.localized should return the fallback locale's (pt-BR)
+    translation rather than the en-US original.
+    """
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    assert not Locale.objects.filter(language_code="pt-PT").exists()
+
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+    # copy_for_translation requires the parent to exist in the target locale
+    root_page.copy_for_translation(pt_br_locale)
+
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-localized-test",
+        parent=root_page,
+    )
+    pt_br_page = en_us_page.copy_for_translation(pt_br_locale)
+    pt_br_page.title = "pt-BR Article"
+    pt_br_page.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        localized = en_us_page.localized
+
+    assert localized.id == pt_br_page.id
+    assert localized.locale == pt_br_locale
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_page_localized_uses_fallback_locale_when_alias_locale_exists_but_no_translation():
+    """
+    When the alias locale (pt-PT) has a Locale DB record but the page has no
+    pt-PT translation, page.localized should return the fallback locale's (pt-BR)
+    translation rather than the en-US original.
+    """
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    _pt_pt_locale = LocaleFactory(language_code="pt-PT")  # Locale exists in DB
+    # Deliberately do NOT create a pt-PT translation of the article
+
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+    root_page.copy_for_translation(pt_br_locale)
+
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-fallback-test",
+        parent=root_page,
+    )
+    pt_br_page = en_us_page.copy_for_translation(pt_br_locale)
+    pt_br_page.title = "pt-BR Article"
+    pt_br_page.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        result = en_us_page.localized
+
+    assert result.id == pt_br_page.id
+    assert result.locale == pt_br_locale
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_page_localized_returns_translation_when_active_locale_has_one():
+    """
+    When the active locale (pt-BR) has a published translation, localized
+    returns it directly without consulting FALLBACK_LOCALES.
+    """
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+    root_page.copy_for_translation(pt_br_locale)
+
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-normal-locale-test",
+        parent=root_page,
+    )
+    pt_br_page = en_us_page.copy_for_translation(pt_br_locale)
+    pt_br_page.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-br"):
+        result = en_us_page.localized
+
+    assert result.id == pt_br_page.id
+    assert result.locale == pt_br_locale
+
+
+def test_page_localized_returns_self_when_no_translation_and_locale_not_in_fallback_locales():
+    """
+    When the active locale (fr) is not in FALLBACK_LOCALES and the page has no
+    French translation, localized returns the source page unchanged.
+    """
+    _fr_locale = LocaleFactory(language_code="fr")
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-no-fallback-test",
+    )
+
+    with mock.patch("django.utils.translation.get_language", return_value="fr"):
+        result = en_us_page.localized
+
+    assert result.id == en_us_page.id
+    assert result.locale.language_code == "en-US"
+
+
+def test_page_localized_returns_self_for_source_locale():
+    """
+    When the active locale is the source locale (en-US), localized returns
+    the page unchanged without any extra lookups.
+    """
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-source-locale-test",
+    )
+
+    with mock.patch("django.utils.translation.get_language", return_value="en-us"):
+        result = en_us_page.localized
+
+    assert result.id == en_us_page.id
+    assert result.locale.language_code == "en-US"
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_page_localized_returns_self_when_fallback_locale_also_has_no_translation():
+    """
+    When the alias locale (pt-PT) maps to pt-BR via FALLBACK_LOCALES but the
+    page has no pt-BR translation either, localized returns the source page.
+    """
+    _pt_pt_locale = LocaleFactory(language_code="pt-PT")
+    _pt_br_locale = LocaleFactory(language_code="pt-BR")
+    # No pt-PT or pt-BR translation created for the page
+
+    en_us_page = SimpleRichTextPageFactory(
+        title="en-US Article",
+        slug="en-us-article-no-fallback-translation-test",
+    )
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        result = en_us_page.localized
+
+    assert result.id == en_us_page.id
+    assert result.locale.language_code == "en-US"
 
 
 def test_thanks_page_get_template_default(rf):

--- a/springfield/cms/tests/test_models.py
+++ b/springfield/cms/tests/test_models.py
@@ -1251,3 +1251,77 @@ def test_download_page_featured_image_variants(
     assert len(variants_div.find_all("img")) == expected_img_count
 
     _check_image_variant_classes(variants_div, primary_classes, dark_classes, mobile_classes, dark_mobile_classes)
+
+
+# Snippets
+def test_get_localized_snippet_returns_translation(minimal_site):
+    en_us_locale = Locale.objects.get(language_code="en-US")
+    fr_locale = Locale.objects.get(language_code="fr")
+
+    original_snippet = Tag.objects.create(name="Original Snippet", slug="original-snippet", locale=en_us_locale)
+    translated_snippet = original_snippet.copy_for_translation(fr_locale)
+    translated_snippet.name = "Extrait traduit"
+    translated_snippet.save()
+    translated_snippet.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="fr"):
+        localized_snippet = original_snippet.get_localized()
+        assert localized_snippet.id == translated_snippet.id
+        assert localized_snippet.name == "Extrait traduit"
+
+
+def test_get_localized_snippet_returns_none_if_translation_is_not_published(minimal_site):
+    en_us_locale = Locale.objects.get(language_code="en-US")
+    fr_locale = Locale.objects.get(language_code="fr")
+
+    original_snippet = Tag.objects.create(name="Original Snippet", slug="original-snippet", locale=en_us_locale)
+    translated_snippet = original_snippet.copy_for_translation(fr_locale)
+    translated_snippet.name = "Extrait traduit"
+    translated_snippet.live = False
+    translated_snippet.save()
+
+    with mock.patch("django.utils.translation.get_language", return_value="fr"):
+        localized_snippet = original_snippet.get_localized()
+        assert localized_snippet is None
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_get_localized_snippet_returns_translation_fallback(minimal_site):
+    en_us_locale = Locale.objects.get(language_code="en-US")
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    LocaleFactory(language_code="pt-PT")
+
+    original_snippet = Tag.objects.create(name="Original Snippet", slug="original-snippet", locale=en_us_locale)
+    translated_snippet = original_snippet.copy_for_translation(pt_br_locale)
+    translated_snippet.name = "Snippet traduzido"
+    translated_snippet.save()
+    translated_snippet.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        localized_snippet = original_snippet.get_localized()
+        assert localized_snippet.id == translated_snippet.id
+        assert localized_snippet.name == "Snippet traduzido"
+
+
+@override_settings(FALLBACK_LOCALES={"pt-PT": "pt-BR"})
+def test_get_localized_snippet_returns_translation_translated_instance_despite_fallback(minimal_site):
+    en_us_locale = Locale.objects.get(language_code="en-US")
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+    pt_pt_locale = LocaleFactory(language_code="pt-PT")
+
+    original_snippet = Tag.objects.create(name="Original Snippet", slug="original-snippet", locale=en_us_locale)
+
+    pt_br_snippet = original_snippet.copy_for_translation(pt_br_locale)
+    pt_br_snippet.name = "Snippet traduzido"
+    pt_br_snippet.save()
+    pt_br_snippet.save_revision().publish()
+
+    pt_pt_snippet = original_snippet.copy_for_translation(pt_pt_locale)
+    pt_pt_snippet.name = "Trecho traduzido"
+    pt_pt_snippet.save()
+    pt_pt_snippet.save_revision().publish()
+
+    with mock.patch("django.utils.translation.get_language", return_value="pt-pt"):
+        localized_snippet = original_snippet.get_localized()
+        assert localized_snippet.id == pt_pt_snippet.id
+        assert localized_snippet.name == "Trecho traduzido"


### PR DESCRIPTION
## One-line summary
When a page is served in a fallback locale, any references to pages in the page's content should now be in the same locale as the page content.

## Significant changes and points to review
 - the most significant change is that `AbstractSpringfieldCMSPage.localized` now extends `Page.localized` to make sure that we are returning the appropriate page in fallback scenarios
 - `BaseArticleValue.get_article()` now calls `.specific` before `.localized`, so that `AbstractSpringfieldCMSPage.localized` gets called. Without the `.specific`, `.localized` calls `Page.localized` (not our `AbstractSpringfieldCMSPage.localized`)
 - `Locale.get_active()` also properly handles the scenario where the alias locale does not exist in the database


## Issue / Bugzilla link
Previously, when the requested page didn't exist in an alias locale, and the content was served in the fallback locale at the alias URL , if the fallback content included a foreign key to a Page, that Page reference shown to the end user may
have been in the default (en-US) locale. Now, the Page reference should match the locale that the content is served in.
Example: because there is no features protection page in the pt-PT locale, https://firefox.com/pt-PT/features/protection/ serves pt-BR content. However, "Learn more" links show up on the page, because the article detail pages being linked to are being returned in the default (en-US) locale.

Examples from janbrasna:
<img width="2144" height="1462" alt="Screenshot1" src="https://github.com/user-attachments/assets/16bd8b53-f973-4938-8392-efaaebe221e1" />
<img width="2814" height="1320" alt="Screenshot2" src="https://github.com/user-attachments/assets/1098a5d1-b2b4-4072-8ca3-543bbb20130e" />


## Testing
- load the problematic pages locally, and observe that the content is fully translated:
  - http://localhost:8000/pt-PT/features/protection/ should show the same content as http://localhost:8000/pt-BR/features/protection/  "Learn more" should not show up; it should be "Saiba mas"
  - http://localhost:8000/pt-PT/features/focus/ should show the same content as http://localhost:8000/pt-BR/features/focus/       "Learn more" should not show up; it should be "Saiba mas"
  - http://localhost:8000/es-AR/features/protection/ should show the same content as http://localhost:8000/es-MX/features/protection/            "Learn more" should not show up; it should be "Leer más"