### PR TITLE
WT-800: Update enterprise page wording to reflect current program state

### DIFF
--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -53,7 +53,7 @@ firefox-enterprise-download-firefox-or-esr = Download { -brand-name-firefox } or
 firefox-enterprise-support-for-organizations = { -brand-name-support-for-organizations }
 # Obsolete string (expires: 2026-06-10)
 firefox-enterprise-early-access-is = Early access is now open for our new support program launching in January 2026. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
-firefox-enterprise-early-access-launched = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
+firefox-enterprise-early-access-is-v2 = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-contact-sales = Contact Sales
 firefox-enterprise-support-for-organizations-documentation = { -brand-name-support-for-organizations } documentation
 firefox-enterprise-support-for-organizations-is = { -brand-name-support-for-organizations } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.

--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -51,7 +51,9 @@ firefox-enterprise-windows-32-bit = { -brand-name-windows } 32-bit
 firefox-enterprise-download-firefox-or-esr = Download { -brand-name-firefox } or { -brand-name-firefox-esr } for <a { $firefox_all }>another language or platform.</a>
 
 firefox-enterprise-support-for-organizations = { -brand-name-support-for-organizations }
+# Obsolete string (expires: 2026-06-10)
 firefox-enterprise-early-access-is = Early access is now open for our new support program launching in January 2026. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
+firefox-enterprise-early-access-launched = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-contact-sales = Contact Sales
 firefox-enterprise-support-for-organizations-documentation = { -brand-name-support-for-organizations } documentation
 firefox-enterprise-support-for-organizations-is = { -brand-name-support-for-organizations } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -74,7 +74,7 @@
         level="h2"
         heading_text="{{ ftl('firefox-enterprise-support-for-organizations') }}"
         heading_size="fl-heading-size-2"
-        subheading_text="{{ ftl('firefox-enterprise-early-access-launched', fallback='firefox-enterprise-early-access-is') }}"
+        subheading_text="{{ ftl('firefox-enterprise-early-access-is-v2', fallback='firefox-enterprise-early-access-is') }}"
         subheading_size="fl-subheading-4"
       />
     </content:heading>
@@ -210,7 +210,7 @@
       <div class="mzp-c-callout-content">
         <h2 class="mzp-c-callout-title">{{ ftl('firefox-enterprise-support-for-organizations') }}</h2>
         <div class="mzp-c-callout-desc">
-          <p>{{ ftl('firefox-enterprise-early-access-launched', fallback='firefox-enterprise-early-access-is') }}</p>
+          <p>{{ ftl('firefox-enterprise-early-access-is-v2', fallback='firefox-enterprise-early-access-is') }}</p>
         </div>
         <a class="callout-cta mzp-c-button mzp-t-product" href="https://qsurvey.mozilla.com/s3/firefox-support-plan?src=firefox-enterprise-cta" data-cta-text="Contact Sales">
           {{ ftl('firefox-enterprise-contact-sales') }}

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -74,7 +74,7 @@
         level="h2"
         heading_text="{{ ftl('firefox-enterprise-support-for-organizations') }}"
         heading_size="fl-heading-size-2"
-        subheading_text="{{ ftl('firefox-enterprise-early-access-is') }}"
+        subheading_text="{{ ftl('firefox-enterprise-early-access-launched', fallback='firefox-enterprise-early-access-is') }}"
         subheading_size="fl-subheading-4"
       />
     </content:heading>
@@ -210,7 +210,7 @@
       <div class="mzp-c-callout-content">
         <h2 class="mzp-c-callout-title">{{ ftl('firefox-enterprise-support-for-organizations') }}</h2>
         <div class="mzp-c-callout-desc">
-          <p>{{ ftl('firefox-enterprise-early-access-is') }}</p>
+          <p>{{ ftl('firefox-enterprise-early-access-launched', fallback='firefox-enterprise-early-access-is') }}</p>
         </div>
         <a class="callout-cta mzp-c-button mzp-t-product" href="https://qsurvey.mozilla.com/s3/firefox-support-plan?src=firefox-enterprise-cta" data-cta-text="Contact Sales">
           {{ ftl('firefox-enterprise-contact-sales') }}


### PR DESCRIPTION
## One-line summary
Updates wording on enterprise page to specify that the program is opening instead of "opening in January 2026" which has passed.

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-800

## Testing
- [x] Checkout this PR
- [x] Navigate to http://localhost:8000/en-US/browsers/enterprise/
- [ ] Ensure the `Support for Organizations` box no longer states the program is opening in January 2026