### PR TITLE
Improved handling of excluding fallback locales from smartling

### DIFF
--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1400,7 +1400,7 @@ WAGTAIL_LOCALIZE_SMARTLING = {
     ),
     "REFORMAT_LANGUAGE_CODES": False,  # don't force language codes into Django's all-lowercase pattern
     "VISUAL_CONTEXT_CALLBACK": "springfield.cms.wagtail_localize_smartling.callbacks.visual_context",
-    "EXCLUDE_LOCALES": ["en-CA", "en-GB"],
+    "EXCLUDE_LOCALES": list(FALLBACK_LOCALES.keys()),
 }
 
 WAGTAILDRAFTSHARING = {


### PR DESCRIPTION
## One-line summary
Pulls list of locales to exclude from smartling from `list(FALLBACK_LOCALES.keys()),` instead of adding manually. 


