### PR TITLE
Update /landing/get to serve Flare26 template for all locales

### DIFF
--- a/media/css/cms/pages/flare26-landing-get-page.css
+++ b/media/css/cms/pages/flare26-landing-get-page.css
@@ -203,6 +203,11 @@ body.data-uitour #protection-report {
 }
 
 @media (--viewport-md-up) {
+    /* Keep nav always visible on scroll for this page */
+    body:has(.fl-landing-get) .fl-header.headroom-unpinned {
+        transform: translateY(0%);
+    }
+
     .fl-landing-get .c-intro-download {
         align-items: flex-start;
     }

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -531,27 +531,17 @@ class TestFirefoxSetAsDefaultThanks(TestCase):
         assert resp.templates[0].name == "firefox/default/thanks.html"
 
 
-class TestFirefoxGetExperiment(TestCase):
-    """Tests for /landing/get/ privacy-focused download experiment."""
+class TestFirefoxGetPage(TestCase):
+    """Tests for /landing/get/ page."""
 
-    def test_firefox_get_default(self):
-        """Default"""
+    def test_firefox_get_en_us(self):
+        """en-US serves the new template"""
         response = self.client.get("/en-US/landing/get/")
-        assert response.templates[0].name == "firefox/landing/get.html"
+        assert response.templates[0].name == "firefox/landing/get-new.html"
 
-    def test_firefox_get_control(self):
-        """Control parameters"""
-        response = self.client.get("/en-US/landing/get/?experiment=download-privacy&variation=control")
-        assert response.templates[0].name == "firefox/landing/get.html"
-
-    def test_firefox_get_treatment(self):
-        """Treatment parameters"""
-        response = self.client.get("/en-US/landing/get/?experiment=download-privacy&variation=treatment")
-        assert response.templates[0].name == "firefox/landing/get-treatment.html"
-
-    def test_firefox_get_not_en_us_locale(self):
-        """Default"""
-        response = self.client.get("/en-CA/landing/get/?experiment=download-privacy&variation=treatment")
+    def test_firefox_get_not_en_us(self):
+        """Non-en-US locales serve the new template"""
+        response = self.client.get("/en-CA/landing/get/")
         assert response.templates[0].name == "firefox/landing/get-new.html"
 
 

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -1004,26 +1004,5 @@ class WhatsnewView(L10nTemplateView):
 @require_safe
 def landing_get_page(request):
     ftl_files = ["firefox/download/desktop", "firefox/download/home"]
-    experiment = request.GET.get("experiment", None)
-    variation = request.GET.get("variation", None)
-
-    # ensure experiment parameters matches pre-defined values
-    if variation not in ["treatment", "control"]:
-        variation = None
-
-    if experiment not in ["download-privacy"]:
-        experiment = None
-
-    if request.locale == "en-US" and experiment == "download-privacy" and variation == "treatment":
-        template_name = "firefox/landing/get-treatment.html"
-    elif request.locale == "en-US":
-        template_name = "firefox/landing/get.html"
-    else:
-        template_name = "firefox/landing/get-new.html"
-
-    context = {
-        "experiment": experiment,
-        "variation": variation,
-    }
-
-    return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)
+    template_name = "firefox/landing/get-new.html"
+    return l10n_utils.render(request, template_name, ftl_files=ftl_files)


### PR DESCRIPTION
Stop the download-privacy split test and serve the new Flare26 template (get-new.html) for en-US, matching all other locales. The old templates (get.html, get-treatment.html) and download_privacy waffle switch are kept for future reuse.

Also addresses leadership request to make the nav permanently sticky on this page so the download button is always visible on scroll.
