### PR TITLE
Remove "the" from Mozilla Foundation donate string on 404 page

### DIFF
--- a/l10n/en/404.ftl
+++ b/l10n/en/404.ftl
@@ -17,6 +17,11 @@ not-found-page-learn-about-mozilla-the-non = <a href="{ $about }">Learn</a> abou
 #   $download (url) - link to https://www.firefox.com/
 not-found-page-download-the-firefox-browser = <a href={ $download }>Download</a> the { -brand-name-firefox } browser for your mobile device or desktop
 
+# Obsolete string (expires: 2026-06-15)
 # Variables:
 #   $donate (url) - link to https://foundation.mozilla.org/?form=donate-404
 not-found-page-donate-to-mozilla-reclaim-from = <a { $donate }>Donate</a> to the { -brand-name-mozilla-foundation } and reclaim the internet from big tech.
+
+# Variables:
+#   $donate (url) - link to https://foundation.mozilla.org/?form=donate-404
+not-found-page-donate-to-mozilla-foundation = <a { $donate }>Donate</a> to { -brand-name-mozilla-foundation } and reclaim the internet from big tech.

--- a/springfield/base/templates/404.html
+++ b/springfield/base/templates/404.html
@@ -39,7 +39,7 @@
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
         <span>
-          {{ ftl('not-found-page-donate-to-mozilla-reclaim-from', donate='href="%s"'|safe|format(donate_url(location='donate-404'))) }}
+          {{ ftl('not-found-page-donate-to-mozilla-foundation', fallback="not-found-page-donate-to-mozilla-reclaim-from", donate='href="%s"'|safe|format(donate_url(location='donate-404'))) }}
         </span>
       </li>
     </ul>


### PR DESCRIPTION
Adds a new FTL string that removes the definite article before "Mozilla Foundation" in the 404 page donate call-to-action. The old string is kept as a fallback and marked obsolete with a 2-month expiry to allow translations to catch up.

Instead of versioning and using `v2` suffix on the existing string id, I used a new one that better fits.

* Closes #426
* [Jira WT-123](https://mozilla-hub.atlassian.net/browse/WT-123)