### PR TITLE
Add four view states to Smart Window page with analytics URL params

### DIFF
--- a/media/css/cms/pages/flare26-smart-window.css
+++ b/media/css/cms/pages/flare26-smart-window.css
@@ -121,6 +121,20 @@
     max-inline-size: 100%;
 }
 
+/* Smart Window view states: version-based visibility */
+
+.sw-view-enable {
+    display: none;
+}
+
+.is-firefox-150-plus .sw-view-enable {
+    display: block;
+}
+
+.is-firefox-150-plus .sw-view-update {
+    display: none;
+}
+
 /* Play/pause buttons */
 
 .fl-smart-window-page .fl-video-play-icon,

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -1025,12 +1025,17 @@ class SmartWindowPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
-        country = get_country_from_request(request)
         context["ui_tour_class"] = UI_TOUR_CLASSES[UITOUR_BUTTON_SMART_WINDOW]
-        context["show_try_smart_window"] = self.show_smart_window_button == "all" or (
-            self.show_smart_window_button == self.ALLOWED_TERRITORIES_OPTION and country in self.ALLOWED_TERRITORIES
-        )
         context["redirect_url"] = self.redirect_page.get_url() if self.redirect_page else None
+
+        # ?view=waitlist forces waitlist regardless of geo
+        if request.GET.get("view") == "waitlist":
+            context["in_supported_geo"] = False
+        else:
+            country = get_country_from_request(request)
+            context["in_supported_geo"] = self.show_smart_window_button == "all" or (
+                self.show_smart_window_button == self.ALLOWED_TERRITORIES_OPTION and country in self.ALLOWED_TERRITORIES
+            )
         return context
 
 

--- a/springfield/cms/templates/cms/smart_window_page.html
+++ b/springfield/cms/templates/cms/smart_window_page.html
@@ -8,32 +8,43 @@
 
 {% block body_class %}fl-smart-window-page{% endblock %}
 
+{% block extra_meta %}
+<script>
+(function() {
+    var m = /Firefox\/(\d+)/.exec(navigator.userAgent);
+    if (m && parseInt(m[1], 10) >= 150) {
+        document.documentElement.classList.add('is-firefox-150-plus');
+    }
+})();
+</script>
+{% endblock %}
+
 {% block flare_header %}
   {% set custom_nav_cta %}
     <div class="nav-cta-wrap">
-      <include:conditional-display firefox_condition="not-firefox">
-        <include:download-firefox-button
-          analytics_id="nav-download-firefox"
-          label="{{ ftl('navigation-get-firefox') }}"
-          cta_text="{{ ftl('navigation-get-firefox') }}"
-          icon_name="downloads"
-          icon_position="left"
-          block_position="nav"
-          exclude_unsupported_content="True"
-        />
-      </include:conditional-display>
-      {% if show_try_smart_window %}
+      {% if in_supported_geo %}
+        <include:conditional-display firefox_condition="not-firefox">
+          <include:download-firefox-button
+            analytics_id="nav-download-firefox"
+            label="{{ ftl('navigation-get-firefox') }}"
+            cta_text="{{ ftl('navigation-get-firefox') }}"
+            icon_name="downloads"
+            icon_position="left"
+            block_position="nav"
+            exclude_unsupported_content="True"
+          />
+        </include:conditional-display>
         <include:conditional-display firefox_condition="is-firefox">
-         <include:uitour_button
-          theme_class="{{ ui_tour_class }}"
-          label="{{ page.waitlist_button_label }}"
-          analytics_text="{{ page.waitlist_button_label }}"
-          analytics_position="nav"
-          analytics_id="{{ page.nav_button_uid }}"
-          {% if redirect_url %}
-          next_url="{{ redirect_url }}"
-          {% endif %}
-        />
+          <include:uitour_button
+            theme_class="{{ ui_tour_class }}"
+            label="{{ page.waitlist_button_label }}"
+            analytics_text="{{ page.waitlist_button_label }}"
+            analytics_position="nav"
+            analytics_id="{{ page.nav_button_uid }}"
+            {% if redirect_url %}
+            next_url="{{ redirect_url }}"
+            {% endif %}
+          />
         </include:conditional-display>
       {% endif %}
     </div>
@@ -52,79 +63,85 @@
           <p class="fl-subheading">{{ page.subheading_text|richtext|remove_p_tag }}</p>
         </hgroup>
 
-        <include:conditional-display firefox_condition="not-firefox">
-          <include:download-firefox-button
-            analytics_id="intro-download-firefox"
-            label="{{ ftl('navigation-get-firefox') }}"
-            cta_text="{{ ftl('navigation-get-firefox') }}"
-            icon_name="downloads"
-            icon_position="left"
-            block_position="intro"
-            exclude_unsupported_content="True"
-          />
-        </include:conditional-display>
-
-        {% if show_try_smart_window %}
-          <include:conditional-display firefox_condition="is-firefox">
-            <include:uitour_button
-              theme_class="{{ ui_tour_class }}"
-              label="{{ page.waitlist_button_label }}"
-              analytics_text="Try Smart Window"
-              analytics_position="intro"
-              analytics_id="{{ page.intro_button_uid }}"
-              {% if redirect_url %}
-              next_url="{{ redirect_url }}"
-              {% endif %}
+        {% if in_supported_geo %}
+          {# Download state: not-Firefox users in supported geo #}
+          <include:conditional-display firefox_condition="not-firefox">
+            <include:download-firefox-button
+              analytics_id="intro-download-firefox"
+              label="{{ ftl('navigation-get-firefox') }}"
+              cta_text="{{ ftl('navigation-get-firefox') }}"
+              icon_name="downloads"
+              icon_position="left"
+              block_position="intro"
+              exclude_unsupported_content="True"
             />
           </include:conditional-display>
-        {% else %}
+
+          {# Enable/Update states: Firefox users in supported geo #}
           <include:conditional-display firefox_condition="is-firefox">
-            <form id="newsletter-form" class="fl-smart-window-form fl-newsletterform" action="{{ settings.BASKET_SUBSCRIBE_URL }}" method="post" novalidate data-testid="newsletter-form">
-              <div hidden>
-                <input type="checkbox" name="newsletters" value="smart-window-waitlist" checked>
-              </div>
-              <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
-              <input type="hidden" name="lang" id="id_lang" value="en">
-              <div class="fl-newsletterform-field">
-                <label class="fl-newsletterform-label visually-hidden" for="newsletter-email">{{ ftl('newsletter-form-your-email-address') }}</label>
-                <input id="newsletter-email" class="fl-newsletterform-input" type="email" name="email" placeholder="{{ ftl('newsletter-form-yournameexamplecom', fallback='newsletter-form-your-email-here') }}" autocomplete="email" data-testid="newsletter-email-input">
-              </div>
-              <div id="newsletter-details" class="fl-newsletterform-details fl-newsletterform-row-hidden">
-                <div class="fl-newsletterform-consent">
-                  <label for="newsletter-privacy" class="fl-body fl-newsletterform-checkbox-label">
-                    <input type="checkbox" id="newsletter-privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox">
-                    <span class="fl-newsletterform-checkbox-text">{{ page.privacy_notice|richtext }}</span>
-                  </label>
-                </div>
-              </div>
-              <button
-                id="newsletter-submit"
-                class="fl-button"
-                type="submit"
-                data-cta-uid="{{ page.waitlist_submit_uid }}"
-                data-cta-text="{{ page.form_submit_label }}"
-                data-cta-position="intro"
-                disabled
-                data-testid="newsletter-submit-button"
-              >{{ page.form_submit_label }}</button>
-              <div class="fl-body fl-newsletterform-feedback fl-newsletterform-error mzp-c-form-errors hidden" id="newsletter-errors" data-testid="newsletter-error-message">
-                <ul class="fl-newsletterform-error-list mzp-u-list-styled">
-                  <li class="error-email-invalid hidden">{{ ftl('newsletter-form-please-enter-a-valid') }}</li>
-                  <li class="error-try-again-later hidden">{{ ftl('newsletter-form-we-are-sorry-but-there') }}</li>
-                </ul>
-              </div>
-            </form>
-            <div id="newsletter-thanks" class="fl-smart-window-thankyou hidden" data-testid="newsletter-thanks-message">
-
-              <include:inline-notification
-                message="{{ page.thank_you_message|richtext }}"
-                color="green"
-                icon="checkmark"
+            {# Enable: Firefox 150+ — shown by CSS when .is-firefox-150-plus on <html> #}
+            <div class="sw-view-enable">
+              <include:uitour_button
+                theme_class="{{ ui_tour_class }}"
+                label="{{ page.waitlist_button_label }}"
+                analytics_text="{{ page.waitlist_button_label }}"
+                analytics_position="intro"
+                analytics_id="{{ page.intro_button_uid }}"
+                {% if redirect_url %}
+                next_url="{{ redirect_url }}"
+                {% endif %}
               />
+            </div>
 
-
+            {# Update: Firefox <150 — visible by default, hidden by CSS when .is-firefox-150-plus #}
+            <div class="sw-view-update">
+              {# TODO: Update state content to be managed via CMS #}
             </div>
           </include:conditional-display>
+        {% else %}
+          {# Waitlist: not in supported geo — shown to ALL browsers #}
+          <form id="newsletter-form" class="fl-smart-window-form fl-newsletterform" action="{{ settings.BASKET_SUBSCRIBE_URL }}" method="post" novalidate data-testid="newsletter-form">
+            <div hidden>
+              <input type="checkbox" name="newsletters" value="smart-window-waitlist" checked>
+            </div>
+            <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
+            <input type="hidden" name="lang" id="id_lang" value="en">
+            <div class="fl-newsletterform-field">
+              <label class="fl-newsletterform-label visually-hidden" for="newsletter-email">{{ ftl('newsletter-form-your-email-address') }}</label>
+              <input id="newsletter-email" class="fl-newsletterform-input" type="email" name="email" placeholder="{{ ftl('newsletter-form-yournameexamplecom', fallback='newsletter-form-your-email-here') }}" autocomplete="email" data-testid="newsletter-email-input">
+            </div>
+            <div id="newsletter-details" class="fl-newsletterform-details fl-newsletterform-row-hidden">
+              <div class="fl-newsletterform-consent">
+                <label for="newsletter-privacy" class="fl-body fl-newsletterform-checkbox-label">
+                  <input type="checkbox" id="newsletter-privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox">
+                  <span class="fl-newsletterform-checkbox-text">{{ page.privacy_notice|richtext }}</span>
+                </label>
+              </div>
+            </div>
+            <button
+              id="newsletter-submit"
+              class="fl-button"
+              type="submit"
+              data-cta-uid="{{ page.waitlist_submit_uid }}"
+              data-cta-text="{{ page.form_submit_label }}"
+              data-cta-position="intro"
+              disabled
+              data-testid="newsletter-submit-button"
+            >{{ page.form_submit_label }}</button>
+            <div class="fl-body fl-newsletterform-feedback fl-newsletterform-error mzp-c-form-errors hidden" id="newsletter-errors" data-testid="newsletter-error-message">
+              <ul class="fl-newsletterform-error-list mzp-u-list-styled">
+                <li class="error-email-invalid hidden">{{ ftl('newsletter-form-please-enter-a-valid') }}</li>
+                <li class="error-try-again-later hidden">{{ ftl('newsletter-form-we-are-sorry-but-there') }}</li>
+              </ul>
+            </div>
+          </form>
+          <div id="newsletter-thanks" class="fl-smart-window-thankyou hidden" data-testid="newsletter-thanks-message">
+            <include:inline-notification
+              message="{{ page.thank_you_message|richtext }}"
+              color="green"
+              icon="checkmark"
+            />
+          </div>
         {% endif %}
 
         {% if page.animation %}
@@ -202,6 +219,28 @@
 </div>
 {% endblock %}
 
+
+{% block js %}
+<script>
+(function() {
+    if (!window.history || !window.history.replaceState) return;
+    var cl = document.documentElement.classList;
+    var view;
+    {% if not in_supported_geo %}
+    view = 'waitlist';
+    {% else %}
+    if (cl.contains('not-firefox')) view = 'download';
+    else if (cl.contains('is-firefox-150-plus')) view = 'enable';
+    else if (cl.contains('is-firefox')) view = 'update';
+    {% endif %}
+    if (view) {
+        var url = new URL(window.location);
+        url.searchParams.set('view', view);
+        window.history.replaceState({}, '', url);
+    }
+})();
+</script>
+{% endblock %}
 
 {% block pre_footer %}
 {% endblock pre_footer %}

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -3724,15 +3724,19 @@ def test_smart_window_page(index_page, placeholder_images, rf):
         attribution_text = BeautifulSoup(card["value"]["attribution"], "html.parser").get_text()
         assert attribution_text in testimonial_card_els[i].get_text()
 
-    # --- UITour buttons: rendered when show_smart_window_button="all" ---
+    # --- In supported geo: UITour buttons + update view rendered ---
     page.show_smart_window_button = "all"
     sw_request = rf.get(page.get_full_url())
     sw_response = page.serve(sw_request)
     assert sw_response.status_code == 200
     sw_soup = BeautifulSoup(sw_response.content, "html.parser")
 
-    # No form in the UITour state
+    # No form in the in-geo state
     assert not sw_soup.find("form", {"data-testid": "newsletter-form"})
+
+    # Enable and update view containers are present
+    assert sw_soup.find("div", class_="sw-view-enable")
+    assert sw_soup.find("div", class_="sw-view-update")
 
     uitour_buttons = sw_soup.find_all("button", attrs={"data-cta-uid": True})
     uitour_by_id = {btn["data-cta-uid"]: btn for btn in uitour_buttons}
@@ -3743,15 +3747,16 @@ def test_smart_window_page(index_page, placeholder_images, rf):
     assert nav_btn["data-cta-position"] == "nav"
     assert nav_btn.get_text(strip=True) == page.waitlist_button_label
 
-    # Intro (upper content) button
+    # Intro (upper content) button inside enable view
     intro_btn = uitour_by_id.get(str(page.intro_button_uid))
     assert intro_btn
     assert intro_btn["data-cta-position"] == "intro"
     assert intro_btn.get_text(strip=True) == page.waitlist_button_label
+    assert intro_btn.find_parent("div", class_="sw-view-enable")
 
 
 @pytest.mark.parametrize(
-    "show_button,country,expected",
+    "show_button,country,in_supported_geo",
     [
         ("all", "US", True),
         ("all", "DE", True),
@@ -3764,7 +3769,7 @@ def test_smart_window_page(index_page, placeholder_images, rf):
         ("never", None, False),
     ],
 )
-def test_smart_window_show_try_smart_window(index_page, placeholder_images, rf, show_button, country, expected):
+def test_smart_window_in_supported_geo(index_page, placeholder_images, rf, show_button, country, in_supported_geo):
     page = get_smart_window_test_page()
     page.show_smart_window_button = show_button
 
@@ -3775,17 +3780,31 @@ def test_smart_window_show_try_smart_window(index_page, placeholder_images, rf, 
     soup = BeautifulSoup(response.content, "html.parser")
 
     form = soup.find("form", {"data-testid": "newsletter-form"})
-    nav_button = soup.find("button", {"data-cta-uid": str(page.nav_button_uid)})
-    intro_button = soup.find("button", {"data-cta-uid": str(page.intro_button_uid)})
+    enable_view = soup.find("div", class_="sw-view-enable")
+    update_view = soup.find("div", class_="sw-view-update")
 
-    if expected:
-        assert nav_button, f"Expected nav UITour button for show_button={show_button!r}, country={country!r}"
-        assert intro_button, f"Expected intro UITour button for show_button={show_button!r}, country={country!r}"
+    if in_supported_geo:
+        assert enable_view, f"Expected enable view for show_button={show_button!r}, country={country!r}"
+        assert update_view, f"Expected update view for show_button={show_button!r}, country={country!r}"
         assert not form, f"Expected no form for show_button={show_button!r}, country={country!r}"
     else:
         assert form, f"Expected form for show_button={show_button!r}, country={country!r}"
-        assert not nav_button, f"Expected no nav UITour button for show_button={show_button!r}, country={country!r}"
-        assert not intro_button, f"Expected no intro UITour button for show_button={show_button!r}, country={country!r}"
+        assert not enable_view, f"Expected no enable view for show_button={show_button!r}, country={country!r}"
+        assert not update_view, f"Expected no update view for show_button={show_button!r}, country={country!r}"
+
+
+def test_smart_window_waitlist_override(index_page, placeholder_images, rf):
+    """?view=waitlist forces waitlist form regardless of geo."""
+    page = get_smart_window_test_page()
+    page.show_smart_window_button = "all"  # would normally show in-geo content
+
+    request = rf.get(page.get_full_url() + "?view=waitlist")
+    response = page.serve(request)
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    form = soup.find("form", {"data-testid": "newsletter-form"})
+    assert form, "Expected waitlist form when ?view=waitlist is set"
+    assert not soup.find("div", class_="sw-view-enable"), "Expected no enable view with ?view=waitlist"
 
 
 def test_smart_window_explainer_page(index_page, rf):


### PR DESCRIPTION
Add four view states to Smart Window page with analytics URL params

- Enable (?view=enable): Firefox 150+ in supported geo — shows UITour button
- Update (?view=update): Firefox <150 in supported geo — shows update messaging
- Download (?view=download): non-Firefox in supported geo — shows update link
- Waitlist (?view=waitlist): not in supported geo, or ?view=waitlist override

Server-side: get_context() renamed show_try_smart_window to in_supported_geo, added ?view=waitlist param override to force waitlist regardless of geo.

Client-side: inline script adds is-firefox-150-plus class to <html> for CSS-driven enable/update visibility. Second inline script appends ?view= URL param via history.replaceState() for analytics tracking.

Nav CTAs (download + UITour button) now geo-gated — not-in-geo users see no nav CTA since their action (waitlist) is in the main content area.

Waitlist form moved outside conditional-display wrapper when not in geo so all browsers (not just Firefox) can see it.


## Testing

Enable state (Firefox 150+, supported geo): http://localhost:8000/en-US/smart-window/?geo=US
- Should see "Get early access" UITour button
- URL should update to include ?view=enable

Update state (Firefox <150, supported geo):
- You're probably on a recent Firefox, so to simulate old Firefox you'd need to use a different browser (Chrome/Safari) — but that would trigger the download state instead. The update state is hard to test locally unless you have an old Firefox build. You can verify the HTML is present by inspecting the page source and confirming .sw-view-update div exists (just hidden by CSS).

Download state (non-Firefox, supported geo): Open in Chrome/Safari:  http://localhost:8000/en-US/smart-window/?geo=US
 - Should see "How to update Firefox" button + messaging
- URL should update to ?view=download

Waitlist state (not in supported geo): http://localhost:8000/en-US/smart-window/?geo=DE
- Should see email form + "Join the Waitlist" in any browser
- URL should update to ?view=waitlist

Waitlist override: http://localhost:8000/en-US/smart-window/?geo=US&view=waitlist
- Even though geo=US, should see the waitlist form
- URL should show ?view=waitlist

No-JS fallback:
- Open any URL above, disable JS in DevTools, reload
- Verify something reasonable renders (currently the page will show the heading/subheading but the CTA area will be empty for the in-geo case since conditional-display hides by default — this is the existing behavior, not a regression)

## QUESTIONS

Should some of this be handled in CMS vs template level?