### PR TITLE
Allow ?geo= param in Wagtail preview requests

### DIFF
--- a/springfield/base/geo.py
+++ b/springfield/base/geo.py
@@ -23,8 +23,13 @@ def valid_country_code(country):
 
 def get_country_from_param(request):
     is_prod = request.get_host() == "www.firefox.com"
+    is_preview = getattr(request, "is_preview", False)
+    # Allow ?geo= param on non-prod hosts, and on preview requests
+    # (preview dummy requests have the prod hostname but aren't real user requests)
+    if is_prod and not is_preview:
+        return None
     country_code = valid_country_code(request.GET.get("geo"))
-    return country_code if not is_prod else None
+    return country_code
 
 
 def get_country_from_header(request):

--- a/springfield/base/tests/test_geo.py
+++ b/springfield/base/tests/test_geo.py
@@ -52,3 +52,21 @@ class TestGeo(TestCase):
 
         req = self.factory.get("/", data={"geo": "france"})
         assert get_country_from_request(req) is None
+
+    def test_geo_param_allowed_in_preview(self):
+        """?geo= should be accepted on the prod host when request.is_preview is True."""
+        req = self.factory.get("/", data={"geo": "fr"}, HTTP_CF_IPCOUNTRY="de", HTTP_HOST="www.firefox.com")
+        req.is_preview = True
+        assert get_country_from_request(req) == "FR"
+
+    def test_geo_param_blocked_on_prod_without_preview(self):
+        """?geo= should be ignored on the prod host when request.is_preview is not set."""
+        req = self.factory.get("/", data={"geo": "fr"}, HTTP_CF_IPCOUNTRY="de", HTTP_HOST="www.firefox.com")
+        assert get_country_from_request(req) == "DE"
+
+    @override_settings(DEV=False)
+    def test_invalid_geo_param_in_preview(self):
+        """Invalid ?geo= values should still be ignored even in preview."""
+        req = self.factory.get("/", data={"geo": "france"}, HTTP_CF_IPCOUNTRY="de", HTTP_HOST="www.firefox.com")
+        req.is_preview = True
+        assert get_country_from_request(req) == "DE"


### PR DESCRIPTION
Wagtail preview creates a dummy request using the page's production hostname (www.firefox.com). The ?geo= param is blocked when the host is www.firefox.com to prevent country spoofing by real users. But in preview, this hostname is artificial — set from the Site config, not from the actual browser request — so the block incorrectly prevents editors and QA from testing geo-dependent features like Smart Window view states via the CMS admin.

The fix checks request.is_preview (set server-side by Wagtail, only reachable through authenticated admin views) and allows ?geo= through for preview requests. Regular production requests are unaffected.


## Testing

Preview with ?geo= param

  - Open any page in Wagtail admin → Preview (new tab)
  - Add ?geo=US to the preview URL → data-country-code should return "US"
  - Add ?geo=DE to the preview URL → data-country-code should return "DE"
  - Works on both published and unpublished (draft) pages

  Smart Window preview specifically

  - Smart Window preview with ?geo=US → shows in-geo states (enable/update/download), red conditional
  outlines visible
  - Smart Window preview with ?geo=DE → shows waitlist form
  - Smart Window preview with ?geo=US&view=waitlist → shows waitlist form (override works)
  - Smart Window preview with ?geo=US&hide_preview=1 → shows page as real user would see it, no red
  outlines

  Production safety (on [www.firefox.com](http://www.firefox.com/))

  - Published page with ?geo=US on www.firefox.com → param is still blocked (geo comes from CDN header
  only)
  - Verify by checking data-country-code reflects actual location, not the param value

  No regressions

  - Other pages' preview still works normally
  - Conditional display red outlines still appear on other pages' previews
  - ?hide_preview=1 still hides red outlines on any page preview