### PR TITLE
Prefers reduced motion fixes

### DIFF
--- a/media/css/cms/flare26-card.css
+++ b/media/css/cms/flare26-card.css
@@ -802,9 +802,14 @@ Card Grid - Scroll variant
         overflow-x: auto;
     }
 
-    .fl-card-grid-scroll > * {
-        flex: 0 0 auto;
-        inline-size: clamp(260px, 30vw, 360px);
+    .fl-card-grid-scroll-inner {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: var(--token-spacing-lg);
+    }
+
+    .fl-testimonial-card:hover {
+        transform: none;
     }
 }
 

--- a/media/css/cms/flare26-sliding-carousel.css
+++ b/media/css/cms/flare26-sliding-carousel.css
@@ -130,6 +130,19 @@
     margin-block-end: var(--token-spacing-lg);
 }
 
+/* disable border animation and hide progress bar when user has reduced motion preferences enabled */
+@media (prefers-reduced-motion: reduce) {
+    .fl-sliding-carousel-control.is-active .fl-sliding-carousel-progress::after,
+    .fl-sliding-carousel-control.is-active .fl-sliding-carousel-box::after,
+    .fl-smart-window-instructions::after {
+        animation: none;
+    }
+
+    .fl-sliding-carousel-progress-wrapper {
+        display: none;
+    }
+}
+
 @keyframes fl-sliding-carousel-progress {
     from {
         inline-size: 0%;

--- a/media/js/cms/new.es6.js
+++ b/media/js/cms/new.es6.js
@@ -244,6 +244,42 @@ if (typeof window.cms === 'undefined') {
         });
     }
 
+    function honorReducedMotionForAutoplay() {
+        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches)
+            return;
+
+        document.querySelectorAll('video[autoplay]').forEach(function (video) {
+            // Pause immediately — more reliable than removing the autoplay attribute,
+            // which browsers may have already acted on before JS runs.
+            video.pause();
+
+            // Guard against the browser restarting playback (e.g. after seek).
+            video.addEventListener(
+                'play',
+                function () {
+                    video.pause();
+                },
+                { once: true }
+            );
+
+            // Update the paired pause/play button if one exists.
+            const container = video.closest('.fl-video');
+            const pauseBtn =
+                container && container.querySelector('.js-animation-pause');
+            if (pauseBtn) {
+                pauseBtn.classList.add('is-paused');
+                pauseBtn.setAttribute(
+                    'aria-label',
+                    pauseBtn.dataset.labelPlay || ''
+                );
+                const pauseIcon = pauseBtn.querySelector('.js-pause-icon');
+                const playIcon = pauseBtn.querySelector('.js-play-icon');
+                if (pauseIcon) pauseIcon.hidden = true;
+                if (playIcon) playIcon.hidden = false;
+            }
+        });
+    }
+
     function initVideoPlayers() {
         const videoButtons = document.querySelectorAll('.js-video-play');
 
@@ -275,7 +311,15 @@ if (typeof window.cms === 'undefined') {
 
                     const video = document.createElement('video');
                     video.controls = true;
-                    video.autoplay = true;
+
+                    if (
+                        window.matchMedia('(prefers-reduced-motion: reduce)')
+                            .matches
+                    ) {
+                        video.autoplay = false;
+                    } else {
+                        video.autoplay = true;
+                    }
 
                     if (posterUrl) {
                         video.poster = posterUrl;
@@ -608,6 +652,7 @@ if (typeof window.cms === 'undefined') {
             initVideoPlayers();
             initAnimations();
             initAnimationPauseButtons();
+            honorReducedMotionForAutoplay();
             initDownloadDropdown();
             initQRCodeSnippet();
             initTopicListSidebar();
@@ -623,6 +668,7 @@ if (typeof window.cms === 'undefined') {
         initVideoPlayers();
         initAnimations();
         initAnimationPauseButtons();
+        honorReducedMotionForAutoplay();
         initDownloadDropdown();
         initQRCodeSnippet();
         initTopicListSidebar();

--- a/springfield/cms/templates/cms/smart_window_page.html
+++ b/springfield/cms/templates/cms/smart_window_page.html
@@ -185,7 +185,7 @@
                 </div>
               </include:conditional-display>
               {# Show mobile message for mobile platforms #}
-              <include:conditional-display platform_conditions="{{ ['android', 'ios'] }}">
+              <include:conditional-display platform_conditions="{{ ['android', 'ios', 'unsupported'] }}">
                   {{ page.mobile_message|richtext }}
               </include:conditional-display>
             </include:conditional-display>


### PR DESCRIPTION
## One-line summary
Prefers Reduced Motion improvements

## Significant changes and points to review
* All `autoplay` videos are paused on load when reduced motion is preferred.
* The testimonial carousel design looks better when the animation is disabled
* (unrelated), I added `unsupported` to the display of the mobile conditional text. 

Before: 
<img width="2570" height="773" alt="image" src="https://github.com/user-attachments/assets/fb3d5543-20ff-4fef-88b1-110fb8c0be71" />

After: 
<img width="1676" height="566" alt="Screenshot 2026-04-21 at 10 19 32 AM" src="https://github.com/user-attachments/assets/ad53e44e-f724-463e-9c09-1227d074ad98" />

## Testing
<img width="689" height="457" alt="Screenshot 2026-04-21 at 10 20 03 AM" src="https://github.com/user-attachments/assets/27e31559-895d-4444-99e5-15dffebf6540" />
