### PR TITLE
Support redirecting /ai/ to waitlist mode of smart window page

### DIFF
--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -108,6 +108,13 @@ redirectpatterns = (
     ),
     # Bug 868182
     redirect(r"^mobile/faq/?$", firefox_mobile_faq, query=False),
+    redirect(
+        r"^ai/$",
+        "/smart-window/",
+        query={"view": "waitlist"},
+        permanent=False,
+        merge_query=False,
+    ),
 )
 
 permanent = settings.PERMANENT_CMS_REFRESH_REDIRECTS

--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -163,3 +163,18 @@ def test_refresh_redirects_not_in_redirectpatterns_when_disabled():
     assert resp is None
     # Reload to restore original state
     importlib.reload(redirects_module)
+
+
+@pytest.mark.parametrize(
+    "source, dest",
+    (
+        ("/ai/", "/smart-window/?view=waitlist"),  # no locale; middleware will later add the most appropriate locale
+        ("/en-US/ai/", "/en-US/smart-window/?view=waitlist"),  # with locale
+        ("/fr/ai/", "/fr/smart-window/?view=waitlist"),  # non-default locale
+        ("/en-GB/ai/?foo=bar", "/en-GB/smart-window/?view=waitlist"),  # incoming querystrings lost until WT-1086 is done
+    ),
+)
+def test_ai_redirect_to_smart_window_waitlist(client, source, dest):
+    resp = client.get(source, follow=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == dest


### PR DESCRIPTION
## One-line summary

Redirects visitors to /ai/ to the Smart Window waitlist signup page instead

## Issue / Bugzilla link

No ticket


## Testing
* http://localhost:8000/ai/ -> http://localhost:8000/en-US/smart-window/?view=waitlist
* http://localhost:8000/fr/ai/ -> http://localhost:8000/en-US/smart-window/?view=waitlist
* http://localhost:8000/en-GB/ai/ -> http://localhost:8000/en-GB/smart-window/?view=waitlist
* http://localhost:8000/en-GB/ai/?view=something-else -> http://localhost:8000/en-GB/smart-window/?view=waitlist