### PR TITLE
fix: skip failing /ai/ route test following addition of redirect to smart window

### DIFF
--- a/tests/playwright/specs/products/firefox/firefox-waitlist.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-waitlist.spec.js
@@ -10,7 +10,7 @@ const { test, expect } = require('@playwright/test');
 const openPage = require('../../../scripts/open-page');
 const url = '/en-US/ai';
 
-test.describe(
+test.describe.skip(
     `${url} page`,
     {
         tag: '@newsletter'


### PR DESCRIPTION
The redirect i added broke integration tests.

The code removal is ticketed for follow-up cleanup later https://mozilla-hub.atlassian.net/browse/WT-1087


Integration tests: https://github.com/mozmeao/springfield/actions/runs/24790615701