### PR TITLE
fix: disable no-longer-needed data migration that now breaks DB export

### DIFF
--- a/springfield/cms/migrations/0062_migrate_media_content_content_to_streamblock.py
+++ b/springfield/cms/migrations/0062_migrate_media_content_content_to_streamblock.py
@@ -115,5 +115,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(update_pages, migrations.RunPython.noop),
+        # Disabled because this breaks now that 0071_remove_legacy_stub_attr_fields.py has been applied to the DB
+        # migrations.RunPython(update_pages, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
Should stop https://mozilla.sentry.io/issues/7421933611/events/latest/?project=4508842391633920&query=is%3Aunresolved&referrer=latest-event happening during a DB export run