### PR TITLE
WT-1119 Add /healthz-cdn/ endpoint for Fastly CDN failover

### DIFF
--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -74,6 +74,20 @@ def test_healthz_cdn_fails_when_history_inconsistent(client):
         )
 
 
+def test_healthz_cdn_fails_when_column_missing(client):
+    from django.db import connection
+
+    # Return empty column list for all tables — makes every managed model appear
+    # to have all its columns missing, catching dropped-column schema drift.
+    with patch.object(connection.introspection, "get_table_description", return_value=[]):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="schema mismatch",
+        )
+
+
 def test_healthz_cron(client):
     _test(
         url="/healthz-cron/",

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -48,11 +48,6 @@ def test_healthz_cdn(client):
 def test_healthz_cdn_fails_when_migrations_pending(client):
     from django.db.migrations.executor import MigrationExecutor
 
-    from springfield.base.views import _healthz_cdn_cache
-
-    # Reset cache so the check actually runs
-    _healthz_cdn_cache["status"] = None
-
     class FakeMigration:
         app_label = "fake_app"
         name = "0001_fake"

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -70,7 +70,7 @@ def test_healthz_cdn_fails_when_history_inconsistent(client):
             url="/healthz-cdn/",
             client=client,
             expected_status=500,
-            expected_content="check error",
+            expected_content="migration history inconsistent",
         )
 
 

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -61,6 +61,19 @@ def test_healthz_cdn_fails_when_migrations_pending(client):
         )
 
 
+def test_healthz_cdn_fails_when_history_inconsistent(client):
+    from django.db.migrations.exceptions import InconsistentMigrationHistory
+    from django.db.migrations.loader import MigrationLoader
+
+    with patch.object(MigrationLoader, "check_consistent_history", side_effect=InconsistentMigrationHistory("test")):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="check error",
+        )
+
+
 def test_healthz_cron(client):
     _test(
         url="/healthz-cron/",

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from unittest.mock import patch
+
 import pytest
 
 pytestmark = pytest.mark.django_db
@@ -33,6 +35,35 @@ def test_readiness(client):
         url="/readiness/",
         client=client,
     )
+
+
+def test_healthz_cdn(client):
+    _test(
+        url="/healthz-cdn/",
+        client=client,
+        expected_content="pong",
+    )
+
+
+def test_healthz_cdn_fails_when_migrations_pending(client):
+    from django.db.migrations.executor import MigrationExecutor
+
+    from springfield.base.views import _healthz_cdn_cache
+
+    # Reset cache so the check actually runs
+    _healthz_cdn_cache["status"] = None
+
+    class FakeMigration:
+        app_label = "fake_app"
+        name = "0001_fake"
+
+    with patch.object(MigrationExecutor, "migration_plan", return_value=[(FakeMigration(), False)]):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="migrations pending",
+        )
 
 
 def test_healthz_cron(client):

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -148,16 +148,12 @@ def healthz_cdn(request):
         # This correctly handles Wagtail MTI subclasses, which each have their own table.
         with connection.cursor() as cursor:
             for model in apps.get_models():
-                if not model._meta.managed or model._meta.proxy:
+                if not model._meta.managed or model._meta.proxy or model._meta.app_label == "wagtailsearch":
                     continue
                 expected_cols = {f.column for f in model._meta.local_fields}
                 if not expected_cols:
                     continue
                 actual_cols = {col.name for col in connection.introspection.get_table_description(cursor, model._meta.db_table)}
-                # SQLite's implicit rowid is never listed by PRAGMA table_info() but is
-                # always accessible on every table, including FTS virtual tables.
-                if connection.vendor == "sqlite":
-                    actual_cols.add("rowid")
                 missing = expected_cols - actual_cols
                 if missing:
                     logger.error("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from os import getenv
 from time import time
 
+from django.apps import apps
 from django.conf import settings
 from django.db import connections
 from django.db.migrations.executor import MigrationExecutor
@@ -130,14 +131,38 @@ def healthz_cdn(request):
                 logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
 
         connection = connections["default"]
+
+        # Check 1: migration records — catches new code deployed before migrations run,
+        # and applied migrations whose dependencies are missing (InconsistentMigrationHistory).
         executor = MigrationExecutor(connection)
         executor.loader.check_consistent_history(connection)
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-
         if plan:
             unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
             logger.error("healthz_cdn: unapplied migrations: %s", unapplied)
             return HttpResponse("migrations pending", content_type="text/plain", status=500)
+
+        # Check 2: schema introspection — catches old code running after a column-dropping
+        # migration. Compares each managed model's expected columns (_meta.local_fields,
+        # which reflects what the running code expects) against the actual DB schema.
+        # This correctly handles Wagtail MTI subclasses, which each have their own table.
+        with connection.cursor() as cursor:
+            for model in apps.get_models():
+                if not model._meta.managed or model._meta.proxy:
+                    continue
+                expected_cols = {f.column for f in model._meta.local_fields}
+                if not expected_cols:
+                    continue
+                actual_cols = {col.name for col in connection.introspection.get_table_description(cursor, model._meta.db_table)}
+                # SQLite's implicit rowid is never listed by PRAGMA table_info() but is
+                # always accessible on every table, including FTS virtual tables.
+                if connection.vendor == "sqlite":
+                    actual_cols.add("rowid")
+                missing = expected_cols - actual_cols
+                if missing:
+                    logger.error("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)
+                    return HttpResponse("schema mismatch", content_type="text/plain", status=500)
+
     except Exception:
         logger.exception("healthz_cdn: check failed")
         return HttpResponse("check error", content_type="text/plain", status=500)

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -131,6 +131,7 @@ def healthz_cdn(request):
 
         connection = connections["default"]
         executor = MigrationExecutor(connection)
+        executor.loader.check_consistent_history(connection)
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
 
         if plan:

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -7,7 +7,7 @@ import logging
 import os.path
 from datetime import datetime
 from os import getenv
-from time import monotonic, time
+from time import time
 
 from django.conf import settings
 from django.db import connections
@@ -116,23 +116,18 @@ def get_extra_server_info():
 
 logger = logging.getLogger(__name__)
 
-_healthz_cdn_cache: dict = {"status": None, "body": None, "checked_at": 0}
-
 
 @require_safe
 @never_cache
 def healthz_cdn(request):
-    now = monotonic()
-    cache_ttl = getattr(settings, "HEALTHZ_CDN_CACHE_TTL", 45)
-
-    if _healthz_cdn_cache["status"] is not None and (now - _healthz_cdn_cache["checked_at"]) < cache_ttl:
-        return HttpResponse(_healthz_cdn_cache["body"], content_type="text/plain", status=_healthz_cdn_cache["status"])
-
     try:
         if settings.WATCHMAN_DISABLE_APM:
-            from watchman.views import _disable_apm
+            try:
+                from watchman.views import _disable_apm
 
-            _disable_apm()
+                _disable_apm()
+            except (ImportError, AttributeError):
+                logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
 
         connection = connections["default"]
         executor = MigrationExecutor(connection)
@@ -141,18 +136,12 @@ def healthz_cdn(request):
         if plan:
             unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
             logger.error("healthz_cdn: unapplied migrations: %s", unapplied)
-            status, body = 500, "migrations pending"
-        else:
-            status, body = 200, "pong"
+            return HttpResponse("migrations pending", content_type="text/plain", status=500)
     except Exception:
         logger.exception("healthz_cdn: check failed")
-        status, body = 500, "check error"
+        return HttpResponse("check error", content_type="text/plain", status=500)
 
-    _healthz_cdn_cache["status"] = status
-    _healthz_cdn_cache["body"] = body
-    _healthz_cdn_cache["checked_at"] = now
-
-    return HttpResponse(body, content_type="text/plain", status=status)
+    return HttpResponse("pong", content_type="text/plain")
 
 
 @require_safe

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -3,12 +3,16 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import json
+import logging
 import os.path
 from datetime import datetime
 from os import getenv
-from time import time
+from time import monotonic, time
 
 from django.conf import settings
+from django.db import connections
+from django.db.migrations.executor import MigrationExecutor
+from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
@@ -108,6 +112,47 @@ def get_extra_server_info():
             server_info[f"db_{key}"] = value
 
     return server_info
+
+
+logger = logging.getLogger(__name__)
+
+_healthz_cdn_cache: dict = {"status": None, "body": None, "checked_at": 0}
+
+
+@require_safe
+@never_cache
+def healthz_cdn(request):
+    now = monotonic()
+    cache_ttl = getattr(settings, "HEALTHZ_CDN_CACHE_TTL", 45)
+
+    if _healthz_cdn_cache["status"] is not None and (now - _healthz_cdn_cache["checked_at"]) < cache_ttl:
+        return HttpResponse(_healthz_cdn_cache["body"], content_type="text/plain", status=_healthz_cdn_cache["status"])
+
+    try:
+        if settings.WATCHMAN_DISABLE_APM:
+            from watchman.views import _disable_apm
+
+            _disable_apm()
+
+        connection = connections["default"]
+        executor = MigrationExecutor(connection)
+        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+
+        if plan:
+            unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
+            logger.error("healthz_cdn: unapplied migrations: %s", unapplied)
+            status, body = 500, "migrations pending"
+        else:
+            status, body = 200, "pong"
+    except Exception:
+        logger.exception("healthz_cdn: check failed")
+        status, body = 500, "check error"
+
+    _healthz_cdn_cache["status"] = status
+    _healthz_cdn_cache["body"] = body
+    _healthz_cdn_cache["checked_at"] = now
+
+    return HttpResponse(body, content_type="text/plain", status=status)
 
 
 @require_safe

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -12,6 +12,7 @@ from time import time
 from django.apps import apps
 from django.conf import settings
 from django.db import connections
+from django.db.migrations.exceptions import InconsistentMigrationHistory
 from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -135,7 +136,11 @@ def healthz_cdn(request):
         # Check 1: migration records — catches new code deployed before migrations run,
         # and applied migrations whose dependencies are missing (InconsistentMigrationHistory).
         executor = MigrationExecutor(connection)
-        executor.loader.check_consistent_history(connection)
+        try:
+            executor.loader.check_consistent_history(connection)
+        except InconsistentMigrationHistory as e:
+            logger.warning("healthz_cdn: inconsistent migration history: %s", e)
+            return HttpResponse("migration history inconsistent", content_type="text/plain", status=500)
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
         if plan:
             unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -139,7 +139,7 @@ def healthz_cdn(request):
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
         if plan:
             unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
-            logger.error("healthz_cdn: unapplied migrations: %s", unapplied)
+            logger.warning("healthz_cdn: unapplied migrations: %s", unapplied)
             return HttpResponse("migrations pending", content_type="text/plain", status=500)
 
         # Check 2: schema introspection — catches old code running after a column-dropping
@@ -161,7 +161,7 @@ def healthz_cdn(request):
                     actual_cols.add("rowid")
                 missing = expected_cols - actual_cols
                 if missing:
-                    logger.error("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)
+                    logger.warning("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)
                     return HttpResponse("schema mismatch", content_type="text/plain", status=500)
 
     except Exception:

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -154,6 +154,11 @@ def healthz_cdn(request):
                 if not expected_cols:
                     continue
                 actual_cols = {col.name for col in connection.introspection.get_table_description(cursor, model._meta.db_table)}
+                # SQLite's implicit rowid is never listed by PRAGMA table_info() but is
+                # always accessible on every table. Not needed in production (PostgreSQL)
+                # but allows local SQLite testing.
+                if connection.vendor == "sqlite":
+                    actual_cols.add("rowid")
                 missing = expected_cols - actual_cols
                 if missing:
                     logger.error("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -474,6 +474,7 @@ SUPPORTED_NONLOCALES = [
     "robots.txt",
     ".well-known",
     "healthz",  # Needed for k8s
+    "healthz-cdn",  # Needed for Fastly CDN health checks
     "readiness",  # Needed for k8s
     "healthz-cron",  # status dash
     "revision.txt",  # from root_files
@@ -784,7 +785,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = config("SECURE_CONTENT_TYPE_NOSNIFF", default="tru
 SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", default=str(not DISABLE_SSL), parser=bool)
 SECURE_REDIRECT_EXEMPT = [
     r"^readiness/$",
-    r"^healthz(-cron)?/$",
+    r"^healthz(-cron|-cdn)?/$",
 ]
 if config("USE_SECURE_PROXY_HEADER", default=str(SECURE_SSL_REDIRECT), parser=bool):
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
@@ -797,6 +798,9 @@ WATCHMAN_CHECKS = (
     "watchman.checks.caches",
     "watchman.checks.databases",
 )
+
+# CDN health check: seconds to cache the migration plan result between checks
+HEALTHZ_CDN_CACHE_TTL = config("HEALTHZ_CDN_CACHE_TTL", default="45", parser=int)
 
 
 def _is_springfield_custom_app(app_name):

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -514,7 +514,7 @@ NOINDEX_URLS = [
     r"^thanks/$",
     r"^analytics-tests/",
     r"^readiness/$",
-    r"^healthz(-cron)?/$",
+    r"^healthz(-cron|-cdn)?/$",
     # exclude redirects
     r"^firefox/notes/$",
 ]
@@ -798,9 +798,6 @@ WATCHMAN_CHECKS = (
     "watchman.checks.caches",
     "watchman.checks.databases",
 )
-
-# CDN health check: seconds to cache the migration plan result between checks
-HEALTHZ_CDN_CACHE_TTL = config("HEALTHZ_CDN_CACHE_TTL", default="45", parser=int)
 
 
 def _is_springfield_custom_app(app_name):

--- a/springfield/urls.py
+++ b/springfield/urls.py
@@ -38,6 +38,7 @@ urlpatterns += (
     path("", include("springfield.base.nonlocale_urls")),
     path("", include("springfield.sitemaps.urls")),
     path("healthz/", watchman_views.ping, name="watchman.ping"),
+    path("healthz-cdn/", base_views.healthz_cdn, name="healthz-cdn"),
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("healthz-cron/", base_views.cron_health_check),
     path("_documents/", include(wagtaildocs_urls)),


### PR DESCRIPTION
## Summary

Adds a new `/healthz-cdn/` endpoint for Fastly CDN health checks. During a recent outage, `/healthz/` kept returning 200 while the site was serving 500s, preventing Fastly from failing over using our [static fallback page](https://mozmeao-www-error-page.netlify.app/) as its origin instead. 

The root cause of the pages 500ing was a column-dropping migration applied to the DB while app servers running the previous code version still expected that column (There's a separate process-improvement workflow going on to remedy that side of things.) However, the `/healthz/` endpoint was not affected by the DB schema issue so reported that all was OK. 

The new endpoint speficially for the CDN runs two checks:

**1. Migration record consistency** (`MigrationExecutor.migration_plan` + `check_consistent_history`)
Catches new code deployed before migrations run, and applied migrations whose dependencies are missing.

**2. Schema introspection**
Compares each managed model's expected columns (`_meta.local_fields`, i.e. what the running code expects) against the actual DB schema. Correctly handles Wagtail MTI page subclasses — each has its own table, and a dropped column there is invisible to a query on the base `Page` model.

## Why not change `/healthz/` directly?

k8s uses `/healthz/` as its **liveness probe** — failure causes pod restarts. During a rolling update, old pods would have migrations in the DB that aren't in their code, triggering liveness failures and premature restarts. `/readiness/` is also left unchanged for the same reason (readiness failure removes pods from the load balancer). A separate endpoint for Fastly avoids both risks.

## Follow-up required

Fastly needs reconfiguring to health-check `/healthz-cdn/` instead of `/healthz/`, starting ONLY with Dev. This PR is the application-side change only.

## Test plan

```
pytest springfield/base/tests/test_urls.py
```

### Manual local testing

**Baseline — should return 200:**
```
curl -i http://localhost:8000/healthz-cdn/
```

**Simulate a column-dropping migration** while app code is still looking for that column 
```
sqlite3 data/springfield.db "ALTER TABLE cms_whatsnewpage DROP COLUMN stub_attr_utm_campaign_value;"
```
→ `/healthz-cdn/` should now return 500 `schema mismatch`

Restore:
```
./bin/run-db-download.py --force
```

**Simulate unapplied migrations** (new code deployed before `manage.py migrate` runs):
```
sqlite3 data/springfield.db "DELETE FROM django_migrations WHERE app='cms' AND name='0076_alter_smartwindowpage_post_download_instructions';"
```
→ `/healthz-cdn/` should return 500 `migrations pending`


Restore:
```
./bin/run-db-download.py --force
```
