### PR TITLE
fix: avoid blow-up when DB is in maintenance mode

### DIFF
--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -147,7 +147,7 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
     # if `active_locales` is given use it as the full list of active translations
     translations = []
 
-    if is_cms_page and request._locales_available_via_cms:
+    if is_cms_page and hasattr(request, "_locales_available_via_cms") and request._locales_available_via_cms:
         translations = request._locales_available_via_cms
     elif "active_locales" in context:
         translations = context["active_locales"]

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import logging
 from os.path import splitext
 
 from django.conf import settings
@@ -18,6 +19,8 @@ from springfield.base.i18n import normalize_language, split_path_and_normalize_l
 from springfield.settings.base import language_url_map_with_fallbacks
 
 from .fluent import fluent_l10n, ftl_file_is_active, get_active_locales as ftl_active_locales
+
+log = logging.getLogger(__name__)
 
 
 def render_to_string(template_name, context=None, request=None, using=None, ftl_files=None):
@@ -167,6 +170,11 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
             del context["add_active_locales"]
 
         if not translations:
+            if is_cms_page and not hasattr(request, "_locales_available_via_cms"):
+                log.warning(
+                    "render(): is_cms_page is True but _locales_available_via_cms was not set "
+                    "on request — DB unavailable? Falling back to LANGUAGE_CODE."
+                )
             translations = [settings.LANGUAGE_CODE]
 
     context["translations"] = get_translations_native_names(translations)

--- a/lib/l10n_utils/tests/test_base.py
+++ b/lib/l10n_utils/tests/test_base.py
@@ -217,6 +217,22 @@ class TestRender(TestCase):
             any_order=True,
         )
 
+    @patch.object(l10n_utils, "django_render")
+    def test_cms_page_without_locales_available_does_not_raise(self, dr_mock):
+        """Regression: render() must not blow up when is_cms_page is True but
+        _locales_available_via_cms was never set (e.g. DB unavailable during maintenance)."""
+        path = "/en-US/download/"
+        template = "firefox/download.html"
+        request = RequestFactory().get(path)
+        request.locale = "en-US"
+        request.is_cms_page = True
+        # _locales_available_via_cms deliberately not set
+
+        # Should not raise AttributeError
+        l10n_utils.render(request, template)
+
+        dr_mock.assert_called_once()
+
 
 class TestGetAcceptLanguages(TestCase):
     def _test(self, accept_lang, list):


### PR DESCRIPTION
In response to https://mozilla.sentry.io/issues/7449029422/

When the DB is unavailable, we should survive without it wherever possible 

