### PR TITLE
Prevent GitHub Actions on forks (WT-1124)

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -91,7 +91,7 @@ jobs:
           if-no-files-found: ignore  # this avoids a false "Warning" if there were no issues
 
   notify-of-test-run-completion:
-    if: always()
+    if: always() && github.repository == 'mozmeao/springfield'
     needs: cdn-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/db_sync.yml
+++ b/.github/workflows/db_sync.yml
@@ -34,6 +34,7 @@ jobs:
   sync:
     name: "Sync ${{ inputs.source }} → ${{ inputs.target }}"
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     environment: db-sync
     concurrency:
       group: db-sync-${{ inputs.target }}

--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     name: Deploy Heroku
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   linter:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   notify-of-test-run-start:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,6 +42,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     strategy:
       matrix:
         include:
@@ -98,7 +100,7 @@ jobs:
           if-no-files-found: ignore  # this avoids a false "Warning" if there were no issues
 
   playwright-tests:
-    if: always()
+    if: always() && github.repository == 'mozmeao/springfield'
     runs-on: ubuntu-latest
     env:
       PLAYWRIGHT_BASE_URL: ${{ github.event.inputs.springfield_service_hostname }}
@@ -121,7 +123,7 @@ jobs:
         retention-days: 30
 
   notify-of-test-run-completion:
-    if: always()
+    if: always() && github.repository == 'mozmeao/springfield'
     runs-on: ubuntu-latest
     needs: [integration-tests, playwright-tests]
     steps:

--- a/.github/workflows/post_deploy_asset_check.yml
+++ b/.github/workflows/post_deploy_asset_check.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   notify-of-checks-start:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,6 +45,7 @@ jobs:
 
   asset-check:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     env:
       GIT_SHA: ${{ inputs.git_sha }}
       ORIGIN_HOSTNAME: ${{ inputs.origin_hostname }}
@@ -61,7 +63,7 @@ jobs:
               --manifest-path static/staticfiles.json
 
   notify-of-checks-completion:
-    if: always()
+    if: always() && github.repository == 'mozmeao/springfield'
     runs-on: ubuntu-latest
     needs: [asset-check]
     steps:

--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -7,6 +7,7 @@ jobs:
   create_issue:
     name: Create l10n cleanup issue
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     permissions:
       issues: write
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   test-js:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
@@ -28,6 +29,7 @@ jobs:
 
   test-python:
     runs-on: ubuntu-latest
+    if: github.repository == 'mozmeao/springfield'
     steps:
       - uses: actions/checkout@v6
       - name: "Run Python tests (on Docker)"


### PR DESCRIPTION
# Summary

Add `if: github.repository == 'mozmeao/springfield'` guards to GitHub Actions workflows that were missing them, so none of them run on forks.

# Background

We observed noisy emails from CDN tests on forks. The `cdn-tests` job is correctly guarded with `if: github.repository == 'mozmeao/springfield'`, but `notify-of-test-run-completion` uses `if: always()` without the same guard. That completion job still executes on forks (including `workflow_dispatch`), so the workflow appears to run on forks even though the main `cdn-tests` job is skipped. Adding a repository condition to the completion job prevents any fork execution.

# Problem

Several GitHub Actions workflows were triggering on forks, either on a schedule, on push, or when manually dispatched by a fork owner. This caused two classes of issues:

* Failure emails: jobs that use secrets (Slack, SauceLabs, Heroku) fail silently on forks because secrets are not passed, generating noise for maintainers.
* Unintended side-effects: `routine_l10n_obsolete.yml` uses `GITHUB_TOKEN` which is available on forks, meaning it would actually create l10n cleanup issues on fork repositories.

# Changes

* `cdn_tests.yml`: The `notify-of-test-run-completion` job had `if: always()` without a repo check. Because `if: always()` overrides skipped upstream dependencies, this job ran on forks even when the `cdn-tests` job was correctly skipped, causing failure emails from missing secrets.
* `routine_l10n_obsolete.yml`: This is a scheduled workflow that uses `GITHUB_TOKEN`, which is automatically available on forks. Without the guard it would open GitHub issues on fork repositories on a bimonthly schedule.
* `demo_deploy.yml`: Triggered on pushes to `demo/*` branches. Any fork with such a branch would trigger a Heroku deploy attempt, fail on the missing `HEROKU_API_KEY` secret, and send failure email notifications.
* `integration_tests.yml`: No job had a repo check. Being `workflow_dispatch`-only lowers the risk, but running it on a fork would fail due to missing secrets and generate failure emails. Added guards to all four jobs, using `if: always() && ...` where `always()` was already present.
* `post_deploy_asset_check.yml`: Same situation as `integration_tests.yml`: `workflow_dispatch`-only, no repo checks, missing secrets would cause failures and emails.
* `db_sync.yml`: Same situation: `workflow_dispatch`-only with no repo check.
* `unit_tests.yml` and `fluent_linter.yml`: These don't use secrets and wouldn't fail on forks, but they would run unnecessarily on fork pushes to `main`. Added guards for consistency.

# Not changed

`a11y_tests.yml`, `download_tests.yml`, `build-and-push.yml`, `generate-gh-release-note.yml`, and `send_firefox_fluent_strings_to_l10n_org.yml` were already correctly guarded and required no changes.