### PR TITLE
Update aria-expanded text on download drop down

### DIFF
--- a/media/js/cms/components/flare26-download-dropdown.es6.js
+++ b/media/js/cms/components/flare26-download-dropdown.es6.js
@@ -24,12 +24,14 @@ function initDownloadDropdown() {
         dropdownEl.addEventListener('keyup', function (e) {
             if (e.key === 'Escape') {
                 dropdownEl.classList.remove('dropdown-is-open');
+                dropdownButtonEl.setAttribute('aria-expanded', false);
             }
         });
 
         window.addEventListener('click', function (e) {
             if (!dropdownEl.contains(e.target)) {
                 dropdownEl.classList.remove('dropdown-is-open');
+                dropdownButtonEl.setAttribute('aria-expanded', false);
             }
         });
     }

--- a/media/js/cms/components/flare26-download-dropdown.es6.js
+++ b/media/js/cms/components/flare26-download-dropdown.es6.js
@@ -14,8 +14,10 @@ function initDownloadDropdown() {
         dropdownButtonEl.addEventListener('click', function () {
             if (dropdownEl.classList.contains('dropdown-is-open')) {
                 dropdownEl.classList.remove('dropdown-is-open');
+                dropdownButtonEl.setAttribute('aria-expanded', false);
             } else {
                 dropdownEl.classList.add('dropdown-is-open');
+                dropdownButtonEl.setAttribute('aria-expanded', true);
             }
         });
 


### PR DESCRIPTION
## One-line summary

`aria-expanded` was not being updated on the download page drop down.

## Issue / Bugzilla link
https://github.com/mozmeao/springfield/issues/1307

## Testing
- [ ] Checkout this PR
- [ ] Navigate to http://localhost:8000/en-US/download/mac/
- [ ] Open and close the dropdown observing the `aria-expanded` value updates accordingly (including keyboard navigation)