### PR TITLE
Fix missing CSS bundles in prod build

### DIFF
--- a/media/css/cms/pages/flare26-channels.css
+++ b/media/css/cms/pages/flare26-channels.css
@@ -11,9 +11,6 @@
     what should be refactored away here.
 */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-brand-icon,
     .fl-brand-icon-wrap img {

--- a/media/css/cms/pages/flare26-cookie-settings.css
+++ b/media/css/cms/pages/flare26-cookie-settings.css
@@ -4,9 +4,6 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-page-cookie-settings .cookie-consent-form ul {
         list-style: none;

--- a/media/css/cms/pages/flare26-developer-edition.css
+++ b/media/css/cms/pages/flare26-developer-edition.css
@@ -1,6 +1,3 @@
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-page-developer .fl-section:last-child {
         padding-block-end: 0;

--- a/media/css/cms/pages/flare26-download.css
+++ b/media/css/cms/pages/flare26-download.css
@@ -1,6 +1,3 @@
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-download-intro {
         align-items: center;

--- a/media/css/cms/pages/flare26-download_all.css
+++ b/media/css/cms/pages/flare26-download_all.css
@@ -6,9 +6,6 @@
 
 /* NOTE: this file is _all instead of -all to avoid being hidden by a gitignore rule */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-download-all .fl-intro {
         padding-inline: var(--token-spacing-lg);

--- a/media/css/cms/pages/flare26-enterprise.css
+++ b/media/css/cms/pages/flare26-enterprise.css
@@ -4,9 +4,6 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     main.fl-2026-enterprise {
         background-color: var(--fl-theme-background);

--- a/media/css/cms/pages/flare26-homepage.css
+++ b/media/css/cms/pages/flare26-homepage.css
@@ -4,9 +4,6 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-home-body {
         background: var(--token-color-dark-purple);

--- a/media/css/cms/pages/flare26-landing-get-page.css
+++ b/media/css/cms/pages/flare26-landing-get-page.css
@@ -4,9 +4,6 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-landing-get .fl-main {
         padding-block-end: 0;

--- a/media/css/cms/pages/flare26-mobile-pages.css
+++ b/media/css/cms/pages/flare26-mobile-pages.css
@@ -2,9 +2,6 @@
 
 /* todo: fix over-reliance on body classes */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-mobile-subpage #playStoreLink-primary img,
     .fl-mobile-subpage #playStoreLink-footer img {

--- a/media/css/cms/pages/flare26-release-notes.css
+++ b/media/css/cms/pages/flare26-release-notes.css
@@ -4,9 +4,6 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-release-notes {
         --release-notes-padding: var(--token-spacing-lg) * 2;

--- a/media/css/cms/pages/flare26-smart-window.css
+++ b/media/css/cms/pages/flare26-smart-window.css
@@ -1,6 +1,3 @@
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     .fl-smart-window-explainer-hero {
         background: var(--smart-window-background-gradient);

--- a/media/css/cms/pages/flare26-user-privacy.css
+++ b/media/css/cms/pages/flare26-user-privacy.css
@@ -1,6 +1,3 @@
-/* Required for postcss-custom-media to resolve @custom-media variables in standalone bundles */
-@import 'flare26-tokens.css';
-
 @layer page {
     /* TODO: remove unused css when the cms version goes live */
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -464,60 +464,70 @@
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-channels.css"
       ],
       "name": "flare26-channels"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-cookie-settings.css"
       ],
       "name": "flare26-cookie-settings"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-developer-edition.css"
       ],
       "name": "flare26-developer-edition"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-download.css"
       ],
       "name": "flare26-download"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-download_all.css"
       ],
       "name": "flare26-download-all"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-enterprise.css"
       ],
       "name": "flare26-enterprise"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-homepage.css"
       ],
       "name": "flare26-homepage"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-landing-get-page.css"
       ],
       "name": "flare26-landing-get-page"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-mobile-pages.css"
       ],
       "name": "flare26-mobile-pages"
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-release-notes.css"
       ],
       "name": "flare26-release-notes"
@@ -530,6 +540,7 @@
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-smart-window.css"
       ],
       "name": "flare26-smart-window"
@@ -548,6 +559,7 @@
     },
     {
       "files": [
+        "css/cms/flare26-tokens.css",
         "css/cms/pages/flare26-user-privacy.css"
       ],
       "name": "flare26-user-privacy"


### PR DESCRIPTION
## One-line summary

Fixes errors in production build, i.e. "Post-processing 'css/cms/pages/flare26-cookie-settings.css' failed!"

NOTE: this is **not** a production bug. It's an issue with our `main` branch that we need to resolve before next prod deploy

## Significant changes and points to review
As noted in the CSS comments, the flare26-tokens import is needed in standalone bundles for postcss-custom-media to resolve `@custom-media` variables.

This works as expected with CSS file imports when run through webpack, but the files are not typical relative paths, so all imports in the pages folder are failing to be found on staticfile production builds.

Moving to a typical relative file path structure (../flare26-tokens) creates an error with the custom webpack loader.

Adding the required files into the static bundles instead of importing through the CSS file is the simplest CSS fix to unblock deploys. We may want to revisit to work more seamlessly with the flare-import-anywhere webpack loader.


## Issue / Bugzilla link
https://github.com/mozmeao/springfield/actions/runs/25414000246/job/74541466354


## Testing
Run in [Prod Mode](https://mozmeao.github.io/platform-docs/getting-started/running-locally/#prod-mode) and confirm no errors
Smoke check one or two of the affected pages:
- http://localhost:8000/en-US/
- http://127.0.0.1:8000/en-US/firefox/150.0.2/releasenotes/ (confirm larger screens show three columns on pre-footer notes)

Successful integration test run: ❌ ([new playwright test failures after successful build](https://github.com/mozmeao/springfield/actions/runs/25430003245))