### PR TITLE
Add channels css to the release notes bundle, fixing missing css issues

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -518,6 +518,7 @@
     },
     {
       "files": [
+        "css/cms/pages/flare26-channels.css",
         "css/cms/pages/flare26-release-notes.css"
       ],
       "name": "flare26-release-notes"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -476,6 +476,7 @@
     },
     {
       "files": [
+        "css/cms/pages/flare26-channels.css",
         "css/cms/pages/flare26-developer-edition.css"
       ],
       "name": "flare26-developer-edition"

--- a/springfield/firefox/templates/firefox/developer/index.html
+++ b/springfield/firefox/templates/firefox/developer/index.html
@@ -18,7 +18,6 @@
 
 {% block page_css %}
   {% if switch("flare26_enabled") %}
-    {{ css_bundle('flare26-channels') }}
     {{ css_bundle('flare26-developer-edition') }}
   {% else %}
     {{ css_bundle('protocol-split') }}


### PR DESCRIPTION
## One-line summary

This PR adds the channels css file to the release notes page bundle, fixing missing css issues. It also refactors the import on the ff dev edition page, so it imports a single file instead of two.

## Testing

Either: 
- run the integration tests locally to verify the release notes tests are now passing (cd to the tests/playwright folder and run npm run integration-tests)
- or manually go to a release notes page (I used http://localhost:8000/en-US/firefox/137.0/releasenotes/) with the user agent as something that's not firefox, and verify that the buttons appear correctly, without anything broken in the layout