### PR TITLE
feat: Extend WNP evergreen redirect to support Nightly, Developer, and Beta

### DIFF
--- a/springfield/cms/tests/factories.py
+++ b/springfield/cms/tests/factories.py
@@ -79,6 +79,36 @@ class GeneralWhatsNewPage2026Factory(wagtail_factories.PageFactory):
         model = models.WhatsNewPage2026
 
 
+class NightlyWhatsNewPage2026Factory(wagtail_factories.PageFactory):
+    title = "What's New in Firefox Nightly"
+    live = True
+    slug = "nightly"
+    version = "nightly"
+
+    class Meta:
+        model = models.WhatsNewPage2026
+
+
+class DeveloperWhatsNewPage2026Factory(wagtail_factories.PageFactory):
+    title = "What's New in Firefox Developer Edition"
+    live = True
+    slug = "developer"
+    version = "developer"
+
+    class Meta:
+        model = models.WhatsNewPage2026
+
+
+class BetaWhatsNewPage2026Factory(wagtail_factories.PageFactory):
+    title = "What's New in Firefox Beta"
+    live = True
+    slug = "beta"
+    version = "beta"
+
+    class Meta:
+        model = models.WhatsNewPage2026
+
+
 class FreeFormPageFactory(wagtail_factories.PageFactory):
     title = "Test FreeFormPage"
     live = True

--- a/springfield/cms/tests/test_wnp_general_redirects.py
+++ b/springfield/cms/tests/test_wnp_general_redirects.py
@@ -7,10 +7,10 @@ Tests for the channel-aware WNP redirect behaviour.
 
 When a user requests /LOCALE/whatsnew/VERSION/ and there is no version-specific
 CMS WNP, we check for a channel-specific CMS WNP and 302 to it:
-  - Nightly (a1 suffix)  → /LOCALE/whatsnew/nightly/?version=VERSION
+  - Nightly (a1 suffix)   → /LOCALE/whatsnew/nightly/?version=VERSION
   - Developer (a2 suffix) → /LOCALE/whatsnew/developer/?version=VERSION
-  - Beta (b/beta suffix) → /LOCALE/whatsnew/beta/?version=VERSION
-  - Release              → /LOCALE/whatsnew/general/?version=VERSION
+  - Beta (beta suffix)    → /LOCALE/whatsnew/beta/?version=VERSION
+  - Release               → /LOCALE/whatsnew/general/?version=VERSION
 
 If no channel-specific CMS WNP exists for the locale (or its CMS fallback
 locale), the static evergreen page is rendered instead.

--- a/springfield/cms/tests/test_wnp_general_redirects.py
+++ b/springfield/cms/tests/test_wnp_general_redirects.py
@@ -3,11 +3,17 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """
-Tests for the General WNP redirect behaviour (WT-1038).
+Tests for the channel-aware WNP redirect behaviour.
 
 When a user requests /LOCALE/whatsnew/VERSION/ and there is no version-specific
-CMS WNP but a General WNP (slug='general') exists for the locale (or its CMS
-fallback locale), we 302 to /LOCALE/whatsnew/general/?version=VERSION.
+CMS WNP, we check for a channel-specific CMS WNP and 302 to it:
+  - Nightly (a1 suffix)  → /LOCALE/whatsnew/nightly/?version=VERSION
+  - Developer (a2 suffix) → /LOCALE/whatsnew/developer/?version=VERSION
+  - Beta (b/beta suffix) → /LOCALE/whatsnew/beta/?version=VERSION
+  - Release              → /LOCALE/whatsnew/general/?version=VERSION
+
+If no channel-specific CMS WNP exists for the locale (or its CMS fallback
+locale), the static evergreen page is rendered instead.
 """
 
 from django.test import override_settings
@@ -17,7 +23,10 @@ from wagtail.models import Locale, Site
 
 from springfield.cms.models import SimpleRichTextPage
 from springfield.cms.tests.factories import (
+    BetaWhatsNewPage2026Factory,
+    DeveloperWhatsNewPage2026Factory,
     GeneralWhatsNewPage2026Factory,
+    NightlyWhatsNewPage2026Factory,
     WhatsNewIndexPageFactory,
     WhatsNewPage2026Factory,
 )
@@ -36,6 +45,30 @@ def wnp_index_page(minimal_site):
 def general_wnp(wnp_index_page):
     """A live General WNP (slug='general') under the whatsnew index in en-US."""
     page = GeneralWhatsNewPage2026Factory(parent=wnp_index_page)
+    page.save_revision().publish()
+    return page
+
+
+@pytest.fixture
+def nightly_wnp(wnp_index_page):
+    """A live Nightly WNP (slug='nightly') under the whatsnew index in en-US."""
+    page = NightlyWhatsNewPage2026Factory(parent=wnp_index_page)
+    page.save_revision().publish()
+    return page
+
+
+@pytest.fixture
+def developer_wnp(wnp_index_page):
+    """A live Developer WNP (slug='developer') under the whatsnew index in en-US."""
+    page = DeveloperWhatsNewPage2026Factory(parent=wnp_index_page)
+    page.save_revision().publish()
+    return page
+
+
+@pytest.fixture
+def beta_wnp(wnp_index_page):
+    """A live Beta WNP (slug='beta') under the whatsnew index in en-US."""
+    page = BetaWhatsNewPage2026Factory(parent=wnp_index_page)
     page.save_revision().publish()
     return page
 
@@ -180,3 +213,106 @@ def test_alias_locale_redirects_to_alias_url_when_fallback_has_general_wnp(
     location = response["Location"]
     assert location.startswith("/pt-PT/whatsnew/general/")
     assert "version=151" in location
+
+
+# ---------------------------------------------------------------------------
+# Channel-specific redirects (nightly, developer, beta)
+# ---------------------------------------------------------------------------
+
+
+def test_nightly_redirects_to_nightly_wnp(nightly_wnp, client):
+    """302 to nightly WNP when version ends with a1 and a nightly CMS page exists."""
+    response = client.get("/en-US/whatsnew/152.0a1/")
+    assert response.status_code == 302
+    location = response["Location"]
+    assert location.startswith("/en-US/whatsnew/nightly/")
+    assert "version=152.0a1" in location
+
+
+def test_developer_redirects_to_developer_wnp(developer_wnp, client):
+    """302 to developer WNP when version ends with a2 and a developer CMS page exists."""
+    response = client.get("/en-US/whatsnew/152.0a2/")
+    assert response.status_code == 302
+    location = response["Location"]
+    assert location.startswith("/en-US/whatsnew/developer/")
+    assert "version=152.0a2" in location
+
+
+def test_beta_redirects_to_beta_wnp_with_beta_suffix(beta_wnp, client):
+    """302 to beta WNP when version ends with 'beta' and a beta CMS page exists."""
+    response = client.get("/en-US/whatsnew/152.0beta/")
+    assert response.status_code == 302
+    location = response["Location"]
+    assert location.startswith("/en-US/whatsnew/beta/")
+    assert "version=152.0beta" in location
+
+
+# ---------------------------------------------------------------------------
+# Channel-specific fallback to static evergreen pages
+# ---------------------------------------------------------------------------
+
+
+def test_nightly_falls_back_to_static_when_no_nightly_wnp(wnp_index_page, client):
+    """When no nightly CMS WNP is published, the static nightly evergreen page renders."""
+    response = client.get("/en-US/whatsnew/152.0a1/")
+    assert response.status_code == 200
+    assert "Location" not in response
+
+
+def test_developer_falls_back_to_static_when_no_developer_wnp(wnp_index_page, client):
+    """When no developer CMS WNP is published, the static developer evergreen page renders."""
+    response = client.get("/en-US/whatsnew/152.0a2/")
+    assert response.status_code == 200
+    assert "Location" not in response
+
+
+def test_beta_falls_back_to_static_when_no_beta_wnp(wnp_index_page, client):
+    """When no beta CMS WNP is published, the static release evergreen page renders."""
+    response = client.get("/en-US/whatsnew/152.0beta/")
+    assert response.status_code == 200
+    assert "Location" not in response
+
+
+def test_nightly_does_not_redirect_to_general_wnp(general_wnp, client):
+    """A nightly version does not redirect to the general WNP even if one exists."""
+    response = client.get("/en-US/whatsnew/152.0a1/")
+    assert response.status_code == 200
+    assert "Location" not in response
+
+
+def test_developer_does_not_redirect_to_general_wnp(general_wnp, client):
+    """A developer version does not redirect to the general WNP even if one exists."""
+    response = client.get("/en-US/whatsnew/152.0a2/")
+    assert response.status_code == 200
+    assert "Location" not in response
+
+
+def test_beta_does_not_redirect_to_general_wnp(general_wnp, client):
+    """A beta version does not redirect to the general WNP even if one exists."""
+    response = client.get("/en-US/whatsnew/152.0beta/")
+    assert response.status_code == 200
+    assert "Location" not in response
+
+
+# ---------------------------------------------------------------------------
+# No redirect loop for channel slugs
+# ---------------------------------------------------------------------------
+
+
+def test_nightly_wnp_url_served_directly_without_loop(nightly_wnp, client):
+    """/LOCALE/whatsnew/nightly/ does not match the version URL patterns, so
+    WhatsnewView is never called.  Wagtail's catch-all serves the page as 200."""
+    response = client.get("/en-US/whatsnew/nightly/")
+    assert response.status_code == 200
+
+
+def test_developer_wnp_url_served_directly_without_loop(developer_wnp, client):
+    """/LOCALE/whatsnew/developer/ does not match the version URL patterns."""
+    response = client.get("/en-US/whatsnew/developer/")
+    assert response.status_code == 200
+
+
+def test_beta_wnp_url_served_directly_without_loop(beta_wnp, client):
+    """/LOCALE/whatsnew/beta/ does not match the version URL patterns."""
+    response = client.get("/en-US/whatsnew/beta/")
+    assert response.status_code == 200

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -763,6 +763,31 @@ class TestWhatsNew(TestCase):
     # end URL routing tests
 
 
+class TestDetectChannel(TestCase):
+    def test_nightly_a1(self):
+        assert views.detect_channel("152.0a1") == "nightly"
+
+    def test_developer_a2(self):
+        assert views.detect_channel("152.0a2") == "developer"
+
+    def test_beta_beta_suffix(self):
+        assert views.detect_channel("152.0beta") == "beta"
+
+    def test_beta_b_suffix_not_detected(self):
+        # Only the full "beta" suffix is recognised; short "b1" form is not.
+        assert views.detect_channel("152.0b1") == "unknown"
+
+    def test_release_returns_unknown(self):
+        assert views.detect_channel("152.0") == "unknown"
+
+    def test_three_digit_release_returns_unknown(self):
+        assert views.detect_channel("152") == "unknown"
+
+    def test_old_version_returns_unknown(self):
+        # versions below 35 always return unknown regardless of suffix
+        assert views.detect_channel("34.0a1") == "unknown"
+
+
 @pytest.mark.parametrize(
     "ua, expected",
     (

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -917,11 +917,26 @@ def detect_channel(version):
                 return "nightly"
             if version.endswith("a2"):
                 return "developer"
+            if version.endswith("beta"):
+                return "beta"
 
     return "unknown"
 
 
 class WhatsnewView(L10nTemplateView):
+    # This view is decorated with prefer_cms in urls.py, so will only be called if
+    # there is NOT already a What's New Page that directly matches the request path
+    # (eg /en-US/whatsnew/150/ will have matched a CMS-backed WNP, but
+    # /cy/whatsnew/150/ would have not because cy is not currently a CMS-backed locale
+    #
+    # As such, this view will either
+    # a) redirect to a CMS-backed "evergreen" WNP (for Nightly, Developer or the
+    # "general" WNP for FF Release) IF the request's locale is supported by the CMS
+    # or
+    # b) render a static Django-powered evergreen WNP for Nightly, Developer or Beta,
+    # using Fluent string for L10N, which will cover the locales that are not supported
+    # by the CMS
+
     ftl_files_map = {
         "firefox/whatsnew/nightly/evergreen.html": ["firefox/whatsnew/nightly/evergreen"],
         "firefox/whatsnew/developer/evergreen.html": ["firefox/whatsnew/developer/evergreen"],
@@ -934,24 +949,42 @@ class WhatsnewView(L10nTemplateView):
     # Nimbus experiment variation expected values
     nimbus_variations = ["v1", "v2", "v3", "v4"]
 
-    def _get_general_wnp_redirect(self, request, version):
+    # Maps detect_channel() return values to the WNP CMS slug to redirect to.
+    # Channels absent from this map (i.e. "unknown") fall back to "general".
+    _CHANNEL_WNP_SLUGS = {
+        "nightly": "nightly",
+        "developer": "developer",
+        "beta": "beta",
+    }
+
+    def _get_evergreen_wnp_redirect(self, request, version):
         """
-        If a General WNP (slug='general') exists in the CMS for the request locale
-        (or its configured CMS fallback locale), return a 302 redirect to it,
+        If an "evergreen", channel-appropriate WNP exists in the CMS for the request
+        locale (or its configured CMS fallback locale), return a 302 redirect to it,
         preserving existing querystring params and appending ?version=VERSION.
+
+        The target slug is chosen by the channel detected from the version string:
+          a1 suffix  → /whatsnew/nightly/
+          a2 suffix  → /whatsnew/developer/
+          beta suffix → /whatsnew/beta/
+          anything else → /whatsnew/general/
+
         Returns None if no redirect is warranted.
         """
+        channel = detect_channel(version)
+        wnp_slug = self._CHANNEL_WNP_SLUGS.get(channel, "general")
+
         # Extract the raw locale code from the URL path (e.g. "it", "es-AR")
         _path = request.path.lstrip("/")
         lang_code, _, _ = _path.partition("/")
 
-        # Build an ordered list of CMS locale codes to check for a General WNP.
+        # Build an ordered list of CMS locale codes to check for the target WNP.
         # Always check the request locale first (if it's a CMS locale), then its
         # configured fallback (if any). This handles two cases:
         #   1. Pure alias locales (e.g. es-AR → es-MX): only the fallback is checked.
         #   2. CMS locales that also have a fallback (e.g. en-GB → en-US): the
-        #      direct locale is checked first; if it has no General WNP we also
-        #      check the fallback so that a redirect is still issued and
+        #      direct locale is checked first; if it has no matching evergreen WNP
+        #      we also check the fallback so that a redirect is still issued and
         #      CMSLocaleFallbackMiddleware can transparently serve the fallback
         #      locale's content at the alias URL.
         cms_language_codes = dict(settings.WAGTAIL_CONTENT_LANGUAGES)
@@ -972,7 +1005,7 @@ class WhatsnewView(L10nTemplateView):
                 locale = WagtailLocale.objects.get(language_code=locale_code)
             except WagtailLocale.DoesNotExist:
                 continue
-            if WhatsNewPage2026.objects.live().public().filter(slug="general", locale=locale).exists():
+            if WhatsNewPage2026.objects.live().public().filter(slug=wnp_slug, locale=locale).exists():
                 break
         else:
             return None
@@ -986,7 +1019,7 @@ class WhatsnewView(L10nTemplateView):
         # Use the original lang_code in the redirect URL so that alias locales
         # (e.g. es-AR) redirect to their alias URL; Wagtail's locale-fallback
         # machinery then transparently serves the fallback locale's content.
-        redirect_path = f"/{lang_code}/whatsnew/general/"
+        redirect_path = f"/{lang_code}/whatsnew/{wnp_slug}/"
         query_string = params.urlencode()
         redirect_url = f"{redirect_path}?{query_string}" if query_string else redirect_path
 
@@ -994,7 +1027,7 @@ class WhatsnewView(L10nTemplateView):
 
     def get(self, request, *args, **kwargs):
         version = self.kwargs.get("version", "")
-        redirect_response = self._get_general_wnp_redirect(request, version)
+        redirect_response = self._get_evergreen_wnp_redirect(request, version)
         if redirect_response:
             return redirect_response
         return super().get(request, *args, **kwargs)

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -924,18 +924,23 @@ def detect_channel(version):
 
 
 class WhatsnewView(L10nTemplateView):
-    # This view is decorated with prefer_cms in urls.py, so will only be called if
-    # there is NOT already a What's New Page that directly matches the request path
-    # (eg /en-US/whatsnew/150/ will have matched a CMS-backed WNP, but
-    # /cy/whatsnew/150/ would have not because cy is not currently a CMS-backed locale
+    # The 3-digit Whats New route in urls.py is decorated with prefer_cms, so requests
+    # like /en-US/whatsnew/150/ will only reach this view when there is not already a
+    # CMS-backed What's New Page that directly matches the request path. For example,
+    # /en-US/whatsnew/150/ would match a CMS-backed WNP first, but /cy/whatsnew/150/
+    # would not because cy is not currently a CMS-backed locale.
     #
-    # As such, this view will either
+    # Legacy version routes (for example 152.0a1 or 152.0beta) may also dispatch here
+    # without prefer_cms, so this view is not exclusively a "no CMS page matched"
+    # fallback for every Whats New URL pattern.
+    #
+    # When this view handles a request, it will either:
     # a) redirect to a CMS-backed "evergreen" WNP (for Nightly, Developer or the
     # "general" WNP for FF Release) IF the request's locale is supported by the CMS
     # or
     # b) render a static Django-powered evergreen WNP for Nightly, Developer or Beta,
-    # using Fluent string for L10N, which will cover the locales that are not supported
-    # by the CMS
+    # using Fluent strings for L10N, which will cover the locales that are not
+    # supported by the CMS.
 
     ftl_files_map = {
         "firefox/whatsnew/nightly/evergreen.html": ["firefox/whatsnew/nightly/evergreen"],


### PR DESCRIPTION
This changeset adds support for ensuring users of Nightly and Developer will be shown a channel-specific, CMS-backed 'evergreen' WNP on www.firefox.com, if one exists in their locale. It also supports this behaviour for Beta, but we may not use it, because currently we don't offer a custom WNP for Beta, we just use a generic fallback static WNP.

## Points to note

`_get_general_wnp_redirect` (now `_get_evergreen_wnp_redirect`) previously always redirected to `/whatsnew/general/`. It now detects the channel from the version string and redirects to the appropriate CMS evergreen WNP:

(using 152 as an example version number, but valid for all versions)

* `/<locale>/whatsnew/152.0a1` --> `/<locale>/whatsnew/nightly/`
* `/<locale>/whatsnew/152.0a2` --> `/<locale>/whatsnew/developer/`
* `/<locale>/whatsnew/152.0beta` → `/<locale>/whatsnew/beta/`
* `/<locale>/whatsnew/152/` --> `/<locale>/whatsnew/general/` (unchanged behaviour)

If no channel-specific CMS page exists for the locale, the view falls back to the existing static Django/Fluent evergreen templates.

Tests have been updated to cover all three new channels, their static fallbacks, and the  no-redirect-loop guarantee for the new slugs.

## Issue / Bugzilla link

Jira: https://mozilla-hub.atlassian.net/browse/WT-1121

## Testing

### Setup

1. Run the dev server
2. Log into the Wagtail admin at /cms/
3. Navigate via Pages to the What's New section (the `WhatsNewIndexPage` at `/whatsnew/`)

### Create the test CMS pages

Add four child pages under the What's New index. For each, choose What's New 2026 Page as the page type, add any placeholder content (minimal is fine), then publish.

- Slug `general`, title e.g. "WNP General" — may already exist, skip if so
- Slug `nightly`, title e.g. "WNP Nightly"
- Slug `developer`, title e.g. "WNP Developer"
- Slug `beta`, title e.g. "WNP Beta"

### Test 1 — Channel-specific redirects (CMS pages present)

With all four pages published, confirm each URL returns a 302 to the expected destination with the version preserved in `?version=`:

- [x] http://localhost:8000/en-US/whatsnew/152.0a1/ → 302 to /en-US/whatsnew/nightly/?version=152.0a1
- [x] http://localhost:8000/en-US/whatsnew/152.0a2/ → 302 to /en-US/whatsnew/developer/?version=152.0a2
- [x] http://localhost:8000/en-US/whatsnew/152.0beta/ → 302 to /en-US/whatsnew/beta/?version=152.0beta
- [x] http://localhost:8000/en-US/whatsnew/152/ → 302 to /en-US/whatsnew/general/?version=152

Confirm each destination page loads as 200.

### Test 2 — Fallback to static pages (CMS pages absent)

Unpublish (or delete) the nightly, developer, and beta pages, leaving only the general page. Confirm the channel URLs now return 200 directly (static evergreen, no redirect):

- [x] http://localhost:8000/en-US/whatsnew/152.0a1/ → 200, static nightly evergreen
- [x] http://localhost:8000/en-US/whatsnew/152.0a2/ → 200, static developer evergreen
- [x] http://localhost:8000/en-US/whatsnew/152.0beta/ → 200, static release evergreen
- [x] http://localhost:8000/en-US/whatsnew/152/ → 302 to /en-US/whatsnew/general/ (general still live)

### Test 3 — Non-CMS locale always gets static page

With all WNP pages republished, confirm a locale that isn't CMS-backed (e.g. cy) never redirects:

- [x] http://localhost:8000/cy/whatsnew/152.0a1/ → 200, static nightly evergreen
- [x] http://localhost:8000/cy/whatsnew/152/ → 200, static release evergreen

### Test 4 — No redirect loop

Confirm the channel slug URLs are served directly by Wagtail and don't loop:

- [x] http://localhost:8000/en-US/whatsnew/nightly/ → 200, CMS page content
- [x] http://localhost:8000/en-US/whatsnew/developer/ → 200, CMS page content
- [x] http://localhost:8000/en-US/whatsnew/beta/ → 200, CMS page content
- [x] http://localhost:8000/en-US/whatsnew/general/ → 200, CMS page content

