### PR TITLE
Prevent redirects from caching query strings between requests (WT-1086)

### DIFF
--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import importlib
+from functools import partial
 from unittest.mock import patch
 
 from django.http.response import HttpResponse
@@ -13,7 +14,7 @@ import pytest
 import springfield.firefox.redirects as redirects_module
 from springfield.firefox.redirects import mobile_app, validate_param_value
 from springfield.redirects.middleware import RedirectsMiddleware
-from springfield.redirects.util import get_resolver
+from springfield.redirects.util import get_resolver, redirect
 
 
 @pytest.mark.parametrize(
@@ -131,7 +132,7 @@ def test_refresh_redirect_destinations(source, destination, permanent):
         ("/browsers/desktop/mac/?utm_source=foo&utm_medium=bar", "/download/mac/?utm_source=foo&utm_medium=bar"),
     ),
 )
-def test_refresh_redirect_preserves_querystrings(source, destination, permanent):
+def test_refresh_redirect_preserves_query_strings(source, destination, permanent):
     rf = RequestFactory()
     with override_settings(PERMANENT_CMS_REFRESH_REDIRECTS=permanent):
         middleware = _get_refresh_middleware()
@@ -171,10 +172,114 @@ def test_refresh_redirects_not_in_redirectpatterns_when_disabled():
         ("/ai/", "/smart-window/?view=waitlist"),  # no locale; middleware will later add the most appropriate locale
         ("/en-US/ai/", "/en-US/smart-window/?view=waitlist"),  # with locale
         ("/fr/ai/", "/fr/smart-window/?view=waitlist"),  # non-default locale
-        ("/en-GB/ai/?foo=bar", "/en-GB/smart-window/?view=waitlist"),  # incoming querystrings lost until WT-1086 is done
+        ("/en-GB/ai/?foo=bar", "/en-GB/smart-window/?view=waitlist"),  # incoming query strings are disregarded because `merge_query` is False
     ),
 )
 def test_ai_redirect_to_smart_window_waitlist(client, source, dest):
     resp = client.get(source, follow=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == dest
+
+
+# -- Offsite redirect / locale / query string isolation tests --
+
+EXPECTED_REDIRECT_QS = "?redirect_source=test"
+_TEST_EXT_HOST = "https://www.example.com"
+_TEST_EXT_BASE = f"{_TEST_EXT_HOST}/{{_locale}}"
+
+_test_offsite_redirect = partial(
+    redirect,
+    query={"redirect_source": "test"},
+    merge_query=True,
+    permanent=False,
+)
+
+_test_offsite_patterns = (
+    _test_offsite_redirect(r"^firefox/new/$", f"{_TEST_EXT_BASE}/"),
+    _test_offsite_redirect(r"^firefox/installer-help/$", f"{_TEST_EXT_BASE}/download/installer-help/"),
+    _test_offsite_redirect(r"^firefox/set-as-default/$", f"{_TEST_EXT_BASE}/landing/set-as-default/"),
+    _test_offsite_redirect(r"^firefox/browsers/incognito-browser/$", f"{_TEST_EXT_BASE}/more/incognito-browser/"),
+)
+
+
+def _get_offsite_middleware():
+    return RedirectsMiddleware(get_response=HttpResponse, resolver=get_resolver(_test_offsite_patterns))
+
+
+@pytest.mark.parametrize(
+    "path, expected_dest",
+    (
+        ("/en-US/firefox/new/?hello=world", f"{_TEST_EXT_HOST}/en-US/{EXPECTED_REDIRECT_QS}&hello=world"),
+        ("/en-US/firefox/new/", f"{_TEST_EXT_HOST}/en-US/{EXPECTED_REDIRECT_QS}"),
+        (
+            "/en-US/firefox/installer-help/?bar=baz&bam=bam",
+            f"{_TEST_EXT_HOST}/en-US/download/installer-help/{EXPECTED_REDIRECT_QS}&bar=baz&bam=bam",
+        ),
+        ("/en-US/firefox/installer-help/", f"{_TEST_EXT_HOST}/en-US/download/installer-help/{EXPECTED_REDIRECT_QS}"),
+    ),
+)
+def test_subsequent_redirects_do_not_carry_query_strings_from_earlier_requests(path, expected_dest):
+    # Safety check that Django/Springfield isn't caching query strings used in other
+    # responses. Both of the parametrized paths above are included with and
+    # without extra query strings, which should NOT bleed between requests.
+    rf = RequestFactory()
+    middleware = _get_offsite_middleware()
+    resp = middleware.process_request(rf.get(path))
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == expected_dest
+
+
+@pytest.mark.parametrize(
+    "path, expected_dest",
+    (
+        ("/firefox/new/", f"{_TEST_EXT_HOST}/{EXPECTED_REDIRECT_QS}"),
+        ("/firefox/set-as-default/", f"{_TEST_EXT_HOST}/landing/set-as-default/{EXPECTED_REDIRECT_QS}"),
+        ("/firefox/browsers/incognito-browser/", f"{_TEST_EXT_HOST}/more/incognito-browser/{EXPECTED_REDIRECT_QS}"),
+    ),
+)
+def test_offsite_redirects_still_work_when_locale_not_in_source_path(path, expected_dest):
+    # Our redirects kick in before our locale-prepending middleware, so we may
+    # find some redirects that don't have a locale when sending the user to an
+    # external site. The {_locale} placeholder should be stripped cleanly.
+    rf = RequestFactory()
+    middleware = _get_offsite_middleware()
+    resp = middleware.process_request(rf.get(path))
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == expected_dest
+
+
+# -- merge_query=True tests --
+
+_test_merge_query_patterns = (
+    redirect(
+        r"^merge-query-test/$",
+        "/merge-query-dest/",
+        query={"test": "true"},
+        merge_query=True,
+        permanent=False,
+    ),
+)
+
+
+def _get_merge_query_middleware():
+    return RedirectsMiddleware(get_response=HttpResponse, resolver=get_resolver(_test_merge_query_patterns))
+
+
+@pytest.mark.parametrize(
+    "source, dest",
+    (
+        ("/merge-query-test/", "/merge-query-dest/?test=true"),
+        ("/merge-query-test/?hello=world", "/merge-query-dest/?test=true&hello=world"),
+        ("/merge-query-test/?hello=world&foo=bar", "/merge-query-dest/?test=true&hello=world&foo=bar"),
+        ("/en-US/merge-query-test/", "/en-US/merge-query-dest/?test=true"),
+        ("/fr/merge-query-test/", "/fr/merge-query-dest/?test=true"),
+        ("/en-GB/merge-query-test/?foo=bar", "/en-GB/merge-query-dest/?test=true&foo=bar"),
+    ),
+)
+def test_merge_query_redirect(source, dest):
+    # Uses a test-only redirect pattern so coverage doesn't depend on any
+    # production redirect that uses merge_query.
+    rf = RequestFactory()
+    resp = _get_merge_query_middleware().process_request(rf.get(source))
     assert resp.status_code == 302
     assert resp.headers["Location"] == dest

--- a/springfield/redirects/util.py
+++ b/springfield/redirects/util.py
@@ -4,6 +4,7 @@
 
 import re
 from collections import defaultdict
+from copy import deepcopy
 from urllib.parse import parse_qs, urlencode
 
 from django.conf import settings
@@ -235,6 +236,9 @@ def redirect(
         query = query.copy()
 
     def _view(request, *args, **kwargs):
+        # Avoid the _view closure capturing the original _query state
+        request_query = deepcopy(query)
+
         # don't want to have 'None' in substitutions
         kwargs = {k: v or "" for k, v in kwargs.items()}
         args = [x or "" for x in args]
@@ -251,7 +255,7 @@ def redirect(
             try:
                 redirect_url = reverse(to_value, args=to_args, kwargs=to_kwargs)
                 # reverse() will give us, by default, a redirection
-                # with settings.LANGAUGE_CODE as the prefixed language.
+                # with settings.LANGUAGE_CODE as the prefixed language.
                 # We don't want this by default, only if explicitly requested
                 redirect_url = _drop_lang_code(redirect_url)
             except NoReverseMatch:
@@ -260,6 +264,21 @@ def redirect(
 
         if prepend_locale and redirect_url.startswith("/") and kwargs.get("locale"):
             redirect_url = "/{locale}" + redirect_url.lstrip("/")
+        elif prepend_locale and "{_locale}" in redirect_url:
+            # So this is a full domain / offsite redirect, not a relative one.
+            # But do we have a locale already known to us? If so, use it, to avoid
+            # a 302 on the destination when the locale is re-detected
+            #
+            # Note that we're using a variable called _locale in the URL template
+            # to deliberately avoid clashing with `locale` in the current variable
+            # space.
+            if kwargs.get("locale"):  # extracted as, say, "fr/"
+                _locale = kwargs.get("locale").rstrip("/")
+                redirect_url = redirect_url.format(_locale=_locale)
+            else:
+                # If we don't yet have a locale to use in the redirect, we have to
+                # just live without it
+                redirect_url = redirect_url.replace("/{_locale}", "")
 
         # use info from url captures.
         if args or kwargs:
@@ -270,13 +289,13 @@ def redirect(
                 redirect_url = redirect_url.format_map(defaultdict(str, kwargs))
             redirect_url = strip_tags(redirect_url)
 
-        if query:
+        if request_query:
             if merge_query:
-                req_query = parse_qs(request.META.get("QUERY_STRING", ""))
-                query.update(req_query)
+                _req_qs_query = parse_qs(request.META.get("QUERY_STRING", ""))
+                request_query.update(_req_qs_query)
 
-            querystring = urlencode(query, doseq=True)
-        elif query is None:
+            querystring = urlencode(request_query, doseq=True)
+        elif request_query is None:
             querystring = request.META.get("QUERY_STRING", "")
         else:
             querystring = ""

--- a/springfield/redirects/util.py
+++ b/springfield/redirects/util.py
@@ -236,7 +236,7 @@ def redirect(
         query = query.copy()
 
     def _view(request, *args, **kwargs):
-        # Avoid the _view closure capturing the original _query state
+        # Avoid mutating the closed-over query between requests.
         request_query = deepcopy(query)
 
         # don't want to have 'None' in substitutions


### PR DESCRIPTION
# Summary

* `redirects.util.redirect()` was mutating the closed-over `query` dict on every request, so query strings accumulated across requests when `merge_query=True`. Switched to a per-request `deepcopy` so each invocation starts clean.
* Added the `{_locale}` placeholder substitution branch for offsite redirects, so we use the already-known locale and avoid a follow-up 302 at the destination.
* Test coverage for: merge_query behaviour (on-site, with and without locale), offsite locale handling, and query string isolation across consecutive requests.

Ported from bedrock PR mozilla/bedrock#16391. Fixes WT-1086.

# Test plan

* [x] `pytest springfield/firefox/tests/test_redirects.py` passes
* [x] `make test` passes in CI