### PR TITLE
Redirect /mobile/get-app to /mobile

### DIFF
--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -115,6 +115,7 @@ redirectpatterns = (
         permanent=False,
         merge_query=False,
     ),
+    redirect(r"^mobile/get-app/?$", "/mobile/", permanent=False),
 )
 
 permanent = settings.PERMANENT_CMS_REFRESH_REDIRECTS

--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -283,3 +283,14 @@ def test_merge_query_redirect(source, dest):
     resp = _get_merge_query_middleware().process_request(rf.get(source))
     assert resp.status_code == 302
     assert resp.headers["Location"] == dest
+
+
+@pytest.mark.parametrize("permanent", (True, False), ids=("301", "302"))
+@pytest.mark.parametrize(
+    "source, destination",
+    (("/mobile/get-app", "/mobile/"),),
+)
+def test_redirect_destinations(client, source, destination, permanent):
+    resp = client.get(source, follow=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == destination


### PR DESCRIPTION
Redirects the now 404ing /mobile/get-app to /mobile

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1169

## Testing
- [x] Checkout this PR
- [x] Navigate to http://localhost:8000/en-US/mobile/get-app
- [x] Ensure you're redirected to http://localhost:8000/en-US/mobile/ and no longer see a 404