### PR TITLE
Enable stub attribution mode on freeform pages

### DIFF
--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -972,7 +972,7 @@ class FreeFormPage2026(PromotedPageMixin, UTMParamsMixin, QRCodeFloatingSnippetM
         ),
     ]
 
-    promote_panels = AbstractSpringfieldCMSPage.promote_panels + [
+    promote_panels = UTMParamsMixin.promote_panels + [
         FieldPanel("enable_marketing_attribution"),
     ]
 


### PR DESCRIPTION
Change FreeFormPage2026 to base its promote_panels on UTMParamsMixin.promote_panels instead of AbstractSpringfieldCMSPage.promote_panels. This ensures the UTM parameter promote panels are included for this page type while still appending the enable_marketing_attribution FieldPanel.

