### PR TITLE
Add forced color styling on floating QR button, dialog, and icons

### DIFF
--- a/media/css/cms/components/flare26-floating-qr-overlay.css
+++ b/media/css/cms/components/flare26-floating-qr-overlay.css
@@ -132,9 +132,17 @@
     inline-size: 200px;
 }
 
-.fl-qr-code-image svg {
+.fl-qr-code-image svg,
+.fl-qr-code-image img {
     block-size: 100%;
     inline-size: 100%;
+}
+
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+    .fl-qr-code-image svg,
+    .fl-qr-code-image img {
+        filter: invert(1);
+    }
 }
 
 .fl-qr-code-floating-button {

--- a/media/css/cms/components/flare26-floating-qr-overlay.css
+++ b/media/css/cms/components/flare26-floating-qr-overlay.css
@@ -23,6 +23,14 @@
         block-size 300ms ease,
         inline-size 300ms ease;
     z-index: 5;
+
+    @media (forced-colors: active) {
+        border: 1px solid CanvasText;
+
+        .fl-icon {
+            background-color: CanvasText;
+        }
+    }
 }
 
 .fl-qr-code-floating-snippet.is-open {
@@ -136,6 +144,26 @@
 
     /* end default reversions */
     display: flex;
+
+    @media (forced-colors: active) {
+        background-color: ButtonFace;
+        border: 1px solid ButtonText;
+        color: ButtonText;
+
+        &:hover {
+            background-color: SelectedItem;
+            border-color: SelectedItemText;
+            color: SelectedItemText;
+
+            .fl-icon {
+                background-color: SelectedItemText;
+            }
+        }
+
+        &:active {
+            border-color: ButtonText;
+        }
+    }
 }
 
 /* Hide on smaller screens */


### PR DESCRIPTION
## One-line summary

Fix floating QR code styling for High Contrast Mode

## Significant changes and points to review



## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1192


## Testing
Use dev tools to force dark mode & active forced-colors: https://developer.chrome.com/docs/devtools/rendering/emulate-css/#emulate_css_media_feature_forced-colors

