### PR TITLE
fix: repair Smartling CAT visual context

### DIFF
--- a/springfield/cms/tests/test_callbacks.py
+++ b/springfield/cms/tests/test_callbacks.py
@@ -4,6 +4,8 @@
 
 from unittest import mock
 
+from django.test import override_settings
+
 import pytest
 import wagtail_factories
 from wagtail.models import Page
@@ -15,6 +17,7 @@ from springfield.cms.wagtail_localize_smartling.callbacks import _get_html_for_s
 
 
 @pytest.mark.django_db
+@override_settings(WAGTAILADMIN_BASE_URL="https://cms.example.com")
 def test_visual_context__for_page(client):
     top_level_page = SimpleRichTextPageFactory()
 
@@ -38,9 +41,41 @@ def test_visual_context__for_page(client):
     # light checks because we're not testing wagtaildraftsharing itself
     assert "<body" in html
     assert "Test SimpleRichTextPage" in html
+    assert '<base href="https://www.firefox.com/">' in html
 
     sharing_link_key = WagtaildraftsharingLink.objects.get().key
-    assert url == f"http://testserver:81/_internal_draft_preview/{sharing_link_key}/"
+    assert url == f"https://cms.example.com/_internal_draft_preview/{sharing_link_key}/"
+
+
+@pytest.mark.django_db
+@override_settings(WAGTAILADMIN_BASE_URL="https://cms.example.com")
+@mock.patch("springfield.cms.wagtail_localize_smartling.callbacks._get_html_for_sharing_link")
+def test_visual_context__cms_hostname_stripped_and_base_tag_injected(mock_get_html, client):
+    top_level_page = SimpleRichTextPageFactory()
+    page = SimpleRichTextPageFactory(parent=top_level_page, slug="visual-context-text-page")
+    page.save_revision()
+
+    site = wagtail_factories.SiteFactory(
+        root_page=top_level_page,
+        is_default_site=True,
+        hostname="cms-internal.example.com",
+        port=8080,
+    )
+    cms_root_url = site.root_url  # e.g. "http://cms-internal.example.com:8080"
+
+    mock_get_html.return_value = f'<html><head></head><body><img src="{cms_root_url}/media/image.jpg"></body></html>'
+
+    user = WagtailUserFactory()
+    mock_job = mock.Mock()
+    mock_job.translation_source.get_source_instance.return_value = page
+    mock_job.user = user
+
+    _, html = visual_context(smartling_job=mock_job)
+
+    assert cms_root_url not in html
+    assert "https://cms.example.com" not in html
+    assert '<base href="https://www.firefox.com/">' in html
+    assert '<img src="/media/image.jpg">' in html
 
 
 def test_visual_context__for_inviable_object(client):

--- a/springfield/cms/wagtail_localize_smartling/callbacks.py
+++ b/springfield/cms/wagtail_localize_smartling/callbacks.py
@@ -43,7 +43,7 @@ def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
 
 def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
     url = f"{settings.WAGTAILADMIN_BASE_URL}{sharing_link.url}"
-    logger.info(f"Page URL being sent to Smartling {url}")
+    logger.debug("Page URL being sent to Smartling for path %s", sharing_link.url)
     return url
 
 

--- a/springfield/cms/wagtail_localize_smartling/callbacks.py
+++ b/springfield/cms/wagtail_localize_smartling/callbacks.py
@@ -8,12 +8,13 @@
 #
 # The README.md of that repo covers what inputs are
 # provided and what outputs are needed
-
+import logging
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.test import RequestFactory
 
-from wagtail.models import Page
+from wagtail.models import Page, Site
 from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 
 if TYPE_CHECKING:
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
 from sentry_sdk import capture_exception, capture_message
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 from wagtaildraftsharing.views import SharingLinkView
+
+logger = logging.getLogger(__name__)
 
 
 def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
@@ -38,8 +41,10 @@ def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
         raise IncapableVisualContextCallback("Was not able to get a HTML export from the sharing link")
 
 
-def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink, page: "Page") -> str:
-    return f"{page.get_site().root_url}{sharing_link.url}"
+def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
+    url = f"{settings.WAGTAILADMIN_BASE_URL}{sharing_link.url}"
+    logger.info(f"Page URL being sent to Smartling {url}")
+    return url
 
 
 def visual_context(smartling_job: "Job") -> tuple[str, str]:
@@ -73,6 +78,16 @@ def visual_context(smartling_job: "Job") -> tuple[str, str]:
         max_ttl=-1,  # -1 signifies "No expiry". If we pass None we get the default TTL
     )
 
-    url = _get_full_url_for_sharing_link(sharing_link=sharing_link, page=content_obj)
+    url = _get_full_url_for_sharing_link(sharing_link=sharing_link)
     html = _get_html_for_sharing_link(sharing_link=sharing_link)
+
+    # Strip the CMS hostname from URLs in the HTML so they become relative,
+    # then inject a <base> tag so Smartling resolves them against the public
+    # domain rather than the IAP-protected CMS host.
+    default_site = Site.objects.filter(is_default_site=True).first()
+    if default_site:
+        html = html.replace(default_site.root_url, "")
+    base_tag = f'<base href="{settings.CANONICAL_URL}/">'
+    html = html.replace("<head>", f"<head>{base_tag}", 1)
+
     return (url, html)


### PR DESCRIPTION
GCP IAP is stopping the preview URL being used by CAT, so this changeset rewrites the HTML artifact sent over to try to make the CAT not need anything from the IAP-protected service. (Instead it loads CSS/JS from the public CDN)

This changeset also fixes a bug with the callback that was using the published hostname (www.firefox.com) for the preview link, not the internal CMS hostname. (This is somehwat academic because IAP is blocking the CMS host, but it helps us narrow down what may be causing CAT to fail on Smartling)


## Issue / Bugzilla link

Jira: https://mozilla-hub.atlassian.net/browse/WT-1184


## Testing

I've tested this manually locally and it's working fine - hopefully it'll also fix things in a deployed environment. Will test on Dev as soon as it's merged 