### PR TITLE
fix: ensure the context renders correctly for draftsharing

### DIFF
--- a/springfield/cms/tests/test_callbacks.py
+++ b/springfield/cms/tests/test_callbacks.py
@@ -123,6 +123,27 @@ def test_visual_context__for_page__with_no_revision(mock_capture_message, client
     mock_capture_message.assert_called_once_with(f"Unable to get a latest_revision for {page} so unable to send visual context.")
 
 
+@override_settings(WAGTAILADMIN_BASE_URL="https://cms.example.com")
+@mock.patch("springfield.cms.wagtail_localize_smartling.callbacks.SharingLinkView.as_view")
+@mock.patch("springfield.cms.wagtail_localize_smartling.callbacks.RequestFactory")
+def test__get_html_for_sharing_link__uses_cms_hostname_and_path_only(mock_factory_cls, mock_as_view):
+    # sharing_link.url is a full URL — we should extract just the path and use
+    # the CMS hostname as SERVER_NAME so make_preview_request doesn't fall back
+    # to 'localhost' / 'testserver' and return a 400 error page.
+    mock_response = mock.Mock()
+    mock_response.text = "<html><body>page content</body></html>"
+    mock_as_view.return_value = mock.Mock(return_value=mock_response)
+
+    sharing_link = mock.Mock()
+    sharing_link.url = "http://localhost/_internal_draft_preview/abc123/"
+
+    result = _get_html_for_sharing_link(sharing_link)
+
+    mock_factory_cls.assert_called_once_with(SERVER_NAME="cms.example.com")
+    mock_factory_cls.return_value.get.assert_called_once_with("/_internal_draft_preview/abc123/")
+    assert result == "<html><body>page content</body></html>"
+
+
 # The happy path is implicitly tested in test_visual_context__*, above
 @mock.patch("springfield.cms.wagtail_localize_smartling.callbacks.capture_exception")
 @mock.patch("springfield.cms.wagtail_localize_smartling.callbacks.SharingLinkView.as_view")

--- a/springfield/cms/wagtail_localize_smartling/callbacks.py
+++ b/springfield/cms/wagtail_localize_smartling/callbacks.py
@@ -10,6 +10,7 @@
 # provided and what outputs are needed
 import logging
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.test import RequestFactory
@@ -27,7 +28,14 @@ logger = logging.getLogger(__name__)
 
 
 def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
-    request = RequestFactory().get(sharing_link.url)
+    # Use the CMS hostname (guaranteed to be in ALLOWED_HOSTS) so that
+    # Wagtail's make_preview_request doesn't fall back to 'testserver' /
+    # 'localhost', which would cause DisallowedHost inside the middleware
+    # chain and return a 400 error page instead of the real page HTML.
+    # Also extract just the path from sharing_link.url in case it's absolute.
+    cms_hostname = urlparse(settings.WAGTAILADMIN_BASE_URL).hostname
+    path = urlparse(sharing_link.url).path
+    request = RequestFactory(SERVER_NAME=cms_hostname).get(path)
     view_func = SharingLinkView.as_view()
     try:
         resp = view_func(


### PR DESCRIPTION
We want to avoid a DisallowedHost so we don't end up sending the 400 Page to Smartling, which will
be treated as "no context"

https://mozilla-hub.atlassian.net/browse/WT-1184