### PR TITLE
Attribute mobile downloads from /thanks/-bound buttons and CMS buttons

### DIFF
--- a/media/js/base/mobile-attribution.js
+++ b/media/js/base/mobile-attribution.js
@@ -1,0 +1,234 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Mobile attribution: rewrites /thanks/-bound download buttons to attributed
+ * store URLs on mobile UAs so the page-level campaign survives the click.
+ * Desktop is unaffected — those clicks continue through the stub-attribution
+ * cookie/installer flow.
+ *
+ * Campaign resolution mirrors stub-attribution.js exactly:
+ *   force > override > URL utm_campaign > default.
+ */
+
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+(function (Mozilla) {
+    'use strict';
+
+    var MobileAttribution = {};
+
+    var ANDROID_RE = /\bAndroid\b/i;
+    var IOS_RE = /\b(iPhone|iPad|iPod)\b/i;
+
+    /**
+     * Resolve the campaign value using the same cascade as stub-attribution.js:
+     * force > override > URL utm_campaign > default.
+     * @param {HTMLElement} html - typically document.documentElement.
+     * @param {String} search - typically window.location.search.
+     * @returns {String|null}
+     */
+    MobileAttribution.getCampaign = function (html, search) {
+        // IE9-safe URL parse (avoids URLSearchParams).
+        var urlMatch = (search || '').match(/[?&]utm_campaign=([^&]+)/);
+        var urlCampaign = urlMatch ? decodeURIComponent(urlMatch[1]) : null;
+
+        return (
+            html.getAttribute('data-stub-attribution-campaign-force') ||
+            html.getAttribute('data-stub-attribution-campaign-override') ||
+            urlCampaign ||
+            html.getAttribute('data-stub-attribution-campaign') ||
+            null
+        );
+    };
+
+    /**
+     * Build the attributed store URL for the given campaign + platform.
+     * Mirrors springfield/firefox/templatetags/misc.py app_store_url /
+     * play_store_url so the rewritten URL is byte-identical to what the CMS
+     * download_firefox_button block emits server-side.
+     */
+    MobileAttribution.getStoreUrl = function (campaign, isAndroid) {
+        var encoded = encodeURIComponent(campaign);
+        if (isAndroid) {
+            return (
+                'https://play.google.com/store/apps/details?id=org.mozilla.firefox' +
+                '&referrer=utm_source%3Dwww.firefox.com%26utm_medium%3Dreferral' +
+                '%26utm_campaign%3D' +
+                encoded
+            );
+        }
+        return (
+            'https://apps.apple.com/app/apple-store/id989804926' +
+            '?mz_pr=firefox_mobile&pt=373246&ct=' +
+            encoded +
+            '&mt=8'
+        );
+    };
+
+    /**
+     * Find /thanks/-bound download buttons, rewrite their HREFs to the given
+     * store URL, and attach a click handler that fires the
+     * `firefox_mobile_download` + legacy `product_download` GA4 events that
+     * /thanks/ would have fired today (via thanks-init.js calling
+     * sendEventFromURL after the auto-redirect).
+     *
+     * Selector covers both shapes:
+     *   - `.c-button-download-thanks-link` (set on buttons when
+     *     exclude_unsupported_content is False)
+     *   - `.c-button-download-thanks > .download-link` (the broader pattern,
+     *     covers nav + pre-footer where exclude_unsupported_content is True
+     *     and the `-link` class is omitted)
+     * Path A store buttons (rendered by show_store_button) use
+     * `.fl-store-button-*` classes and are not matched.
+     *
+     * Why sendEventFromURL with a closure-captured URL (vs. attaching
+     * handleLink directly): mozilla-utils.js's initMobileDownloadLinks
+     * mutates Android Play Store hrefs to `market://details?...` on DOM
+     * ready. TrackProductDownload's marketURL regex requires the URL to
+     * start with `market://play.google.com` (which mozilla-utils.js never
+     * produces), so reading event.target.href at click time would not
+     * match. Capturing the original https:// URL bypasses the regex
+     * mismatch entirely.
+     */
+    MobileAttribution.rewriteLinks = function (root, storeUrl) {
+        var buttons = root.querySelectorAll(
+            '.c-button-download-thanks-link, .c-button-download-thanks > .download-link'
+        );
+        for (var i = 0; i < buttons.length; i++) {
+            var href = buttons[i].getAttribute('href') || '';
+            if (href.indexOf('/thanks') === -1) continue;
+
+            buttons[i].setAttribute('href', storeUrl);
+
+            if (
+                window.Mozilla &&
+                window.Mozilla.TrackProductDownload &&
+                typeof window.Mozilla.TrackProductDownload.sendEventFromURL ===
+                    'function'
+            ) {
+                MobileAttribution._attachTrackingClick(buttons[i], storeUrl);
+            }
+        }
+    };
+
+    /**
+     * Attach a click listener that fires the GA4 + legacy download events
+     * AND navigates to the closure-captured https:// store URL.
+     *
+     * Why navigate via JS instead of letting the browser follow the HREF:
+     * mozilla-utils.js mutates Android Play Store hrefs to `market://...`
+     * on DOM ready. `market://` resolves correctly on real Android (the
+     * Play Store app is registered for the scheme) but fails in desktop
+     * browsers (including Chrome with Android UA emulation), surfacing a
+     * "scheme has no registered handler" error and breaking dev testing.
+     *
+     * Navigating to the https:// URL works in both contexts: on real
+     * Android, Android App Links open the Play Store app from the https
+     * URL automatically; in any browser, it loads play.google.com /
+     * apps.apple.com directly. This mirrors how thanks-init.js navigates
+     * via window.location.href after capturing the URL synchronously, so
+     * /thanks/ has been graceful in both environments today.
+     *
+     * Factored out so the closure over `storeUrl` is created per-button
+     * (avoids the classic `var i` loop-closure trap).
+     */
+    MobileAttribution._attachTrackingClick = function (button, storeUrl) {
+        button.addEventListener('click', function (event) {
+            event.preventDefault();
+            window.Mozilla.TrackProductDownload.sendEventFromURL(storeUrl);
+            MobileAttribution._navigate(storeUrl);
+        });
+    };
+
+    /**
+     * Navigation seam. Factored into a named method so tests can spy on it
+     * without actually navigating the test runner away from its harness.
+     */
+    MobileAttribution._navigate = function (url) {
+        window.location.href = url;
+    };
+
+    /**
+     * Entry point. Strict no-op on desktop UAs.
+     *
+     * Two responsibilities on mobile:
+     *   1. Path A: ensure Android clicks on CMS download_firefox_button
+     *      store buttons fire the firefox_mobile_download GA4 event. The
+     *      existing datalayer-productdownload-init.es6.js attaches
+     *      handleLink to all `.ga-product-download` elements, but on
+     *      Android the href has been mutated to `market://details?...` by
+     *      DOM-ready time and the tracker's marketURL regex doesn't match
+     *      it, so the event silently drops. (iOS Path A is unaffected:
+     *      mozilla-utils.js only mutates Android URLs, so the existing
+     *      handler fires the event correctly.) We supplement Android with
+     *      a handler that uses the captured https:// URL.
+     *   2. Path B: rewrite /thanks/-bound download CTAs (nav, pre-footer,
+     *      smart-window, etc.) to attributed store URLs and attach click
+     *      tracking. Gated on a campaign being declared (CMS stub_attr or
+     *      URL utm_campaign).
+     */
+    MobileAttribution.init = function () {
+        var html = document.documentElement;
+        var ua = navigator.userAgent || '';
+        var isAndroid = ANDROID_RE.test(ua);
+        var isIOS = IOS_RE.test(ua);
+        if (!isAndroid && !isIOS) {
+            return;
+        }
+
+        if (isAndroid) {
+            MobileAttribution.attachAndroidStoreButtonTracking(document);
+        }
+
+        var campaign = MobileAttribution.getCampaign(
+            html,
+            window.location.search
+        );
+        if (!campaign) {
+            return;
+        }
+
+        var storeUrl = MobileAttribution.getStoreUrl(campaign, isAndroid);
+        MobileAttribution.rewriteLinks(document, storeUrl);
+    };
+
+    /**
+     * Path A Android fix. Supplements the existing handleLink listener
+     * (attached by datalayer-productdownload-init.es6.js to all
+     * `.ga-product-download` elements) with one that uses the captured
+     * https://play.google.com URL, since by click time the href has been
+     * mutated to market://details?... by mozilla-utils.js — which the
+     * tracker's marketURL regex doesn't recognize. Selector intentionally
+     * matches Android only; iOS Path A already fires correctly via the
+     * existing handler, and adding ours there would double-fire.
+     */
+    MobileAttribution.attachAndroidStoreButtonTracking = function (root) {
+        if (
+            !window.Mozilla ||
+            !window.Mozilla.TrackProductDownload ||
+            typeof window.Mozilla.TrackProductDownload.sendEventFromURL !==
+                'function'
+        ) {
+            return;
+        }
+        var buttons = root.querySelectorAll('.fl-store-button-android');
+        for (var i = 0; i < buttons.length; i++) {
+            var href = buttons[i].getAttribute('href');
+            if (!href) continue;
+            MobileAttribution._attachTrackingClick(buttons[i], href);
+        }
+    };
+
+    Mozilla.MobileAttribution = MobileAttribution;
+
+    // Auto-run unless a test or another caller suppresses it.
+    if (!Mozilla.MobileAttribution.suppressAutoInit) {
+        MobileAttribution.init();
+    }
+})(window.Mozilla);

--- a/media/js/base/mobile-attribution.js
+++ b/media/js/base/mobile-attribution.js
@@ -5,13 +5,11 @@
  */
 
 /*
- * Mobile attribution: rewrites /thanks/-bound download buttons to attributed
- * store URLs on mobile UAs so the page-level campaign survives the click.
- * Desktop is unaffected — those clicks continue through the stub-attribution
- * cookie/installer flow.
- *
- * Campaign resolution mirrors stub-attribution.js exactly:
- *   force > override > URL utm_campaign > default.
+ * On mobile UAs, rewrites /thanks/-bound download buttons to attributed
+ * store URLs so the page-level campaign survives the click, and fires the
+ * same firefox_mobile_download GA4 event /thanks/ fires today. Desktop is
+ * unaffected. Campaign cascade mirrors stub-attribution.js:
+ * force > override > URL utm_campaign > default.
  */
 
 if (typeof window.Mozilla === 'undefined') {
@@ -27,14 +25,13 @@ if (typeof window.Mozilla === 'undefined') {
     var IOS_RE = /\b(iPhone|iPad|iPod)\b/i;
 
     /**
-     * Resolve the campaign value using the same cascade as stub-attribution.js:
-     * force > override > URL utm_campaign > default.
-     * @param {HTMLElement} html - typically document.documentElement.
-     * @param {String} search - typically window.location.search.
+     * Resolve the campaign value: force > override > URL utm_campaign > default.
+     * IE9-safe parse avoids URLSearchParams.
+     * @param {HTMLElement} html
+     * @param {String} search
      * @returns {String|null}
      */
     MobileAttribution.getCampaign = function (html, search) {
-        // IE9-safe URL parse (avoids URLSearchParams).
         var urlMatch = (search || '').match(/[?&]utm_campaign=([^&]+)/);
         var urlCampaign = urlMatch ? decodeURIComponent(urlMatch[1]) : null;
 
@@ -48,10 +45,9 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     /**
-     * Build the attributed store URL for the given campaign + platform.
-     * Mirrors springfield/firefox/templatetags/misc.py app_store_url /
-     * play_store_url so the rewritten URL is byte-identical to what the CMS
-     * download_firefox_button block emits server-side.
+     * Build an attributed store URL byte-identical to what
+     * springfield/firefox/templatetags/misc.py app_store_url / play_store_url
+     * emits server-side.
      */
     MobileAttribution.getStoreUrl = function (campaign, isAndroid) {
         var encoded = encodeURIComponent(campaign);
@@ -72,29 +68,11 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     /**
-     * Find /thanks/-bound download buttons, rewrite their HREFs to the given
-     * store URL, and attach a click handler that fires the
-     * `firefox_mobile_download` + legacy `product_download` GA4 events that
-     * /thanks/ would have fired today (via thanks-init.js calling
-     * sendEventFromURL after the auto-redirect).
-     *
-     * Selector covers both shapes:
-     *   - `.c-button-download-thanks-link` (set on buttons when
-     *     exclude_unsupported_content is False)
-     *   - `.c-button-download-thanks > .download-link` (the broader pattern,
-     *     covers nav + pre-footer where exclude_unsupported_content is True
-     *     and the `-link` class is omitted)
-     * Path A store buttons (rendered by show_store_button) use
-     * `.fl-store-button-*` classes and are not matched.
-     *
-     * Why sendEventFromURL with a closure-captured URL (vs. attaching
-     * handleLink directly): mozilla-utils.js's initMobileDownloadLinks
-     * mutates Android Play Store hrefs to `market://details?...` on DOM
-     * ready. TrackProductDownload's marketURL regex requires the URL to
-     * start with `market://play.google.com` (which mozilla-utils.js never
-     * produces), so reading event.target.href at click time would not
-     * match. Capturing the original https:// URL bypasses the regex
-     * mismatch entirely.
+     * Rewrite /thanks/-bound download buttons to the given attributed store
+     * URL and attach click tracking. Selector covers the two CTA shapes:
+     *   - .c-button-download-thanks-link (exclude_unsupported_content=false)
+     *   - .c-button-download-thanks > .download-link (nav + pre-footer pattern)
+     * Path A store buttons (.fl-store-button-*) are not matched.
      */
     MobileAttribution.rewriteLinks = function (root, storeUrl) {
         var buttons = root.querySelectorAll(
@@ -118,25 +96,13 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     /**
-     * Attach a click listener that fires the GA4 + legacy download events
-     * AND navigates to the closure-captured https:// store URL.
-     *
-     * Why navigate via JS instead of letting the browser follow the HREF:
-     * mozilla-utils.js mutates Android Play Store hrefs to `market://...`
-     * on DOM ready. `market://` resolves correctly on real Android (the
-     * Play Store app is registered for the scheme) but fails in desktop
-     * browsers (including Chrome with Android UA emulation), surfacing a
-     * "scheme has no registered handler" error and breaking dev testing.
-     *
-     * Navigating to the https:// URL works in both contexts: on real
-     * Android, Android App Links open the Play Store app from the https
-     * URL automatically; in any browser, it loads play.google.com /
-     * apps.apple.com directly. This mirrors how thanks-init.js navigates
-     * via window.location.href after capturing the URL synchronously, so
-     * /thanks/ has been graceful in both environments today.
-     *
-     * Factored out so the closure over `storeUrl` is created per-button
-     * (avoids the classic `var i` loop-closure trap).
+     * Click handler: fire the GA4 + legacy download events and navigate to
+     * the closure-captured https:// URL. We navigate via JS (mirroring
+     * thanks-init.js) because mozilla-utils.js mutates Android Play Store
+     * hrefs to `market://details?...` on DOM ready — that scheme works on
+     * real Android but fails in desktop browsers, breaking dev testing.
+     * The https:// URL works in both contexts (Android App Links open the
+     * Play Store app; browsers load the web page).
      */
     MobileAttribution._attachTrackingClick = function (button, storeUrl) {
         button.addEventListener('click', function (event) {
@@ -146,32 +112,23 @@ if (typeof window.Mozilla === 'undefined') {
         });
     };
 
-    /**
-     * Navigation seam. Factored into a named method so tests can spy on it
-     * without actually navigating the test runner away from its harness.
-     */
+    /** Navigation seam — separated so tests can spy without navigating. */
     MobileAttribution._navigate = function (url) {
         window.location.href = url;
     };
 
     /**
-     * Entry point. Strict no-op on desktop UAs.
-     *
-     * Two responsibilities on mobile:
-     *   1. Path A: ensure Android clicks on CMS download_firefox_button
-     *      store buttons fire the firefox_mobile_download GA4 event. The
-     *      existing datalayer-productdownload-init.es6.js attaches
-     *      handleLink to all `.ga-product-download` elements, but on
-     *      Android the href has been mutated to `market://details?...` by
-     *      DOM-ready time and the tracker's marketURL regex doesn't match
-     *      it, so the event silently drops. (iOS Path A is unaffected:
-     *      mozilla-utils.js only mutates Android URLs, so the existing
-     *      handler fires the event correctly.) We supplement Android with
-     *      a handler that uses the captured https:// URL.
-     *   2. Path B: rewrite /thanks/-bound download CTAs (nav, pre-footer,
-     *      smart-window, etc.) to attributed store URLs and attach click
-     *      tracking. Gated on a campaign being declared (CMS stub_attr or
-     *      URL utm_campaign).
+     * Entry point. No-op on desktop. On mobile:
+     *   1. Android-only: supplement the existing .ga-product-download click
+     *      handler on Path A Play Store badges (CMS download_firefox_button
+     *      block). The existing handler reads event.target.href, which
+     *      mozilla-utils.js has mutated to market://details?... by click time,
+     *      and the tracker's marketURL regex doesn't recognize that shape —
+     *      so the event silently drops. We supplement with a handler using
+     *      the captured https:// URL. iOS Path A is unaffected and not
+     *      supplemented (would double-fire).
+     *   2. Path B: rewrite /thanks/-bound CTAs to attributed store URLs.
+     *      Gated on a declared campaign (CMS stub_attr or URL utm_campaign).
      */
     MobileAttribution.init = function () {
         var html = document.documentElement;
@@ -198,16 +155,7 @@ if (typeof window.Mozilla === 'undefined') {
         MobileAttribution.rewriteLinks(document, storeUrl);
     };
 
-    /**
-     * Path A Android fix. Supplements the existing handleLink listener
-     * (attached by datalayer-productdownload-init.es6.js to all
-     * `.ga-product-download` elements) with one that uses the captured
-     * https://play.google.com URL, since by click time the href has been
-     * mutated to market://details?... by mozilla-utils.js — which the
-     * tracker's marketURL regex doesn't recognize. Selector intentionally
-     * matches Android only; iOS Path A already fires correctly via the
-     * existing handler, and adding ours there would double-fire.
-     */
+    /** Path A Android-only supplement (see init docstring for rationale). */
     MobileAttribution.attachAndroidStoreButtonTracking = function (root) {
         if (
             !window.Mozilla ||

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -683,6 +683,12 @@
     },
     {
       "files": [
+        "js/base/mobile-attribution.js"
+      ],
+      "name": "mobile-attribution"
+    },
+    {
+      "files": [
         "js/base/protocol/modal-global.es6.js"
       ],
       "name": "protocol-modal"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -656,6 +656,12 @@
     },
     {
       "files": [
+        "js/base/mobile-attribution.js"
+      ],
+      "name": "mobile-attribution"
+    },
+    {
+      "files": [
         "js/base/protocol/modal-global.es6.js"
       ],
       "name": "protocol-modal"

--- a/springfield/base/templates/base-protocol.html
+++ b/springfield/base/templates/base-protocol.html
@@ -160,6 +160,13 @@
       {% endif %}
     {% endblock %}
 
+    {% block mobile_attribution %}
+      {# Rewrites /thanks/-bound download buttons to attributed store URLs on
+         mobile UAs so page-level campaign survives the click. Self-gates on
+         campaign data attrs or URL utm_campaign; no-op otherwise. #}
+      {{ js_bundle('mobile-attribution') }}
+    {% endblock %}
+
     <!--[if !IE]><!-->
     {% block js %}{% endblock %}
 

--- a/springfield/base/templates/base-protocol.html
+++ b/springfield/base/templates/base-protocol.html
@@ -156,6 +156,13 @@
       {% endif %}
     {% endblock %}
 
+    {% block mobile_attribution %}
+      {# Rewrites /thanks/-bound download buttons to attributed store URLs on
+         mobile UAs so page-level campaign survives the click. Self-gates on
+         campaign data attrs or URL utm_campaign; no-op otherwise. #}
+      {{ js_bundle('mobile-attribution') }}
+    {% endblock %}
+
     <!--[if !IE]><!-->
     {% block js %}{% endblock %}
 

--- a/springfield/cms/templates/cms/base-flare.html
+++ b/springfield/cms/templates/cms/base-flare.html
@@ -103,6 +103,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
       {# Download as default needs to come after stub attribution #}
       {{ js_bundle('download_as_default') }}
+
+      {# Rewrites /thanks/-bound download buttons to attributed store URLs on
+         mobile UAs so page-level campaign survives the click. Self-gates on
+         campaign data attrs or URL utm_campaign; no-op otherwise. #}
+      {{ js_bundle('mobile-attribution') }}
     {% endblock %}
 
     {% block js %}

--- a/springfield/cms/templates/cms/base-flare26.html
+++ b/springfield/cms/templates/cms/base-flare26.html
@@ -212,6 +212,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       {# Download as default needs to come after stub attribution #}
       {{ js_bundle('download_as_default') }}
 
+      {# Rewrites /thanks/-bound download buttons to attributed store URLs on
+         mobile UAs so page-level campaign survives the click. Self-gates on
+         campaign data attrs or URL utm_campaign; no-op otherwise. #}
+      {{ js_bundle('mobile-attribution') }}
+
       {% if page is defined and page.enable_marketing_attribution %}
         <!--[if IE 9]><!-->
           {# Marketing opt-out runs on all evergreen browsers plus IE9 and above. #}

--- a/springfield/cms/templates/cms/base-flare26.html
+++ b/springfield/cms/templates/cms/base-flare26.html
@@ -221,6 +221,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         {{ js_bundle('download_as_default') }}
       {% endif %}
 
+      {# Rewrites /thanks/-bound download buttons to attributed store URLs on
+         mobile UAs so page-level campaign survives the click. Self-gates on
+         campaign data attrs or URL utm_campaign; no-op otherwise. #}
+      {{ js_bundle('mobile-attribution') }}
+
       {% if page is defined and page.enable_marketing_attribution %}
         <!--[if IE 9]><!-->
           {# Marketing opt-out runs on all evergreen browsers plus IE9 and above. #}

--- a/tests/unit/spec/base/mobile-attribution/mobile-attribution.js
+++ b/tests/unit/spec/base/mobile-attribution/mobile-attribution.js
@@ -1,0 +1,494 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+const ANDROID_UA =
+    'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36';
+const IOS_UA =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const DESKTOP_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36';
+
+const ANDROID_STORE_PREFIX =
+    'https://play.google.com/store/apps/details?id=org.mozilla.firefox';
+const IOS_STORE_PREFIX = 'https://apps.apple.com/app/apple-store/id989804926';
+
+describe('mobile-attribution.js', function () {
+    let html;
+    let container;
+
+    beforeEach(function () {
+        html = document.documentElement;
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(function () {
+        // Clean up any campaign attrs the test set.
+        html.removeAttribute('data-stub-attribution-campaign');
+        html.removeAttribute('data-stub-attribution-campaign-override');
+        html.removeAttribute('data-stub-attribution-campaign-force');
+        document.body.removeChild(container);
+    });
+
+    describe('getCampaign', function () {
+        const getCampaign = function (search) {
+            return Mozilla.MobileAttribution.getCampaign(html, search);
+        };
+
+        it('returns null when nothing is set', function () {
+            expect(getCampaign('')).toBeNull();
+        });
+
+        it('returns the default data attr when set', function () {
+            html.setAttribute('data-stub-attribution-campaign', 'default-x');
+            expect(getCampaign('')).toBe('default-x');
+        });
+
+        it('returns the URL utm_campaign when present', function () {
+            expect(getCampaign('?utm_campaign=url-x')).toBe('url-x');
+        });
+
+        it('URL utm_campaign wins over default data attr', function () {
+            html.setAttribute('data-stub-attribution-campaign', 'default-x');
+            expect(getCampaign('?utm_campaign=url-x')).toBe('url-x');
+        });
+
+        it('override data attr wins over URL utm_campaign', function () {
+            html.setAttribute(
+                'data-stub-attribution-campaign-override',
+                'override-x'
+            );
+            expect(getCampaign('?utm_campaign=url-x')).toBe('override-x');
+        });
+
+        it('force data attr wins over everything', function () {
+            html.setAttribute(
+                'data-stub-attribution-campaign-force',
+                'force-x'
+            );
+            html.setAttribute(
+                'data-stub-attribution-campaign-override',
+                'override-x'
+            );
+            html.setAttribute('data-stub-attribution-campaign', 'default-x');
+            expect(getCampaign('?utm_campaign=url-x')).toBe('force-x');
+        });
+
+        it('decodes URL-encoded utm_campaign values', function () {
+            expect(getCampaign('?utm_campaign=hello%20world')).toBe(
+                'hello world'
+            );
+        });
+
+        it('handles utm_campaign as not the first query param', function () {
+            expect(getCampaign('?foo=bar&utm_campaign=second')).toBe('second');
+        });
+    });
+
+    describe('getStoreUrl', function () {
+        it('builds an Android Play Store URL with the install_referrer', function () {
+            const url = Mozilla.MobileAttribution.getStoreUrl('test-19', true);
+            expect(url.indexOf(ANDROID_STORE_PREFIX)).toBe(0);
+            expect(url).toContain('utm_campaign%3Dtest-19');
+            expect(url).toContain('utm_source%3Dwww.firefox.com');
+            expect(url).toContain('utm_medium%3Dreferral');
+        });
+
+        it('builds an iOS App Store URL with pt/ct', function () {
+            const url = Mozilla.MobileAttribution.getStoreUrl('test-19', false);
+            expect(url.indexOf(IOS_STORE_PREFIX)).toBe(0);
+            expect(url).toContain('pt=373246');
+            expect(url).toContain('ct=test-19');
+            expect(url).toContain('mz_pr=firefox_mobile');
+        });
+
+        it('URL-encodes campaign values containing special characters', function () {
+            const url = Mozilla.MobileAttribution.getStoreUrl(
+                'hello world',
+                true
+            );
+            expect(url).toContain('utm_campaign%3Dhello%20world');
+        });
+    });
+
+    describe('rewriteLinks', function () {
+        afterEach(function () {
+            // Restore the TrackProductDownload namespace so other test suites
+            // see it intact. Some tests delete or stub it.
+            if (
+                window.Mozilla &&
+                !window.Mozilla.TrackProductDownload &&
+                window._OriginalTrackProductDownload
+            ) {
+                window.Mozilla.TrackProductDownload =
+                    window._OriginalTrackProductDownload;
+                delete window._OriginalTrackProductDownload;
+            }
+        });
+
+        it('rewrites HREFs of /thanks/-bound .c-button-download-thanks-link elements', function () {
+            container.innerHTML =
+                '<a class="c-button-download-thanks-link" href="/thanks/">Download</a>' +
+                '<a class="c-button-download-thanks-link" href="/en-US/thanks/">Download</a>';
+
+            Mozilla.MobileAttribution.rewriteLinks(container, 'TARGET');
+
+            const links = container.querySelectorAll('a');
+            expect(links[0].getAttribute('href')).toBe('TARGET');
+            expect(links[1].getAttribute('href')).toBe('TARGET');
+        });
+
+        it('rewrites .download-link inside .c-button-download-thanks (nav and pre-footer pattern)', function () {
+            // Nav and pre-footer pass exclude_unsupported_content=True, which
+            // omits the `-link` suffix on the class. The .download-link inside
+            // the wrapper still needs to be rewritten.
+            container.innerHTML =
+                '<div class="c-button-download-thanks">' +
+                '<a class="download-link" href="/thanks/">Download</a>' +
+                '</div>';
+
+            Mozilla.MobileAttribution.rewriteLinks(container, 'TARGET');
+
+            expect(container.querySelector('a').getAttribute('href')).toBe(
+                'TARGET'
+            );
+        });
+
+        it('leaves non-/thanks/ HREFs alone (Path A store buttons are unaffected)', function () {
+            container.innerHTML =
+                '<a class="c-button-download-thanks-link" href="/thanks/">Should rewrite</a>' +
+                '<a class="fl-store-button fl-store-button-android" href="https://play.google.com/...">Should not rewrite</a>' +
+                '<a class="fl-store-button fl-store-button-ios" href="https://apps.apple.com/...">Should not rewrite</a>';
+
+            Mozilla.MobileAttribution.rewriteLinks(container, 'TARGET');
+
+            expect(
+                container
+                    .querySelector('.c-button-download-thanks-link')
+                    .getAttribute('href')
+            ).toBe('TARGET');
+            expect(
+                container
+                    .querySelector('.fl-store-button-android')
+                    .getAttribute('href')
+            ).toBe('https://play.google.com/...');
+            expect(
+                container
+                    .querySelector('.fl-store-button-ios')
+                    .getAttribute('href')
+            ).toBe('https://apps.apple.com/...');
+        });
+
+        it('skips elements whose href is not /thanks/', function () {
+            // Defense in depth: even if the class lands on a non-/thanks/ link,
+            // we should not rewrite it.
+            container.innerHTML =
+                '<a class="c-button-download-thanks-link" href="https://example.com/other">Should not rewrite</a>' +
+                '<div class="c-button-download-thanks">' +
+                '<a class="download-link" href="https://example.com/other2">Should not rewrite</a>' +
+                '</div>';
+
+            Mozilla.MobileAttribution.rewriteLinks(container, 'TARGET');
+
+            const links = container.querySelectorAll('a');
+            expect(links[0].getAttribute('href')).toBe(
+                'https://example.com/other'
+            );
+            expect(links[1].getAttribute('href')).toBe(
+                'https://example.com/other2'
+            );
+        });
+
+        it('clicking a rewritten button fires sendEventFromURL and navigates to the original https store URL', function () {
+            // Simulate the post-rewrite + post-mozilla-utils.js state: the
+            // button HREF has been mutated to a market:// URL after our
+            // rewrite ran (as would happen on real Android UAs). The click
+            // handler must still pass the original https:// URL — not the
+            // market:// URL — so TrackProductDownload's regex recognizes it,
+            // and the navigation should target the original URL so desktop
+            // browsers (with mobile UA spoofing) reach a real destination
+            // instead of an unregistered market:// scheme.
+            const ORIGINAL_STORE_URL =
+                'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_campaign%3Dtest-19';
+            const MUTATED_HREF =
+                'market://details?id=org.mozilla.firefox&referrer=utm_campaign%3Dtest-19';
+
+            container.innerHTML =
+                '<a class="c-button-download-thanks-link" href="/thanks/">Download</a>';
+
+            const sendEventSpy = spyOn(
+                Mozilla.TrackProductDownload,
+                'sendEventFromURL'
+            );
+            // Spy on the navigation seam so the test doesn't actually
+            // navigate the jasmine runner away.
+            const navigateSpy = spyOn(Mozilla.MobileAttribution, '_navigate');
+
+            Mozilla.MobileAttribution.rewriteLinks(
+                container,
+                ORIGINAL_STORE_URL
+            );
+
+            // Simulate mozilla-utils.js mutating the href to market:// after
+            // our rewrite (this is what happens in practice on Android UAs).
+            const link = container.querySelector('a');
+            link.setAttribute('href', MUTATED_HREF);
+
+            const clickEvent = new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true
+            });
+            const preventSpy = spyOn(
+                clickEvent,
+                'preventDefault'
+            ).and.callThrough();
+            link.dispatchEvent(clickEvent);
+
+            expect(sendEventSpy).toHaveBeenCalledWith(ORIGINAL_STORE_URL);
+            expect(navigateSpy).toHaveBeenCalledWith(ORIGINAL_STORE_URL);
+            expect(preventSpy).toHaveBeenCalled();
+        });
+
+        it('does not throw if TrackProductDownload is undefined at init time', function () {
+            window._OriginalTrackProductDownload =
+                window.Mozilla.TrackProductDownload;
+            delete window.Mozilla.TrackProductDownload;
+
+            container.innerHTML =
+                '<a class="c-button-download-thanks-link" href="/thanks/">Download</a>';
+
+            expect(function () {
+                Mozilla.MobileAttribution.rewriteLinks(container, 'TARGET');
+            }).not.toThrow();
+
+            // The HREF still gets rewritten even without the tracker — the
+            // navigation works, only the click event is missed.
+            expect(container.querySelector('a').getAttribute('href')).toBe(
+                'TARGET'
+            );
+        });
+    });
+
+    describe('attachAndroidStoreButtonTracking', function () {
+        afterEach(function () {
+            // Restore the TrackProductDownload namespace if a test deleted it.
+            if (
+                window.Mozilla &&
+                !window.Mozilla.TrackProductDownload &&
+                window._OriginalTrackProductDownload
+            ) {
+                window.Mozilla.TrackProductDownload =
+                    window._OriginalTrackProductDownload;
+                delete window._OriginalTrackProductDownload;
+            }
+        });
+
+        it('attaches a sendEventFromURL click handler to .fl-store-button-android elements', function () {
+            const ORIGINAL_ANDROID_URL =
+                'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_campaign%3Dpage-slug';
+
+            container.innerHTML =
+                '<a class="ga-product-download fl-store-button fl-store-button-android" href="' +
+                ORIGINAL_ANDROID_URL +
+                '">Play Store</a>';
+
+            const sendEventSpy = spyOn(
+                Mozilla.TrackProductDownload,
+                'sendEventFromURL'
+            );
+            const navigateSpy = spyOn(Mozilla.MobileAttribution, '_navigate');
+
+            Mozilla.MobileAttribution.attachAndroidStoreButtonTracking(
+                container
+            );
+
+            const link = container.querySelector('a');
+            link.dispatchEvent(
+                new MouseEvent('click', { bubbles: true, cancelable: true })
+            );
+
+            expect(sendEventSpy).toHaveBeenCalledWith(ORIGINAL_ANDROID_URL);
+            expect(navigateSpy).toHaveBeenCalledWith(ORIGINAL_ANDROID_URL);
+        });
+
+        it('captures the original https URL even if href is later mutated to market://', function () {
+            // Simulate the real-world race: our handler is attached at
+            // script load (sync). mozilla-utils.js mutates the href on
+            // DOMContentLoaded. By click time, the href is market://...
+            // but our captured URL is still the original https://.
+            const ORIGINAL_ANDROID_URL =
+                'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_campaign%3Dpage-slug';
+            const MUTATED_HREF =
+                'market://details?id=org.mozilla.firefox&referrer=utm_campaign%3Dpage-slug';
+
+            container.innerHTML =
+                '<a class="ga-product-download fl-store-button fl-store-button-android" href="' +
+                ORIGINAL_ANDROID_URL +
+                '">Play Store</a>';
+
+            const sendEventSpy = spyOn(
+                Mozilla.TrackProductDownload,
+                'sendEventFromURL'
+            );
+            spyOn(Mozilla.MobileAttribution, '_navigate');
+
+            Mozilla.MobileAttribution.attachAndroidStoreButtonTracking(
+                container
+            );
+
+            // Simulate mozilla-utils.js mutation after our attach.
+            container.querySelector('a').setAttribute('href', MUTATED_HREF);
+
+            container
+                .querySelector('a')
+                .dispatchEvent(
+                    new MouseEvent('click', { bubbles: true, cancelable: true })
+                );
+
+            // Captured URL wins — not the mutated market:// URL.
+            expect(sendEventSpy).toHaveBeenCalledWith(ORIGINAL_ANDROID_URL);
+        });
+
+        it('does NOT attach to .fl-store-button-ios elements (iOS already fires via existing handler)', function () {
+            container.innerHTML =
+                '<a class="ga-product-download fl-store-button fl-store-button-ios" href="https://apps.apple.com/...?ct=page-slug">App Store</a>';
+
+            const sendEventSpy = spyOn(
+                Mozilla.TrackProductDownload,
+                'sendEventFromURL'
+            );
+
+            Mozilla.MobileAttribution.attachAndroidStoreButtonTracking(
+                container
+            );
+
+            container
+                .querySelector('a')
+                .dispatchEvent(
+                    new MouseEvent('click', { bubbles: true, cancelable: true })
+                );
+
+            expect(sendEventSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not throw if TrackProductDownload is undefined', function () {
+            window._OriginalTrackProductDownload =
+                window.Mozilla.TrackProductDownload;
+            delete window.Mozilla.TrackProductDownload;
+
+            container.innerHTML =
+                '<a class="fl-store-button-android" href="https://play.google.com/...">Play Store</a>';
+
+            expect(function () {
+                Mozilla.MobileAttribution.attachAndroidStoreButtonTracking(
+                    container
+                );
+            }).not.toThrow();
+        });
+    });
+
+    describe('init', function () {
+        beforeEach(function () {
+            spyOn(Mozilla.MobileAttribution, 'rewriteLinks');
+            spyOn(
+                Mozilla.MobileAttribution,
+                'attachAndroidStoreButtonTracking'
+            );
+        });
+
+        it('is a no-op when no campaign resolves and no Android UA', function () {
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                IOS_UA
+            );
+
+            Mozilla.MobileAttribution.init();
+
+            expect(
+                Mozilla.MobileAttribution.rewriteLinks
+            ).not.toHaveBeenCalled();
+            expect(
+                Mozilla.MobileAttribution.attachAndroidStoreButtonTracking
+            ).not.toHaveBeenCalled();
+        });
+
+        it('is a no-op on desktop UA even when a campaign is set', function () {
+            html.setAttribute('data-stub-attribution-campaign', 'test-19');
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                DESKTOP_UA
+            );
+
+            Mozilla.MobileAttribution.init();
+
+            expect(
+                Mozilla.MobileAttribution.rewriteLinks
+            ).not.toHaveBeenCalled();
+            expect(
+                Mozilla.MobileAttribution.attachAndroidStoreButtonTracking
+            ).not.toHaveBeenCalled();
+        });
+
+        it('calls attachAndroidStoreButtonTracking on Android UA regardless of campaign', function () {
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                ANDROID_UA
+            );
+
+            Mozilla.MobileAttribution.init();
+
+            expect(
+                Mozilla.MobileAttribution.attachAndroidStoreButtonTracking
+            ).toHaveBeenCalled();
+        });
+
+        it('does NOT call attachAndroidStoreButtonTracking on iOS UA', function () {
+            html.setAttribute('data-stub-attribution-campaign', 'test-19');
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                IOS_UA
+            );
+
+            Mozilla.MobileAttribution.init();
+
+            expect(
+                Mozilla.MobileAttribution.attachAndroidStoreButtonTracking
+            ).not.toHaveBeenCalled();
+        });
+
+        it('rewrites with the Android URL on Android UA', function () {
+            html.setAttribute('data-stub-attribution-campaign', 'test-19');
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                ANDROID_UA
+            );
+
+            Mozilla.MobileAttribution.init();
+
+            expect(Mozilla.MobileAttribution.rewriteLinks).toHaveBeenCalled();
+            const callArgs =
+                Mozilla.MobileAttribution.rewriteLinks.calls.mostRecent().args;
+            expect(callArgs[0]).toBe(document);
+            expect(callArgs[1].indexOf(ANDROID_STORE_PREFIX)).toBe(0);
+            expect(callArgs[1]).toContain('utm_campaign%3Dtest-19');
+        });
+
+        it('rewrites with the iOS URL on iOS UA', function () {
+            html.setAttribute('data-stub-attribution-campaign', 'test-19');
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                IOS_UA
+            );
+
+            Mozilla.MobileAttribution.init();
+
+            expect(Mozilla.MobileAttribution.rewriteLinks).toHaveBeenCalled();
+            const callArgs =
+                Mozilla.MobileAttribution.rewriteLinks.calls.mostRecent().args;
+            expect(callArgs[1].indexOf(IOS_STORE_PREFIX)).toBe(0);
+            expect(callArgs[1]).toContain('ct=test-19');
+        });
+    });
+});

--- a/tests/unit/spec/base/mobile-attribution/mobile-attribution.js
+++ b/tests/unit/spec/base/mobile-attribution/mobile-attribution.js
@@ -27,6 +27,15 @@ describe('mobile-attribution.js', function () {
     beforeEach(function () {
         html = document.documentElement;
         container = document.createElement('div');
+        // Suppress default <a> navigation for any test that dispatches a
+        // click event. Synthetic clicks on real-looking URLs (e.g.
+        // https://apps.apple.com/...) in headless CI browsers will navigate
+        // the runner away, killing the rest of the suite — so we
+        // preventDefault at the container level for any click that bubbles
+        // out unhandled by a test's own listeners.
+        container.addEventListener('click', function (event) {
+            event.preventDefault();
+        });
         document.body.appendChild(container);
     });
 

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -23,6 +23,8 @@ module.exports = {
             'media/js/base/experiment-amo.es6.js',
             'media/js/base/mozilla-fxa.js',
             'media/js/base/stub-attribution/stub-attribution.js',
+            'media/js/base/datalayer-productdownload-init.es6.js',
+            'media/js/base/mobile-attribution.js',
             'media/js/firefox/download/common/thanks.js',
             'node_modules/sinon/pkg/sinon.js'
         ]


### PR DESCRIPTION
## Summary
Closes the mobile attribution gap on landing-page download buttons. Two related fixes:
### Path B — `/thanks/`-bound CTAs (nav, pre-footer, etc.)
Today, mobile users clicking these buttons land on `/thanks/`, which auto-redirects to a **bare** Play Store / App Store URL with no `install_referrer` / `pt`+`ct` params for the originating page's campaign. The install reaches the store but the page-campaign is lost.

A new client-side module (`media/js/base/mobile-attribution.js`):
- Resolves the page's campaign via the same cascade `stub-attribution.js` uses: `force > override > URL utm_campaign > default`.
- On mobile UAs, rewrites matching button HREFs to attributed `play_store_url()` / `app_store_url()`-shaped URLs.
- Attaches a click handler that fires `Mozilla.TrackProductDownload.sendEventFromURL` with the captured `https://` URL (mirroring `thanks-init.js`) and navigates via `window.location.href` so the rewrite works in any browser despite `mozilla-utils.js`'s `market://` scheme mutation.

### Path A — CMS `download_firefox_button` Play/App Store badges

These already have attributed URLs server-side and have always fired the `firefox_mobile_download` GA4 event correctly **on iOS** — the existing [`datalayer-productdownload-init.es6.js`](media/js/base/datalayer-productdownload-init.es6.js) attaches `handleLink` to every `.ga-product-download` element.

But on Android the event has been silently dropping. `mozilla-utils.js` mutates `https://play.google.com/...` to `market://details?...` on DOM ready, and the tracker's `marketURL` regex (`/^market:\/\/play.google.com/`) doesn't match that shape — so `isValidDownloadURL` returns false and the event never fires.

We supplement Android Path A buttons (`.fl-store-button-android`) with a click handler that uses the captured `https://` URL. iOS Path A is untouched (existing handler still works there) — adding ours would double-fire the event.

## Analytics changes — for Martech review
> ⚠️ **Two analytics deltas in this PR.** Both should net to *more* accurate signal in dashboards that use the `firefox_mobile_download` / `product_download` events.

Scenario Before this PR After this PR
---------

Mobile click on **nav / pre-footer** download CTA (Android or iOS), page has a campaign Click → `/thanks/` → auto-redirect to **bare** store URL (with hardcoded `utm_campaign=download` for Android, or no `pt`/`ct` for iOS). `firefox_mobile_download` event fires correctly from `/thanks/` (it captures the URL synchronously), but the install itself reaches the store with no page-campaign attribution. Click → directly to **attributed** store URL with the page's campaign. `firefox_mobile_download` event fires from the landing page (not `/thanks/`) with the same payload. Same total event volume; campaign now reaches Play Console / App Store Connect.

Mobile click on **nav / pre-footer** CTA, no campaign anywhere on page Same as today (bare store URL via `/thanks/` auto-redirect, event fires from `/thanks/`). Strict no-op (JS exits early). Identical to today.

Click on **CMS `download_firefox_button` Play Store badge (Android)** Event silently dropped on click. The existing `datalayer-productdownload-init.es6.js` handler reads `event.target.href` at click time, which `mozilla-utils.js` has already mutated to `market://details?...`; the tracker's `marketURL` regex (`/^market:\/\/play.google.com/`) doesn't match that shape. No `firefox_mobile_download` event fires. Event now fires correctly with the campaign in the URL. **Expect previously-zero volume on Android Path A clicks to appear in dashboards.**

Click on **CMS `download_firefox_button` App Store badge (iOS)** Event fires correctly (existing handler works — `mozilla-utils.js` doesn't mutate iOS URLs). Unchanged — we deliberately don't double-attach. `/thanks/` page itself (mobile user lands there directly, e.g. from a hand-rolled link or in the absence of a campaign) `thanks-init.js` auto-redirects after 1s and fires the event correctly (captures URL synchronously before mutation). **Unchanged.** Our JS doesn't touch the auto-redirect path. `/thanks/` GTM pageview for mobile users transiting `/thanks/` Fires Skipped for users who would have transited `/thanks/` (because they now go directly to the store). Mobile users who land on `/thanks/` directly still fire it.
**No GTM dashboard changes needed.** The canonical signal for mobile downloads is the `firefox_mobile_download` event itself, which fires under both Path A and Path B. If a dashboard estimates mobile downloads by counting `/thanks/` pageviews specifically, it should switch to the event count.

**Existing latent bug worth a follow-up (separate PR)**: the `marketURL` regex in [`datalayer-productdownload.es6.js:15`](media/js/base/datalayer-productdownload.es6.js) is `/^market:\/\/play.google.com/`, but `mozilla-utils.js`'s `initMobileDownloadLinks` produces `market://details?...` (no `play.google.com` in the path). This affects any click-time-URL-read handler on a `.ga-product-download` Android button. `/thanks/`'s auto-redirect is unaffected because `thanks-init.js` captures the URL synchronously before the mutation. This PR works around the regex bug for our specific buttons via the same synchronous-capture pattern. A separate PR could broaden the regex to `/^market:\/\//` to fix the root cause for any other Path A buttons across the site (e.g. release-notes, landing/gaming, landing/ios-summarizer).

## Files
- `media/js/base/mobile-attribution.js` (new)
- `tests/unit/spec/base/mobile-attribution/mobile-attribution.js` (new)
- `media/static-bundles.json` — new `mobile-attribution` bundle
- `webpack.test.config.js` — `datalayer-productdownload-init.es6.js` and `mobile-attribution.js` added to `test-deps`
- `springfield/base/templates/base-protocol.html`, `springfield/cms/templates/cms/base-flare26.html`, `springfield/cms/templates/cms/base-flare.html` — load the new bundle alongside the existing `stub-attribution` bundle
## Test plan
### Regression checks (must be byte-identical to before)
- [x] **Desktop (no UA spoof), `stub_attr_utm_campaign_value="test-19"` set**: nav button HREF stays `/thanks/`. Click → stub installer flow, `moz-stub-attribution-code` cookie carries `test-19`.
- [x] **Page with no `stub_attr` and no URL `utm_campaign`, mobile UA**: nav HREF stays `/thanks/`. JS exits early. Identical to today.
- [x] **Hand-rolled footer "Download Firefox" link** still routes to `/thanks/` on any UA (intentional — no wrapper class).
- [x] **Mobile user lands directly on `/thanks/`** (e.g. from a hand-rolled link or no-campaign nav): auto-redirect to store fires after 1s with the existing event. Unchanged.
### New behavior
- [x] **Mobile UA Chrome devtools (Android UA), page with `test-19`**: nav and pre-footer button HREFs rewrite to `play.google.com/...&utm_campaign=test-19`. `mozilla-utils.js` further converts to `market://...` on real Android. Click → store install attributed.
- [x] **Mobile UA Chrome devtools (iOS UA), same page**: nav and pre-footer button HREFs rewrite to `apps.apple.com/...&ct=test-19`. Click → App
Store.
- [x] **URL-param attribution**: any page (CMS or not) with `?utm_campaign=test-19`, mobile UA → nav HREF rewrites.
- [x] **Cascade precedence**: `stub_attr_utm_campaign_mode="force"` value `force-val` + URL `?utm_campaign=url-val` → mobile HREF reflects `force-val`. Switch mode to `default` → URL value wins.
- [x] **Path A Android button**: CMS `download_firefox_button` block on a page, Android UA, click the green Play Store badge. In DevTools
Console: `dataLayer.filter(e => e.event === 'firefox_mobile_download')` returns an entry with `platform: 'android'`, `method: 'store'`, `release_channel: 'release'`. (Previously this would have been empty due to the regex mismatch.)
- [x] **Path A iOS button**: same setup, iOS UA, click the black App Store badge. Confirm exactly **one** event fires (not two — we're relying on the existing handler, not adding our own).
### End-to-end (recommended before launch)
- [ ] **Real Android device**: visit a `stub_attr`-configured page on a device without Firefox installed. Tap nav button → Play Store opens → install Firefox → open it once. Verify the install appears in Play Console attributed to the campaign value.
- [ ] **Real iOS device**: same, with the App Store. Verify campaign shows in App Store Connect attribution.