### PR TITLE
WT-1217: Drop HTML comments from sanitized output

### DIFF
--- a/springfield/base/sanitization.py
+++ b/springfield/base/sanitization.py
@@ -9,7 +9,14 @@ This module provides functions for sanitizing HTML content, replacing
 the deprecated bleach library.
 """
 
+import re
+
 from justhtml import JustHTML, SanitizationPolicy, UrlPolicy, UrlRule
+
+# Matches HTML comments. justhtml's DropComments transform cannot drop
+# comments when disallowed_tag_handling="escape" is in effect), so
+# we strip comments before handing the input to justhtml.
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 
 # Tags whose content should be completely dropped (not just the tags)
 _DROP_CONTENT_TAGS = frozenset({"script", "style"})
@@ -48,6 +55,7 @@ def strip_all_tags(html: str) -> str:
         disallowed_tag_handling="unwrap",
         drop_content_tags=_DROP_CONTENT_TAGS,
     )
+    html = _HTML_COMMENT_RE.sub("", html)
     doc = JustHTML(html, policy=policy, fragment=True)
     return doc.to_html(pretty=False)
 
@@ -55,7 +63,9 @@ def strip_all_tags(html: str) -> str:
 def sanitize_html(html: str, allowed_tags: set, allowed_attributes: dict) -> str:
     """Sanitize HTML using an allowlist of tags and attributes.
 
-    Disallowed tags are escaped (converted to &lt;tag&gt;).
+    Disallowed tags are escaped (converted to &lt;tag&gt;). HTML comments are
+    dropped: keeping them would reveal authoring notes and, with the
+    current escape policy, surface them as visible &lt;!-- ... --&gt; text.
 
     Args:
         html: The HTML string to sanitize.
@@ -73,5 +83,6 @@ def sanitize_html(html: str, allowed_tags: set, allowed_attributes: dict) -> str
         disallowed_tag_handling="escape",
         drop_content_tags=_DROP_CONTENT_TAGS,
     )
+    html = _HTML_COMMENT_RE.sub("", html)
     doc = JustHTML(html, policy=policy, fragment=True)
     return doc.to_html(pretty=False)

--- a/springfield/base/sanitization.py
+++ b/springfield/base/sanitization.py
@@ -14,7 +14,7 @@ import re
 from justhtml import JustHTML, SanitizationPolicy, UrlPolicy, UrlRule
 
 # Matches HTML comments. justhtml's DropComments transform cannot drop
-# comments when disallowed_tag_handling="escape" is in effect), so
+# comments when disallowed_tag_handling="escape" is in effect, so
 # we strip comments before handing the input to justhtml.
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 

--- a/springfield/base/tests/test_sanitization.py
+++ b/springfield/base/tests/test_sanitization.py
@@ -36,6 +36,10 @@ class TestStripAllTags:
             # Attributes are ignored
             ('<a href="https://example.com">link</a>', "link"),
             ('<div class="test" id="foo">content</div>', "content"),
+            # HTML comments are dropped
+            ("<!-- hidden -->", ""),
+            ("before<!-- mid -->after", "beforeafter"),
+            ("<p>visible<!-- note --></p>", "visible"),
         ],
     )
     def test_strip_all_tags(self, html, expected):
@@ -113,6 +117,30 @@ class TestSanitizeHtml:
         """Test that HTML entities are preserved."""
         assert sanitize_html("text &amp; more", {"a"}, {}) == "text &amp; more"
         assert sanitize_html("<b>&lt;escaped&gt;</b>", {"b"}, {}) == "<b>&lt;escaped&gt;</b>"
+
+    @pytest.mark.parametrize(
+        "html, expected",
+        [
+            # Comment-only input is dropped to empty string
+            ("<!-- only -->", ""),
+            ("<!-- Keep this note until 156 -->", ""),
+            # Comments adjacent to text disappear
+            ("<!-- hidden -->visible", "visible"),
+            # Comments interleaved with allowed tags
+            ("<p>before<!-- mid -->after</p>", "<p>beforeafter</p>"),
+            # Multi-line / multi-word comment content
+            ("<p>x<!-- a\nb\nc -->y</p>", "<p>xy</p>"),
+            # Comments are dropped while unknown tags continue to be escaped
+            (
+                "<!-- drop me --><custom>x</custom>",
+                "&lt;custom&gt;x&lt;/custom&gt;",
+            ),
+        ],
+    )
+    def test_comments_are_dropped(self, html, expected):
+        allowed_tags = {"p"}
+        allowed_attributes = {}
+        assert sanitize_html(html, allowed_tags, allowed_attributes) == expected
 
 
 class TestUrlSchemeValidation:


### PR DESCRIPTION
Since switching from bleach to justhtml (WT-578), HTML comments in release-notes Markdown have been surfaced on the page as literal `<!-- ... -->` text because the markup was HTML escaped. With the setting on `disallowed_tag_handling="escape"`, justhtml's escape pass wins over its DropComments transform, and using an explicit Sanitize() to force ordering discards our custom policy.

The fix is to strip `<!--...-->` with a regex before handing the HTML to justhtml. This keeps the escape behaviour for unknown tags so example markup still renders as visible source.

## Testing


* `./manage.py update_release_notes`
* on main, visit http://localhost:8000/en-GB/firefox/153.0a1/releasenotes/ scroll down to Web Platform and see a HTML comment (escaped)
* switch to this branch 
* reload the page and you'll see the HTML comment is gone