### PR TITLE
Technical SEO - Stop emitting empty meta description tags

### DIFF
--- a/springfield/cms/templates/cms/base-flare26.html
+++ b/springfield/cms/templates/cms/base-flare26.html
@@ -44,14 +44,22 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
     {% block shared_meta %}
     <title>{% filter striptags %}{% block page_title_full %}{% block page_title_prefix %}{% endblock %}{% block page_title %}{{ (page.og_title or page.title) if page is defined and page.title is defined else 'Firefox' }}{% endblock %}{% endblock page_title_full %}{% block page_title_suffix %} — Firefox.com{% endblock %}{% endfilter %}</title>
-    <meta name="description" content="{% filter striptags %}{% block page_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endfilter %}">
+    {% set page_desc_content %}{% block page_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset %}
+    {% set page_desc_content = page_desc_content|striptags|trim %}
+    {%- if page_desc_content %}
+    <meta name="description" content="{{ page_desc_content }}">
+    {%- endif %}
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Firefox">
     <meta property="og:locale" content="{{ LANG|replace("-", "_") }}">
     <meta property="og:url" content="{% filter trim|absolute_url %}{% block page_og_url %}{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}{% endblock %}{% endfilter %}">
     <meta property="og:image" content="{% filter trim|absolute_url %}{% block page_image %}{% if page and page.og_image %}{% set img = image(page.og_image, "width-1200") %}{{ img.url }}{% else %}{{ static('img/firefox/flare/og.png') }}{% endif %}{% endblock %}{% endfilter %}">
     <meta property="og:title" content="{% filter striptags %}{% block page_og_title %}{{ (page.og_title or page.title) if page is defined and page.title is defined else 'Firefox'  }}{% endblock %}{% endfilter %}">
-    <meta property="og:description" content="{% filter striptags %}{% block page_og_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endfilter %}">
+    {% set page_og_desc_content %}{% block page_og_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset %}
+    {% set page_og_desc_content = page_og_desc_content|striptags|trim %}
+    {%- if page_og_desc_content %}
+    <meta property="og:description" content="{{ page_og_desc_content }}">
+    {%- endif %}
     <meta property="fb:page_id" content="{% block facebook_id %}14696440021{# facebook.com/firefox #}{% endblock %}">
     <meta name="twitter:card" content="{% block twitter_card %}summary_large_image{% endblock %}">
     <meta name="twitter:site" content="@{% block twitter_id %}firefox{% endblock %}">


### PR DESCRIPTION
## Summary

When a CMS page has a blank `search_description`, base-flare26.html was rendering `<meta name="description" content="">` and `<meta property="og:description" content="">` — empty tags. This change captures the rendered block content, strips tags and whitespace, and only emits the surrounding `<meta>` tag when there's actual content to put in it.

## Why

- An **empty** meta description tag explicitly signals "no description" to crawlers and LLM-driven search.
- An **absent** tag lets Google synthesize a snippet from the page content (which it does well).
- Absent is strictly better than empty.

Part of the firefox.com technical SEO workstream (item A3 in the master plan).

  ## What changed

`springfield/cms/templates/cms/base-flare26.html` only — two parallel changes on the `page_desc` and `page_og_desc` blocks. The block definitions are unchanged, so the ~60 child templates that override them (`features/fast.html`, `browsers/desktop/base.html`, etc.) continue to work without modification.

Before:
```jinja
  <meta name="description" content="{% filter striptags %}{% block page_desc %}{{ page.og_description if page is defined and page.og_description is
  defined }}{% endblock %}{% endfilter %}">
```

After:
```jinja
{% set page_desc_content %}{% block page_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset
%}
{% set page_desc_content = page_desc_content|striptags|trim %}
{%- if page_desc_content %}
<meta name="description" content="{{ page_desc_content }}">
{%- endif %}
```

Same pattern for `page_og_desc`.

## Out of scope

The same defect exists in `cms/base-flare.html` and `base/base-protocol.html`. Both are being sunset and intentionally excluded from this change.

  ## Test plan

  - [x] CMS page with blank `search_description` → no `<meta name="description">` and no `<meta property="og:description">` in rendered `<head>`
  - [x] CMS page with `search_description` set → both tags render with content
  - [ ] Hard-coded template overriding `page_desc` (e.g. `firefox/features/fast/`) → meta description tag renders with the overridden content
  - [ ] `firefox/landing/win10-eos/` (explicit empty `{% block page_desc %}{% endblock %}`) → no tag rendered (improvement over current empty tag)
  - [x] `pytest springfield/cms/tests/` passes