### PR TITLE
Technical SEO - Add Vary: User-Agent to /download/ platform redirect

### DIFF
--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -505,7 +505,9 @@ def download_redirect(request):
     if qs:
         redirect_url = f"{redirect_url}?{qs}"
 
-    return HttpResponseRedirect(redirect_url)
+    response = HttpResponseRedirect(redirect_url)
+    response["Vary"] = "User-Agent"
+    return response
 
 
 class DownloadView(L10nTemplateView):


### PR DESCRIPTION
## Summary

The `/download/` endpoint redirects to `/download/{platform}/` based on the requesting client's `User-Agent`. This change adds `Vary: User-Agent` to that response so caches and crawlers correctly understand the endpoint as content-negotiated.
## Why

- `download_redirect()` reads `User-Agent` and picks a destination — without `Vary: User-Agent`, an intermediate cache could serve one user's resolved destination to another user with a different platform
- `@never_cache` already protects against compliant caches, but `Vary` is the correct semantic declaration and protects against misconfigured intermediaries that ignore `Cache-Control`
- Most important for SEO: Googlebot and AI search crawlers can correctly understand `/download/` as a content-negotiated endpoint rather than treating one observed destination as canonical

Part of the firefox.com technical SEO workstream (item A13 in the master plan; A13a was already correctly setting `Vary: Accept-Language` on the locale redirect).
## What changed
`springfield/firefox/views.py` — `download_redirect()` view. The platform-detection return path now builds the response, sets `Vary: User-Agent`, and returns.

The switch-off fallback path (line 490) is intentionally not modified — it returns a fixed homepage redirect regardless of User-Agent, so declaring variance there would be inaccurate.
## Test plan

- [ ] `curl -I https://www.firefox.com/en-US/download/` (after deploy) shows `Vary: User-Agent` in response headers
- [ ] Hit `/download/` locally with different `User-Agent` strings via curl — confirm correct platform redirect for each, and `Vary: User-Agent` present
- [ ] `pytest springfield/firefox/tests/` passes