### PR TITLE
Technical SEO - Canonicalize per-version system requirements pages to latest

### DIFF
--- a/springfield/releasenotes/views.py
+++ b/springfield/releasenotes/views.py
@@ -219,8 +219,20 @@ def release_notes(request, version, product="Firefox"):
 @require_safe
 def system_requirements(request, version, product="Firefox"):
     release = get_release_or_404(version, product)
-    dir = "firefox"
-    return l10n_utils.render(request, f"{dir}/releases/system_requirements.html", {"release": release, "version": version})
+
+    canonical_path = None
+    try:
+        latest = get_latest_release_or_404(release.product, release.channel)
+        if latest.version != release.version:
+            canonical_path = re.sub(r"^/[^/]+", "", latest.get_sysreq_url())
+    except Http404:
+        pass
+
+    context = {"release": release, "version": version}
+    if canonical_path:
+        context["canonical_path"] = canonical_path
+
+    return l10n_utils.render(request, "firefox/releases/system_requirements.html", context)
 
 
 def latest_release(product="firefox", platform=None, channel=None):


### PR DESCRIPTION
## Summary

Per-version `/firefox/{version}/system-requirements/` pages are near-duplicates of each other — system requirements barely change between Firefox versions. This change makes old per-version sysreqs pages set `rel=canonical` to the latest version's sysreqs page, consolidating ranking signal onto one URL instead of fragmenting it across hundreds of near-identical pages.

## Why

  - Per-version sysreqs pages are genuine near-duplicates (per-version requirements rarely differ)
  - Without canonical consolidation, link equity and ranking signal fragments across many versioned URLs
  - The current-version page stays self-canonical so Google has a clear "head" target
  - Self-correcting: when a new Firefox version ships, all old versions' canonical automatically updates via the existing product-details data feed — no manual maintenance

Part of the firefox.com technical SEO workstream

## What changed

`springfield/releasenotes/views.py` — `system_requirements()` view. The view now:
1. Looks up the latest release in the same product + channel as the requested version (using the existing `get_latest_release_or_404` helper that
already powers `latest_sysreq()`)
2. If the requested version isn't the latest, builds a canonical path pointing at the latest version's sysreqs URL (locale prefix stripped, since the
`canonical_path` context variable is locale-agnostic)
3. Passes that as `canonical_path` to override the default self-canonical behavior provided by `springfield/base/context_processors.py:canonical_path`
4. Falls back to self-canonical if the latest-release lookup fails (graceful degradation)

Release notes pages are intentionally untouched — they're version-distinct authoritative content, not near-duplicates. Confirmed self-canonical with no noindex; no changes needed there.

## Out of scope

`/firefox/system-requirements/` (the unversioned URL) remains a 302 redirect to the latest version's sysreqs page. The master plan originally framed canonicaling to this URL, but it's a redirect, not a 200 page — pointing canonical to a redirect is suboptimal. A future refactor of release notes / sys reqs may make this a real 200 page; if so, the canonical target can be updated to point there.

  ## Test plan

  - [ ] Visit `/firefox/{old_version}/system-requirements/` in dev → view source shows `<link rel="canonical"
  href=".../firefox/{latest_version}/system-requirements/">`
  - [ ] Visit `/firefox/{latest_version}/system-requirements/` → view source shows self-canonical (current behavior)
  - [ ] Same checks for `/firefox/android/{version}/system-requirements/` and `/firefox/ios/{version}/system-requirements/`
  - [ ] ESR version page (e.g. `/firefox/128.0esr/system-requirements/`) → canonical to latest ESR, not latest stable
  - [ ] `pytest springfield/releasenotes/tests/` passes
  - [ ] Direct user visits to old version URLs still render the correct per-version content (no client redirect)