### PR TITLE
Technical SEO - Add /sitemap.xml with hreflang annotations and Sitemap directive in r…

### DIFF
--- a/springfield/base/templates/base/robots.txt
+++ b/springfield/base/templates/base/robots.txt
@@ -3,4 +3,6 @@ user-agent: *
 disallow: /
 {% else -%}
 disallow: /*/etc/
+
+Sitemap: {{ settings.CANONICAL_URL }}/sitemap.xml
 {% endif -%}

--- a/springfield/base/tests/test_views.py
+++ b/springfield/base/tests/test_views.py
@@ -84,6 +84,22 @@ class TestRobots(TestCase):
         self.assertFalse(response.context_data["disallow_all"])
         self.assertEqual(response.get("Content-Type"), "text/plain")
 
+    @override_switch("ROBOTS_FORCE_DISALLOW_ALL", active=False)
+    def test_robots_production_emits_sitemap_directive(self):
+        """On production hostname, robots.txt advertises the sitemap."""
+        response = self.client.get("/robots.txt", headers={"host": "www.firefox.com"})
+        body = response.content.decode("utf-8")
+        self.assertIn("Sitemap: https://www.firefox.com/sitemap.xml", body)
+
+    @override_switch("ROBOTS_FORCE_DISALLOW_ALL", active=False)
+    def test_robots_non_production_omits_sitemap(self):
+        """On non-production hostnames, disallow_all is True; the response is
+        a blanket disallow with no Sitemap directive."""
+        response = self.client.get("/robots.txt", headers={"host": "www.springfield.moz.works"})
+        body = response.content.decode("utf-8")
+        self.assertIn("disallow: /", body)
+        self.assertNotIn("Sitemap:", body)
+
 
 class TestSecurityDotTxt(TestCase):
     def setUp(self):

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -491,8 +491,10 @@ if DEBUG:
 # Paths that can exist either with or without a locale code in the URL.
 # Matches the whole URL path
 SUPPORTED_LOCALE_IGNORE = [
-    "/all-urls-global.xml",  # in sitemap urls
-    "/all-urls.xml",  # in sitemap urls
+    "/all-urls-global.xml",  # in sitemap urls (legacy alias)
+    "/all-urls.xml",  # in sitemap urls (legacy alias)
+    "/sitemap-global.xml",  # in sitemap urls
+    "/sitemap.xml",  # in sitemap urls
 ]
 
 # Pages that we don't want to be indexed by search engines.

--- a/springfield/sitemaps/templates/sitemap.xml
+++ b/springfield/sitemaps/templates/sitemap.xml
@@ -3,6 +3,33 @@
 {%- for path in paths %}
   <url>
     <loc>{{ path.get_absolute_url() }}</loc>
+    {%- set path_locales = alternates.get(path.path, []) %}
+    {%- if path_locales|length > 1 %}
+    {%- for alt_locale in path_locales %}
+    <xhtml:link rel="alternate" hreflang="{{ alt_locale }}" href="{{ settings.CANONICAL_URL }}/{{ alt_locale }}{{ path.path }}"/>
+    {%- if alt_locale == 'pt-BR' %}
+    <xhtml:link rel="alternate" hreflang="pt" href="{{ settings.CANONICAL_URL }}/pt-BR{{ path.path }}"/>
+    {%- elif alt_locale == 'en-US' %}
+    <xhtml:link rel="alternate" hreflang="en" href="{{ settings.CANONICAL_URL }}/en-US{{ path.path }}"/>
+    {%- elif alt_locale == 'es-ES' %}
+    <xhtml:link rel="alternate" hreflang="es" href="{{ settings.CANONICAL_URL }}/es-ES{{ path.path }}"/>
+    {%- elif alt_locale == 'fy-NL' %}
+    <xhtml:link rel="alternate" hreflang="fy" href="{{ settings.CANONICAL_URL }}/fy-NL{{ path.path }}"/>
+    {%- elif alt_locale == 'gu-IN' %}
+    <xhtml:link rel="alternate" hreflang="gu" href="{{ settings.CANONICAL_URL }}/gu-IN{{ path.path }}"/>
+    {%- elif alt_locale == 'hi-IN' %}
+    <xhtml:link rel="alternate" hreflang="hi" href="{{ settings.CANONICAL_URL }}/hi-IN{{ path.path }}"/>
+    {%- elif alt_locale == 'hy-AM' %}
+    <xhtml:link rel="alternate" hreflang="hy" href="{{ settings.CANONICAL_URL }}/hy-AM{{ path.path }}"/>
+    {%- elif alt_locale == 'pa-IN' %}
+    <xhtml:link rel="alternate" hreflang="pa" href="{{ settings.CANONICAL_URL }}/pa-IN{{ path.path }}"/>
+    {%- elif alt_locale == 'sv-SE' %}
+    <xhtml:link rel="alternate" hreflang="sv" href="{{ settings.CANONICAL_URL }}/sv-SE{{ path.path }}"/>
+    {%- elif alt_locale == 'zh-CN' %}
+    <xhtml:link rel="alternate" hreflang="zh" href="{{ settings.CANONICAL_URL }}/zh-CN{{ path.path }}"/>
+    {%- endif %}
+    {%- endfor %}
+    {%- endif %}
   </url>
 {%- endfor %}
 </urlset>

--- a/springfield/sitemaps/templates/sitemap_index.xml
+++ b/springfield/sitemaps/templates/sitemap_index.xml
@@ -3,9 +3,9 @@
 {%- for locale in locales %}
   <sitemap>
     {% if locale == NO_LOCALE -%}
-      <loc>{{ settings.CANONICAL_URL }}/all-urls-global.xml</loc>
+      <loc>{{ settings.CANONICAL_URL }}/sitemap-global.xml</loc>
     {%- else -%}
-      <loc>{{ settings.CANONICAL_URL }}/{{ locale }}/all-urls.xml</loc>
+      <loc>{{ settings.CANONICAL_URL }}/{{ locale }}/sitemap.xml</loc>
     {%- endif %}
   </sitemap>
 {%- endfor %}

--- a/springfield/sitemaps/tests/test_views.py
+++ b/springfield/sitemaps/tests/test_views.py
@@ -4,6 +4,8 @@
 
 from textwrap import dedent
 
+from wagtail.models import Locale
+
 from springfield.base.tests import TestCase
 from springfield.sitemaps.models import NO_LOCALE, SitemapURL
 
@@ -32,17 +34,20 @@ class TestSitemapView(TestCase):
             <?xml version="1.0" encoding="UTF-8"?>
             <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
               <sitemap>
-                <loc>https://www.firefox.com/all-urls-global.xml</loc>
+                <loc>https://www.firefox.com/sitemap-global.xml</loc>
               </sitemap>
               <sitemap>
-                <loc>https://www.firefox.com/de/all-urls.xml</loc>
+                <loc>https://www.firefox.com/de/sitemap.xml</loc>
               </sitemap>
               <sitemap>
-                <loc>https://www.firefox.com/fr/all-urls.xml</loc>
+                <loc>https://www.firefox.com/fr/sitemap.xml</loc>
               </sitemap>
             </sitemapindex>"""
         )
+        # Both alias and canonical paths return the index when unprefixed.
         resp = self.client.get("/all-urls.xml")
+        assert resp.text == good_resp
+        resp = self.client.get("/sitemap.xml")
         assert resp.text == good_resp
 
     def test_none(self):
@@ -58,11 +63,16 @@ class TestSitemapView(TestCase):
               </url>
             </urlset>"""
         )
+        # NO_LOCALE entries never emit hreflang annotations.
         resp = self.client.get("/all-urls-global.xml")
+        assert resp.text == good_resp
+        resp = self.client.get("/sitemap-global.xml")
         assert resp.text == good_resp
 
     def test_locales(self):
-        good_resp = dedent(
+        # No Wagtail Locale records configured here, so de/fr are treated as
+        # legacy locales and emit no <xhtml:link> hreflang annotations.
+        good_resp_de = dedent(
             """\
             <?xml version="1.0" encoding="UTF-8"?>
             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
@@ -75,9 +85,11 @@ class TestSitemapView(TestCase):
             </urlset>"""
         )
         resp = self.client.get("/de/all-urls.xml")
-        assert resp.text == good_resp
+        assert resp.text == good_resp_de
+        resp = self.client.get("/de/sitemap.xml")
+        assert resp.text == good_resp_de
 
-        good_resp = dedent(
+        good_resp_fr = dedent(
             """\
             <?xml version="1.0" encoding="UTF-8"?>
             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
@@ -90,8 +102,119 @@ class TestSitemapView(TestCase):
             </urlset>"""
         )
         resp = self.client.get("/fr/all-urls.xml")
-        assert resp.text == good_resp
+        assert resp.text == good_resp_fr
+        resp = self.client.get("/fr/sitemap.xml")
+        assert resp.text == good_resp_fr
 
     def test_post(self):
         resp = self.client.post("/en-US/all-urls.xml")
         assert resp.status_code == 405
+        resp = self.client.post("/en-US/sitemap.xml")
+        assert resp.status_code == 405
+
+
+class TestSitemapHreflang(TestCase):
+    """Tests for hreflang alternate emission, filtered by Wagtail's supported
+    locale set (Locale.objects).
+    """
+
+    def setUp(self):
+        # Configure Wagtail Locales — this is the "supported" set. de, fr, en-US,
+        # pt-BR, and pt-PT are supported. ach is intentionally NOT in Wagtail
+        # Locales — it's treated as a legacy locale.
+        for code in ["en-US", "de", "fr", "pt-BR", "pt-PT"]:
+            Locale.objects.get_or_create(language_code=code)
+
+        data = [
+            # Multi-locale path with both supported and legacy locales.
+            {"path": "/features/", "locale": "en-US"},
+            {"path": "/features/", "locale": "fr"},
+            {"path": "/features/", "locale": "de"},
+            {"path": "/features/", "locale": "ach"},  # legacy
+            # Path that exists in pt-BR + pt-PT + en-US (tests bare-language
+            # and pt-PT-as-promoted-alias conventions).
+            {"path": "/about/", "locale": "en-US"},
+            {"path": "/about/", "locale": "pt-BR"},
+            {"path": "/about/", "locale": "pt-PT"},
+            # Single-locale path: only one locale → no alternates emitted.
+            {"path": "/only-en/", "locale": "en-US"},
+            # Legacy-only path: only ach has it → since ach not in supported,
+            # ach sitemap will list it but with no alternates.
+            {"path": "/legacy-only/", "locale": "ach"},
+        ]
+        SitemapURL.objects.bulk_create(SitemapURL(**kw) for kw in data)
+
+    def test_supported_locale_emits_alternates(self):
+        """A page in a supported locale that exists in multiple supported
+        locales declares all of them as hreflang alternates."""
+        resp = self.client.get("/en-US/sitemap.xml")
+        body = resp.text
+        # /features/ has en-US, fr, de in supported (plus ach which is legacy
+        # and should be filtered out).
+        assert "<loc>https://www.firefox.com/en-US/features/</loc>" in body
+        assert '<xhtml:link rel="alternate" hreflang="en-US" href="https://www.firefox.com/en-US/features/"/>' in body
+        assert '<xhtml:link rel="alternate" hreflang="fr" href="https://www.firefox.com/fr/features/"/>' in body
+        assert '<xhtml:link rel="alternate" hreflang="de" href="https://www.firefox.com/de/features/"/>' in body
+        # Legacy locale (ach) must NOT appear as an alternate.
+        assert 'hreflang="ach"' not in body
+        assert "/ach/features/" not in body
+
+    def test_en_us_emits_bare_language_alternate(self):
+        """en-US emits both hreflang="en" and hreflang="en-US"."""
+        resp = self.client.get("/en-US/sitemap.xml")
+        body = resp.text
+        assert '<xhtml:link rel="alternate" hreflang="en-US" href="https://www.firefox.com/en-US/features/"/>' in body
+        assert '<xhtml:link rel="alternate" hreflang="en" href="https://www.firefox.com/en-US/features/"/>' in body
+
+    def test_pt_br_emits_bare_language_alternate(self):
+        """pt-BR emits both hreflang="pt" and hreflang="pt-BR" (primary
+        Portuguese), mirroring canonical-url.html convention."""
+        resp = self.client.get("/pt-BR/sitemap.xml")
+        body = resp.text
+        assert '<xhtml:link rel="alternate" hreflang="pt-BR" href="https://www.firefox.com/pt-BR/about/"/>' in body
+        assert '<xhtml:link rel="alternate" hreflang="pt" href="https://www.firefox.com/pt-BR/about/"/>' in body
+
+    def test_pt_pt_does_not_emit_bare_pt(self):
+        """pt-PT emits only hreflang="pt-PT"; the bare hreflang="pt" belongs
+        to pt-BR exclusively (alias convention)."""
+        resp = self.client.get("/pt-PT/sitemap.xml")
+        body = resp.text
+        # The pt-PT URL itself is declared.
+        assert '<xhtml:link rel="alternate" hreflang="pt-PT" href="https://www.firefox.com/pt-PT/about/"/>' in body
+        # But the bare "pt" should only ever point to pt-BR, not pt-PT.
+        assert 'hreflang="pt" href="https://www.firefox.com/pt-PT/' not in body
+
+    def test_single_locale_url_emits_no_xhtml_link(self):
+        """A URL that exists in only one locale should not emit any
+        <xhtml:link> alternates (W3C: hreflang requires >=2 alternates to be
+        meaningful)."""
+        resp = self.client.get("/en-US/sitemap.xml")
+        body = resp.text
+        # /only-en/ has only en-US — no hreflang block expected for it.
+        # We check that the URL block contains <loc> but no <xhtml:link>.
+        assert "<loc>https://www.firefox.com/en-US/only-en/</loc>" in body
+        # The xhtml:link line right after this loc shouldn't exist for /only-en/.
+        # We assert there is no xhtml:link href to /only-en/ anywhere.
+        assert '/only-en/"/>' not in body
+
+    def test_legacy_locale_emits_no_hreflang(self):
+        """A page in a legacy locale (not in Wagtail Locale.objects) is still
+        listed in its per-locale sitemap, but emits no <xhtml:link> alternates
+        — treats legacy URLs as standalone, not alternates of supported pages."""
+        resp = self.client.get("/ach/sitemap.xml")
+        body = resp.text
+        # The URLs are still there (crawl coverage preserved).
+        assert "<loc>https://www.firefox.com/ach/features/</loc>" in body
+        assert "<loc>https://www.firefox.com/ach/legacy-only/</loc>" in body
+        # But no hreflang annotations at all.
+        assert "<xhtml:link" not in body
+
+    def test_supported_pages_do_not_declare_legacy_as_alternate(self):
+        """Supported-locale pages must not declare legacy locales as
+        alternates, even when the legacy locale has the same URL path."""
+        # /features/ exists in en-US (supported) and ach (legacy). The en-US
+        # sitemap must not declare ach as an alternate.
+        resp = self.client.get("/en-US/sitemap.xml")
+        body = resp.text
+        assert "/ach/" not in body
+        assert 'hreflang="ach"' not in body

--- a/springfield/sitemaps/urls.py
+++ b/springfield/sitemaps/urls.py
@@ -6,4 +6,9 @@ from django.urls import re_path
 
 from springfield.sitemaps.views import SitemapView
 
-urlpatterns = (re_path(r"all-urls(?P<is_global>-global)?.xml", SitemapView.as_view()),)
+urlpatterns = (
+    # Backward-compatible alias: Google has indexed /all-urls.xml; keep working.
+    re_path(r"all-urls(?P<is_global>-global)?.xml", SitemapView.as_view()),
+    # Canonical sitemap path; referenced from robots.txt and sitemap_index.xml.
+    re_path(r"sitemap(?P<is_global>-global)?.xml", SitemapView.as_view()),
+)

--- a/springfield/sitemaps/views.py
+++ b/springfield/sitemaps/views.py
@@ -2,8 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from collections import defaultdict
+
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
+
+from wagtail.models import Locale
 
 from lib.l10n_utils import RequireSafeMixin
 from springfield.base.decorators import cache_control_expires
@@ -36,11 +40,43 @@ class SitemapView(RequireSafeMixin, TemplateView):
         else:
             return ["sitemap_index.xml"]
 
+    def _get_supported_locales(self):
+        """Return the set of language codes Mozilla actively supports.
+
+        Source of truth: Wagtail's Locale model, managed via the Wagtail admin
+        under Settings > Languages. As Mozilla adds/removes paid-translation
+        locales there, this set stays in sync without code changes.
+        """
+        return set(Locale.objects.values_list("language_code", flat=True))
+
+    def _build_alternates(self, locale, supported_locales):
+        """Build the {path: [locale_list]} hreflang alternates map.
+
+        Returns an empty dict for:
+        - NO_LOCALE (global URLs have no language alternates)
+        - Locales not in the supported set (legacy locales emit no hreflang
+          annotations, since their content has drifted from the supported
+          translations and declaring them as alternates would misuse hreflang)
+
+        Otherwise returns the alternates grouped from SitemapURL rows, filtered
+        to supported locales only.
+        """
+        if locale == NO_LOCALE or locale not in supported_locales:
+            return {}
+
+        alternates = defaultdict(list)
+        for row in SitemapURL.objects.exclude(locale=NO_LOCALE).values("path", "locale"):
+            if row["locale"] in supported_locales:
+                alternates[row["path"]].append(row["locale"])
+        return dict(alternates)
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         locale = self._get_locale()
         if locale:
             ctx["paths"] = SitemapURL.objects.all_for_locale(locale)
+            supported_locales = self._get_supported_locales()
+            ctx["alternates"] = self._build_alternates(locale, supported_locales)
         else:
             ctx["locales"] = SitemapURL.objects.all_locales()
             ctx["NO_LOCALE"] = NO_LOCALE

--- a/springfield/sitemaps/views.py
+++ b/springfield/sitemaps/views.py
@@ -65,9 +65,9 @@ class SitemapView(RequireSafeMixin, TemplateView):
             return {}
 
         alternates = defaultdict(list)
-        for row in SitemapURL.objects.exclude(locale=NO_LOCALE).values("path", "locale"):
-            if row["locale"] in supported_locales:
-                alternates[row["path"]].append(row["locale"])
+        rows = SitemapURL.objects.filter(locale__in=supported_locales).order_by("path", "locale").values("path", "locale")
+        for row in rows:
+            alternates[row["path"]].append(row["locale"])
         return dict(alternates)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Summary

Improves Mozilla's SEO signal to Google by adding:

1. **`/sitemap.xml`** as the canonical sitemap URL (alongside the existing `/all-urls.xml` which stays working as an alias).
2. **Hreflang annotations** (`<xhtml:link rel="alternate">`) per URL entry, filtered to the supported-locale set sourced from Wagtail's `Locale` model.
3. **`Sitemap:` directive** in robots.txt pointing to the new canonical URL.

Old `/all-urls.xml` had zero hreflang annotations — Google had no machine-readable signal at the sitemap level about which URLs are translations of each other. This change provides that signal explicitly.

Part of the firefox.com technical SEO workstream (item A4 in the master plan). A14b (explicit AI crawler welcome in robots.txt) was scoped in but dropped from this PR — the optics of an explicit named-bot welcome don't justify the zero functional change (AI bots already crawl under `user-agent: *`).

## Why hreflang in the sitemap matters

Today's `canonical-url.html` emits hreflang annotations in the HTML `<head>` of each page. The sitemap, however, was a flat list of URLs with no language relationships declared. Google reads both signals; adding hreflang to the sitemap reinforces the in-page signal and is the convention Google recommends for multi-locale sites.

## The supported-locale filter

Firefox.com has started to use smartling for translations. (~15 supported locales). There are ~88 locales that still have indexed content but it has drifted from the supported content — declaring them as hreflang alternates of supported URLs would misuse hreflang (which is meant for equivalent translations, not drifted ones).

The filter uses **Wagtail's `Locale` model** (`Locale.objects.values_list('language_code', flat=True)`) as the source of truth — the same set Mozilla manages via the Wagtail admin's Settings > Languages page. When Mozilla adds/removes a supported locale via the admin, the sitemap filter updates automatically with no code change.

**Verify before merge:** `Locale.objects.count()` returns the expected ~15 supported locales. If it includes surprise extras, the filter signal would be wrong.

**Legacy-locale behavior:** legacy URLs still appear in their per-locale sitemap for crawl coverage, but emit no `<xhtml:link>` annotations. They become standalone in Google's view — exactly what Mozilla wants given the content drift.

## What changed

**`springfield/sitemaps/urls.py`** — new `sitemap(-global)?.xml` route alongside existing `all-urls(-global)?.xml` (kept as backward-compat alias since Google has indexed it).

**`springfield/sitemaps/views.py`** — `SitemapView` now builds an `alternates` context dict via two new helpers: `_get_supported_locales()` (queries Wagtail Locale.objects) and `_build_alternates()` (groups SitemapURL rows by path, filters to supported locales). NO_LOCALE sitemap and legacy-locale sitemaps both get an empty alternates dict → template emits no `<xhtml:link>` for them.

**`springfield/sitemaps/templates/sitemap.xml`** — adds `<xhtml:link rel="alternate" hreflang="..." href="..."/>` per URL when 2+ supported locales exist for that path. Bare-language conventions (pt-BR → `pt` + `pt-BR`, en-US → `en` + `en-US`, etc.) mirror `canonical-url.html` exactly. pt-PT correctly emits only `pt-PT` (not bare `pt`).

**`springfield/sitemaps/templates/sitemap_index.xml`** — index now emits `/sitemap-global.xml` and `/{locale}/sitemap.xml` URLs.

**`springfield/base/templates/base/robots.txt`** — adds `Sitemap: https://www.firefox.com/sitemap.xml` directive, wrapped in the existing `{% if not disallow_all %}` so non-prod hosts skip it.

**`springfield/settings/base.py`** — adds `/sitemap.xml` and `/sitemap-global.xml` to `SUPPORTED_LOCALE_IGNORE` so the locale middleware doesn't redirect them.

## Tests

`springfield/sitemaps/tests/test_views.py`:
- Updated 4 existing tests (`test_index`, `test_none`, `test_locales`, `test_post`) to cover both legacy and new URLs
- Added 7 new tests covering supported-locale hreflang emission, bare-language conventions for en-US and pt-BR, pt-PT's no-bare-pt convention, single-locale-URL edge case, legacy-locale skip, and the filter excluding legacy from supported-page alternates

`springfield/base/tests/test_views.py`:
- Added `test_robots_production_emits_sitemap_directive` and `test_robots_non_production_omits_sitemap`

**24/24 sitemap tests pass. 7/7 robots tests pass. No regressions in broader `springfield/base/tests/` or `lib/l10n_utils/tests/`.**

## Manual verification after deploy to stage

- `curl https://stage.../sitemap.xml` → 200, sitemap index XML
- `curl https://stage.../en-US/sitemap.xml` → 200, contains `<xhtml:link>` alternates with bare-language conventions (e.g., both `hreflang="en"` and `hreflang="en-US"`)
- `curl https://stage.../robots.txt` → contains `Sitemap: https://www.firefox.com/sitemap.xml`
- `curl https://stage.../{legacy-locale}/sitemap.xml` → 200, URLs listed but no `<xhtml:link>` annotations
- `curl https://stage.../all-urls.xml` → still 200 (backward-compat alias)
- Paste rendered sitemap into Google Search Console Sitemaps validator → no errors

## Follow-ups to file

1. **Extend supported-locale filter to canonical-url.html** (in-page hreflang). Same `Locale.objects`-based approach. Currently in-page hreflang declares all locales where content exists, including drifted legacy content — same misuse as sitemap had before this PR. Mechanism is the same; just needs the template change.
2. **Resubmit `/sitemap.xml` in Google Search Console** post-deploy so Google adopts the new canonical entry point faster (vs. relying on continued use of `/all-urls.xml`).
3. **Monitor Search Console's hreflang validation** for 2–4 weeks post-deploy. Expect transient warnings as Google reindexes; should clear naturally.

## Known transition costs

- Search Console may show transient hreflang warnings during the 2–4 week reindex window (old/new signals coexist). Will clear.
- Slight short-term ranking volatility on legacy-locale URLs as they lose alternate-cluster signal — aligns with strategic direction (legacy slated for sunset).
- Sitemap-vs-in-page inconsistency until follow-up #1 ships: sitemap declares ~15 alternates, in-page hreflang declares ~100. Google reads both. File the follow-up explicitly to avoid drift.