### PR TITLE
Skip inactive refactor tests

### DIFF
--- a/tests/playwright/specs/download-attribution/create.spec.js
+++ b/tests/playwright/specs/download-attribution/create.spec.js
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe('analytics download attribution', () => {
+test.describe.skip('analytics download attribution', () => {
     test('has expected cookie values', async ({ page, browserName }) => {
         await page.addInitScript(mockGetGtagClientID);
 
@@ -379,7 +379,7 @@ test.describe('analytics download attribution', () => {
     );
 });
 
-test.describe('essential download attribution', () => {
+test.describe.skip('essential download attribution', () => {
     const url = '/en-US/?geo=us';
 
     test('has expected cookie values', async ({ page, browserName }) => {
@@ -539,7 +539,7 @@ test.describe('essential download attribution', () => {
     );
 });
 
-test.describe('essential and analytics download attribution', () => {
+test.describe.skip('essential and analytics download attribution', () => {
     const url =
         '/en-US/?geo=us&utm_source=newsletter&utm_campaign=test&utm_medium=email';
 

--- a/tests/playwright/specs/download-attribution/download-links.spec.js
+++ b/tests/playwright/specs/download-attribution/download-links.spec.js
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe('attribution cookies exist', () => {
+test.describe.skip('attribution cookies exist', () => {
     test('add to links', async ({ page, browserName }) => {
         await page.addInitScript(mockGetGtagClientID);
 
@@ -58,7 +58,7 @@ test.describe('attribution cookies exist', () => {
     });
 });
 
-test.describe('attribution cookies do not exist', () => {
+test.describe.skip('attribution cookies do not exist', () => {
     test('download links unchanged', async ({ page, browserName }) => {
         await page.addInitScript(mockGetGtagClientID);
 

--- a/tests/playwright/specs/download-attribution/remove.spec.js
+++ b/tests/playwright/specs/download-attribution/remove.spec.js
@@ -20,7 +20,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe('analytics download attribution', () => {
+test.describe.skip('analytics download attribution', () => {
     test.describe(
         'user action denies consent',
         {
@@ -155,7 +155,7 @@ test.describe('analytics download attribution', () => {
     );
 });
 
-test.describe('essential download attribution', () => {
+test.describe.skip('essential download attribution', () => {
     test.describe('new page with no essential data', () => {
         test('cookie removed', async ({ page, browserName }) => {
             const capture = { params: null };

--- a/tests/playwright/specs/download-attribution/update.spec.js
+++ b/tests/playwright/specs/download-attribution/update.spec.js
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe('analytics download attribution', () => {
+test.describe.skip('analytics download attribution', () => {
     test.describe(
         'essential data added',
         {
@@ -211,7 +211,7 @@ test.describe('analytics download attribution', () => {
     );
 });
 
-test.describe('essential download attribution', () => {
+test.describe.skip('essential download attribution', () => {
     test.describe(
         'analytics data added',
         {
@@ -383,7 +383,7 @@ test.describe('essential download attribution', () => {
     );
 });
 
-test.describe('conflict management', () => {
+test.describe.skip('conflict management', () => {
     const url =
         '/en-US/?geo=us&utm_source=newsletter&utm_campaign=test&utm_medium=email';
 


### PR DESCRIPTION
These are helpful for local development, but slowing down the integration tests CI too much in production. The switch remains OFF for production, so there is no harm in skipping these tests for now.

We'll need to reduce tests to maintain a reasonable playwright runtime in CI

## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
confirm tests are skipped locally: https://mozmeao.github.io/platform-docs/testing/playwright/?h=playw#installing-playwright