### PR TITLE
Update psycopg[c] to 3.3.4

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1452,12 +1452,12 @@ protobuf==7.34.1 \
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-psycopg[c]==3.2.6 \
-    --hash=sha256:16fa094efa2698f260f2af74f3710f781e4a6f226efe9d1fd0c37f384639ed8a \
-    --hash=sha256:f3ff5488525890abb0566c429146add66b329e20d6d4835662b920cbbf90ac58
+psycopg[c]==3.3.4 \
+    --hash=sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a \
+    --hash=sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc
     # via -r requirements/prod.txt
-psycopg-c==3.2.6 \
-    --hash=sha256:b5fd4ce70f82766a122ca5076a36c4d5818eaa9df9bf76870bc83a064ffaed3a
+psycopg-c==3.3.4 \
+    --hash=sha256:ed8106128b2d04359c185fc9641b4409abfce4d0b6fb1d1ff6800646e27f1a22
     # via
     #   -r requirements/prod.txt
     #   psycopg

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -36,7 +36,7 @@ Markdown==3.10.2
 markus[datadog]==5.0.0
 mozilla-django-oidc==5.0.2
 Pillow==12.2.0
-psycopg[c]==3.2.6  # use version with psycopg_c support - also needs libpq-dev in the Docker image;     may need it for local dev, too
+psycopg[c]==3.3.4  # use version with psycopg_c support - also needs libpq-dev in the Docker image;     may need it for local dev, too
 py-svg-hush==0.3.0
 PyGithub==2.9.1
 PyYAML==6.0.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1190,12 +1190,12 @@ protobuf==7.34.1 \
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-psycopg[c]==3.2.6 \
-    --hash=sha256:16fa094efa2698f260f2af74f3710f781e4a6f226efe9d1fd0c37f384639ed8a \
-    --hash=sha256:f3ff5488525890abb0566c429146add66b329e20d6d4835662b920cbbf90ac58
+psycopg[c]==3.3.4 \
+    --hash=sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a \
+    --hash=sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc
     # via -r requirements/prod.in
-psycopg-c==3.2.6 \
-    --hash=sha256:b5fd4ce70f82766a122ca5076a36c4d5818eaa9df9bf76870bc83a064ffaed3a
+psycopg-c==3.3.4 \
+    --hash=sha256:ed8106128b2d04359c185fc9641b4409abfce4d0b6fb1d1ff6800646e27f1a22
     # via psycopg
 py-svg-hush==0.3.0 \
     --hash=sha256:0331e35cefa186d9ed7ecfccbe4818a0e4a1a6ff85577ddc6a67ceecb5d57c8b \


### PR DESCRIPTION
## One-line summary

This resolves [a compilation error when using PostgreSQL >= 18](https://redirect.github.com/psycopg/psycopg/issues/1082), which is the default when install on macOS for local dev.

## Significant changes and points to review

I’m not a Python developer, so I’m not sure if I updated the dependency correctly. I also just updated to the latest version which I hope is fine.

## Issue / Bugzilla link

Related issue + my comment: https://github.com/mozmeao/platform-docs/issues/33#issuecomment-4558116280

Other related issue: https://github.com/mozilla/bedrock/issues/14805

## Testing

With a fresh clone + virtual env check that `make install-local-python-deps` works without errors.
