### PR TITLE
Restrict `cms/*` Fluent files in Pontoon to locales overlapping with CMS languages

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -111,6 +111,25 @@ locales = [
 [[paths]]
     reference = "en/cms/*.ftl"
     l10n = "{locale}/cms/*.ftl"
+    # subset to locales set up in CMS
+    locales = [
+        "de",
+        "en-CA",
+        "en-GB",
+        "es-ES",
+        "es-MX",
+        "fr",
+        "id",
+        "it",
+        "ja",
+        "nl",
+        "pl",
+        "pt-BR",
+        "pt-PT",
+        "ru",
+        "tr",
+        "zh-CN",
+    ]
 [[paths]]
     reference = "en/banners/**/*.ftl"
     l10n = "{locale}/banners/**/*.ftl"

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -125,7 +125,6 @@ locales = [
         "nl",
         "pl",
         "pt-BR",
-        "pt-PT",
         "ru",
         "tr",
         "zh-CN",


### PR DESCRIPTION
## One-line summary

Limits which Pontoon locales will get CMS–specific Fluent files exposed.
(See https://mozmeao.github.io/platform-docs/l10n/configuration/#pipeline-configuration for deets)

## Significant changes and points to review

Might need maintaining over time to be in sync with languages added or removed in CMS.

Updates only Pontoon config to limit to the few that will get used. Smartling languages can't be limited, so these jobs will always trigger e.g. ar, ms or hi-IN that will end up unused.

## Issue / Bugzilla link

https://github.com/mozilla-l10n/www-firefox-l10n/pull/133#issuecomment-4563066282

## Testing