### PR TITLE
Move playwright component testing out of the integration tests umbrella

### DIFF
--- a/tests/playwright/playwright.config.js
+++ b/tests/playwright/playwright.config.js
@@ -27,8 +27,8 @@ module.exports = defineConfig({
     /* Global setup file to prepare the environment for the test run. */
     globalSetup: require.resolve('./global-setup'),
     testDir: './specs',
-    /* Exclude visual regression tests — those run with the playwright.visual-regression.config.js config */
-    grepInvert: /@visual-regression/,
+    /* Exclude visual regression and component tests — those run with the playwright.visual-regression.config.js config */
+    grepInvert: /@visual-regression|@flare26-components/,
     /* Run tests in files in parallel */
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/playwright/playwright.visual-regression.config.js
+++ b/tests/playwright/playwright.visual-regression.config.js
@@ -13,7 +13,7 @@ module.exports = defineConfig({
     ...baseConfig,
     fullyParallel: false,
     grepInvert: undefined,
-    grep: /@visual-regression/,
+    grep: /@visual-regression|@flare26-components/,
     workers: 1,
     projects: [baseConfig.projects.find((p) => p.name === 'chromium')]
 });


### PR DESCRIPTION
## One-line summary

Previously, component testing with Playwright were in the integration tests umbrella, when they rely on the pattern library. This PR moves them temporarily to the visual regression tests umbrella, which has the pattern library enabled by default.

## Testing

Run both test suites and verify that the tests tagged as `@flare26-components` are not running together with the integration tests.