### PR TITLE
fix: ensure paths that need trailing slashes redirect with a 301 not a 302

### DIFF
--- a/springfield/cms/middleware.py
+++ b/springfield/cms/middleware.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from http import HTTPStatus
 
 from django.conf import settings
-from django.http import HttpResponseRedirect
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.utils.translation.trans_real import parse_accept_lang_header
 
 from wagtail.models import Page, Site
@@ -96,7 +96,8 @@ class CMSLocaleFallbackMiddleware:
                 ranked_locales.append(settings.LANGUAGE_CODE)
 
             _url_path = sub_path.lstrip("/")
-            if not _url_path.endswith("/"):
+            append_slash_needed = settings.APPEND_SLASH and not _url_path.endswith("/")
+            if append_slash_needed:
                 _url_path += "/"
 
             # Now try to get hold of all the pages that exist in the CMS for the extracted path
@@ -143,6 +144,10 @@ class CMSLocaleFallbackMiddleware:
                         if len(page_list) > 1:
                             logger.warning(f"CMS 404-fallback problem - multiple pages with same path found: {page_list}")
                         page = page_list[0]  # page_list should be a list of 1 item
+                        # Pure trailing-slash canonicalisation within the same locale → 301.
+                        # Cross-locale fallbacks remain 302 (Accept-Language dependent).
+                        if append_slash_needed and locale_code == lang_prefix:
+                            return HttpResponsePermanentRedirect(page.url)
                         return HttpResponseRedirect(page.url)
 
                 # Note: we can make this more efficient by leveraging the cached page tree

--- a/springfield/cms/middleware.py
+++ b/springfield/cms/middleware.py
@@ -96,8 +96,8 @@ class CMSLocaleFallbackMiddleware:
                 ranked_locales.append(settings.LANGUAGE_CODE)
 
             _url_path = sub_path.lstrip("/")
-            append_slash_needed = settings.APPEND_SLASH and not _url_path.endswith("/")
-            if append_slash_needed:
+            append_slash_needed = settings.APPEND_SLASH and not request.path.endswith("/")
+            if append_slash_needed and _url_path:
                 _url_path += "/"
 
             # Now try to get hold of all the pages that exist in the CMS for the extracted path
@@ -144,11 +144,14 @@ class CMSLocaleFallbackMiddleware:
                         if len(page_list) > 1:
                             logger.warning(f"CMS 404-fallback problem - multiple pages with same path found: {page_list}")
                         page = page_list[0]  # page_list should be a list of 1 item
+                        target = page.url
+                        if query_string := request.META.get("QUERY_STRING"):
+                            target = f"{target}?{query_string}"
                         # Pure trailing-slash canonicalisation within the same locale → 301.
                         # Cross-locale fallbacks remain 302 (Accept-Language dependent).
                         if append_slash_needed and locale_code == lang_prefix:
-                            return HttpResponsePermanentRedirect(page.url)
-                        return HttpResponseRedirect(page.url)
+                            return HttpResponsePermanentRedirect(target)
+                        return HttpResponseRedirect(target)
 
                 # Note: we can make this more efficient by leveraging the cached page tree
                 # (once the work to pre-cache the page tree lands)

--- a/springfield/cms/tests/test_middleware.py
+++ b/springfield/cms/tests/test_middleware.py
@@ -90,13 +90,12 @@ def test_CMSLocaleFallbackMiddleware_en_US_is_selected_as_fallback_locale(
     assert response.headers["Location"] == "/en-US/test-page/child-page/"
 
 
-def test_CMSLocaleFallbackMiddleware_url_path_without_trailing_slash(
+def test_CMSLocaleFallbackMiddleware_url_path_without_trailing_slash__cross_locale(
     rf,
     tiny_localized_site,
 ):
-    # Unlikely that this code path will get triggered in reality, but worth
-    # testing just in case
-
+    # Cross-locale fallback combined with trailing-slash canonicalisation stays 302,
+    # because the destination depends on Accept-Language.
     # tiny_localized_site supports en-US, fr and pt-BR, but not de
     request = rf.get(
         "/sv/test-page/child-page",
@@ -106,6 +105,21 @@ def test_CMSLocaleFallbackMiddleware_url_path_without_trailing_slash(
     response = middleware(request)
     assert response.status_code == 302
     assert response.headers["Location"] == "/fr/test-page/child-page/"
+
+
+def test_CMSLocaleFallbackMiddleware_url_path_without_trailing_slash__same_locale(
+    rf,
+    tiny_localized_site,
+):
+    # Same-locale trailing-slash canonicalisation is permanent (301), not 302.
+    request = rf.get(
+        "/en-US/test-page/child-page",
+        HTTP_ACCEPT_LANGUAGE="en-US",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 301
+    assert response.headers["Location"] == "/en-US/test-page/child-page/"
 
 
 def test_CMSLocaleFallbackMiddleware_404_when_no_page_exists_in_any_locale(

--- a/springfield/cms/tests/test_middleware.py
+++ b/springfield/cms/tests/test_middleware.py
@@ -122,6 +122,54 @@ def test_CMSLocaleFallbackMiddleware_url_path_without_trailing_slash__same_local
     assert response.headers["Location"] == "/en-US/test-page/child-page/"
 
 
+def test_CMSLocaleFallbackMiddleware_query_string_preserved__same_locale_301(
+    rf,
+    tiny_localized_site,
+):
+    # Query strings must survive the redirect — matches Django CommonMiddleware
+    # APPEND_SLASH semantics. Critical for the 301 path so tracking/UTM params
+    # don't get permanently cached out of existence.
+    request = rf.get(
+        "/en-US/test-page/child-page?utm_source=test&foo=bar",
+        HTTP_ACCEPT_LANGUAGE="en-US",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 301
+    assert response.headers["Location"] == "/en-US/test-page/child-page/?utm_source=test&foo=bar"
+
+
+def test_CMSLocaleFallbackMiddleware_query_string_preserved__cross_locale_302(
+    rf,
+    tiny_localized_site,
+):
+    request = rf.get(
+        "/sv/test-page/child-page/?utm_source=test",
+        HTTP_ACCEPT_LANGUAGE="fr",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/fr/test-page/child-page/?utm_source=test"
+
+
+def test_CMSLocaleFallbackMiddleware_locale_root_without_trailing_slash(
+    rf,
+    tiny_localized_site,
+):
+    # Edge case: /en-US (no slash, no sub-path) must not produce a `/home//`
+    # lookup pattern. Should 301 to the locale root, same as any other
+    # same-locale slash canonicalisation.
+    request = rf.get(
+        "/en-US",
+        HTTP_ACCEPT_LANGUAGE="en-US",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 301
+    assert response.headers["Location"] == "/en-US/"
+
+
 def test_CMSLocaleFallbackMiddleware_404_when_no_page_exists_in_any_locale(
     rf,
     tiny_localized_site,

--- a/springfield/cms/tests/test_middleware.py
+++ b/springfield/cms/tests/test_middleware.py
@@ -153,6 +153,22 @@ def test_CMSLocaleFallbackMiddleware_query_string_preserved__cross_locale_302(
     assert response.headers["Location"] == "/fr/test-page/child-page/?utm_source=test"
 
 
+@override_settings(APPEND_SLASH=False)
+def test_CMSLocaleFallbackMiddleware_no_redirect_when_APPEND_SLASH_disabled(
+    rf,
+    tiny_localized_site,
+):
+    # Regression: with APPEND_SLASH=False the middleware must not invent
+    # a trailing-slash redirect. The slash-less request stays a 404.
+    request = rf.get(
+        "/en-US/test-page/child-page",
+        HTTP_ACCEPT_LANGUAGE="en-US",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 404
+
+
 def test_CMSLocaleFallbackMiddleware_locale_root_without_trailing_slash(
     rf,
     tiny_localized_site,


### PR DESCRIPTION
This changeset ensures we use a HTTP 301 for same-locale trailing-slash canonicalisation in the CMS locale-fallback middleware.

CMSLocaleFallbackMiddleware intercepted 404s for slash-less locale-prefixed URLs (e.g. /en-US/features) and redirected them to the slashed canonical URL via HttpResponseRedirect (302), but this meant Django's CommonMiddleware APPEND_SLASH (which normally does a 301) didn't get to fire.

The fix is to track whether a slash was actually appended (also now respecting settings.APPEND_SLASH), and when the eventual page lives in the originally-requested locale, issue HttpResponsePermanentRedirect (301) instead. All other fallback paths keep their existing 302 semantics.


## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1225

## Testing

Prereqs: dev env running at http://localhost:8000 with at least one published CMS page (/en-US/features/ works in our local fixture). Use curl -sI to inspect status & Location per hop, or curl -sIL to follow the chain.

1. Same-locale slash canonicalisation → 301 (the fix)

```curl -sI -H "Accept-Language: en-US" http://localhost:8000/en-US/features
Expect: HTTP/1.1 301 Moved Permanently, Location: http://localhost:8000/en-US/features/
```
2. Locale-adding redirect → still 302 (unchanged)

```curl -sI -H "Accept-Language: en-US" http://localhost:8000/firefox
Expect: HTTP/1.1 302 Found, Location: /en-US/firefox, Vary: Accept-Language header present.
```
Repeat with a different Accept-Language to confirm the destination varies:
`curl -sI -H "Accept-Language: de" http://localhost:8000/firefox`
Expect: still 302, Location: /de/firefox.

3. Full chain for slash-less unprefixed URL → 302 then 301

`curl -sIL -H "Accept-Language: en-US" http://localhost:8000/features`
Expect (in order):
- HTTP/1.1 302 Found → Location: /en-US/features
- HTTP/1.1 301 Moved Permanently → Location: /en-US/features/
- HTTP/1.1 200 OK

4. Cross-locale fallback with missing slash → stays 302

Request a slash-less URL for a locale that isn't supported by the CMS, where the page exists in en-US.
`curl -sI -H "Accept-Language: sv,en-US;q=0.5" http://localhost:8000/sv/features`
Expect: HTTP/1.1 302 Found, Location: /en-US/features/ (cross-locale fallback must stay temporary because the destination depends on Accept-Language).

5. Cross-locale fallback with slash already present → still 302 (regression check)

`curl -sI -H "Accept-Language: sv,en-US;q=0.5" http://localhost:8000/sv/features/`
Expect: HTTP/1.1 302 Found, Location: /en-US/features/. No change from current main.

6. Genuinely missing page → 404, no spurious redirect

`curl -sI -H "Accept-Language: en-US" http://localhost:8000/en-US/this-page-does-not-exist/`
Expect: HTTP/1.1 404 Not Found (no redirect added by the fix).

7. Browser smoke test

In a fresh browser tab (or incognito to avoid stale 301 cache from previous test runs):
- Visit http://localhost:8000/en-US/features → DevTools Network tab should show a single 301 followed by 200.
- Visit http://localhost:8000/firefox → DevTools Network tab should show 302 → 301 → 200 (or whatever your locale resolves to).
- Confirm the final page renders correctly.

### Notes for reviewers

- Clear browser cache between runs. 301s are aggressively cached — if you tested an earlier version of a URL pre-fix, your browser may still serve the cached 302 from memory. (curl is unaffected.)