### PR TITLE
Fix TestFlight signup form alignment

### DIFF
--- a/media/css/cms/components/flare26-newsletterform.css
+++ b/media/css/cms/components/flare26-newsletterform.css
@@ -27,12 +27,15 @@
 @media (--viewport-md-up) {
     .fl-newsletterform-cta {
         align-items: center;
-        display: grid;
         flex-direction: row;
         gap: var(--token-layout-md);
-        grid-template-columns: 1fr 1fr;
         justify-content: center;
         padding: var(--token-layout-sm);
+    }
+
+    .fl-newsletterform-cta:has(.fl-newsletterform-illustration) {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
     }
 }
 


### PR DESCRIPTION
## One-line summary

A prior change to the `.fl-newsletterform-cta` class for the 2026 What’s New page caused a visual regression for the TestFlight signup form and this PR corrects this while preserving the design intent for the newer page.

## Significant changes and points to review

This uses `:has()` to check for the prescence of an element with `.ft-newsletterform-illustration` to switch to a grid layout. This satisfies both cases.

For browsers that do not support `:has()`, the design gracefully degrades in a way that is unnoticable. The grid layout and the flex layout are very similar. I’m a bit too green on this project to make a judgement call about whether or the change in CSS layout to grid is warranted.

<details><summary>Comparison with and without <code>:has()</code> being available</summary>

**With `:has()` (CSS grid)**:

<img width="3472" height="1976" alt="The newsletter page featuring Kit next to a newsletter form." src="https://github.com/user-attachments/assets/d36837f0-5a6b-4c99-b37c-63cd1ed57020" />

**Without `:has()` (CSS flexbox)**:

<img width="3472" height="1976" alt="The newsletter page featuring Kit next to a newsletter form slightly shifted left with slightly less space between them." src="https://github.com/user-attachments/assets/6ed962d1-aa54-4e95-a9b9-b7d47f1cc244" />

</details>

## Issue / Bugzilla link

- Resolves #1368
- Originally regressed in #1141

## Testing

The following two routes are affected:

- /channel/ios/testflight/ (compare with [live](https://www.firefox.com/channel/ios/testflight/) and [archived](https://web.archive.org/web/20260309235412/https://www.firefox.com/en-US/channel/ios/testflight/))
- /newsletter/ (compare with [live](https://www.firefox.com/newsletter/))
