### PR TITLE
WT-1251: Fix blocking download attribution refactor QA issues

### DIFF
--- a/media/js/base/consent/utils.es6.js
+++ b/media/js/base/consent/utils.es6.js
@@ -323,6 +323,7 @@ function getConsentState(obj) {
 }
 
 export {
+    attributionRefactorEnabled,
     consentRequired,
     dntEnabled,
     getConsentCookie,

--- a/media/js/firefox/all/all-init-v2.es6.js
+++ b/media/js/firefox/all/all-init-v2.es6.js
@@ -23,7 +23,7 @@ import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
         );
         // We don't want to include nav download button
         const downloadButtons = document.querySelectorAll(
-            '#outer-wrapper .download-link'
+            '#partial-target .download-link'
         );
 
         function showHelpModal(modalContent, modalTitle, eventLabel) {

--- a/media/js/firefox/landing/get/marketing-opt-out-init.es6.js
+++ b/media/js/firefox/landing/get/marketing-opt-out-init.es6.js
@@ -4,6 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { attributionRefactorEnabled } from '../../../base/consent/utils.es6';
 import MarketingOptOut from './marketing-opt-out.es6.js';
+import MarketingOptOutV2 from './marketing-opt-out-v2.es6.js';
 
-MarketingOptOut.init();
+if (attributionRefactorEnabled()) {
+    MarketingOptOutV2.init();
+} else {
+    MarketingOptOut.init();
+}

--- a/media/js/firefox/landing/get/marketing-opt-out-v2.es6.js
+++ b/media/js/firefox/landing/get/marketing-opt-out-v2.es6.js
@@ -1,0 +1,244 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    hasConsentCookie,
+    getConsentCookie,
+    setConsentCookie,
+    consentRequired,
+    dntEnabled,
+    gpcEnabled
+} from '../../../base/consent/utils.es6';
+
+const MarketingOptOut = {};
+
+/**
+ * Processes attribution changes depending on checkbox state.
+ * @param {Boolean} checked - checkbox target value.
+ */
+MarketingOptOut.processAttributionRequest = (checked) => {
+    let previousPreferenceCookie;
+
+    /**
+     * Preserve previous preference cookie consent state if one exists
+     */
+    if (hasConsentCookie()) {
+        const cookie = getConsentCookie();
+        previousPreferenceCookie = cookie.preference;
+    }
+
+    /**
+     * If checked, consent to analytics and initiate attribution.
+     */
+    if (checked) {
+        setConsentCookie({
+            analytics: true,
+            preference:
+                previousPreferenceCookie !== undefined &&
+                previousPreferenceCookie !== null
+                    ? previousPreferenceCookie
+                    : true
+        });
+        window.Mozilla.StubAttribution.init(() => {
+            /**
+             * Rebind event listeners only after attribution
+             * request has been successful.
+             */
+            MarketingOptOut.bindEvents();
+        });
+    } else {
+        /**
+         * Else set a cookie that rejects analytics.
+         * Remove all existing attribution data.
+         */
+        setConsentCookie({
+            analytics: false,
+            preference:
+                previousPreferenceCookie !== undefined &&
+                previousPreferenceCookie !== null
+                    ? previousPreferenceCookie
+                    : true
+        });
+        window.Mozilla.StubAttribution.removeAttributionData();
+        MarketingOptOut.bindEvents();
+
+        // Remove param to download /thanks links sharing consent state with /thanks page
+        const downloadThanksLinks = document.querySelectorAll(
+            '.c-button-download-thanks .download-link'
+        );
+        for (let i = 0; i < downloadThanksLinks.length; i++) {
+            const href = downloadThanksLinks[i].getAttribute('href');
+            if (href) {
+                const linkUrl = new URL(href, window.location.href);
+                linkUrl.searchParams.delete('marketing_consent');
+                downloadThanksLinks[i].setAttribute('href', linkUrl.toString());
+            }
+        }
+    }
+};
+
+/**
+ * Handles checkbox change event. Because checkbox state must be
+ * synced between all checkboxes on the page, we must temporarily
+ * unbind event listeners to avoid triggering multiple change
+ * events at once.
+ * @param {Object} e - change event object.
+ */
+MarketingOptOut.handleChangeEvent = (e) => {
+    MarketingOptOut.unbindEvents();
+    MarketingOptOut.setCheckboxState(e.target.checked);
+    MarketingOptOut.processAttributionRequest(e.target.checked);
+};
+
+/**
+ * Unbinds checkbox change event listeners and disables
+ * inputs when unbound.
+ */
+MarketingOptOut.unbindEvents = () => {
+    const checkboxes = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].removeEventListener(
+            'change',
+            MarketingOptOut.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = true;
+    }
+};
+
+/**
+ * Binds checkbox change event listeners and removes
+ * disabled states on inputs when bound.
+ */
+MarketingOptOut.bindEvents = () => {
+    const checkboxes = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].addEventListener(
+            'change',
+            MarketingOptOut.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = false;
+    }
+};
+
+/**
+ * Sets the checked state of all checkbox inputs.
+ * @param {Boolean} checked state
+ */
+MarketingOptOut.setCheckboxState = (checked) => {
+    const checkboxes = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].checked = checked;
+    }
+};
+
+/**
+ * Determines if marketing opt-out checkboxes should
+ * be displayed.
+ * @returns {Boolean}
+ */
+MarketingOptOut.shouldShowCheckbox = () => {
+    let show = false;
+
+    /**
+     * Has the visitor set a browser-level privacy flag?
+     */
+    if (dntEnabled() || gpcEnabled()) {
+        show = false;
+    } else if (window.Mozilla.StubAttribution.hasCookie()) {
+        /**
+         * Does the visitor have an existing attribution cookie?
+         */
+        show = true;
+    } else if (hasConsentCookie()) {
+        /**
+         * Does the visitor have an existing analytics consent cookie?
+         */
+        const cookie = getConsentCookie();
+        show = cookie.analytics ? true : false;
+    } else {
+        /**
+         * Is the visitor in EU/EAA?
+         */
+        show = consentRequired() ? false : true;
+    }
+
+    return show;
+};
+
+/**
+ * Displays checkboxes via CSS by removing the `hidden`
+ * class on their corresponding `<label>` parent elements.
+ * Also sets `checked=true` to enforce opt-out state.
+ */
+MarketingOptOut.showCheckbox = () => {
+    const labels = document.querySelectorAll(
+        '.marketing-opt-out-checkbox-label'
+    );
+
+    for (let i = 0; i < labels.length; i++) {
+        labels[i].classList.remove('hidden');
+        labels[i].querySelector('.marketing-opt-out-checkbox-input').checked =
+            true;
+    }
+
+    // Add param to download /thanks links sharing consent state with /thanks page
+    // This is only necessary on initial "show" of checked checkbox
+    // User interaction with the checkbox will set a global pref cookie
+    const downloadThanksLinks = document.querySelectorAll(
+        '.c-button-download-thanks .download-link'
+    );
+    for (let i = 0; i < downloadThanksLinks.length; i++) {
+        const href = downloadThanksLinks[i].getAttribute('href');
+        if (href) {
+            const linkUrl = new URL(href, window.location.href);
+            linkUrl.searchParams.set('marketing_consent', '1');
+            downloadThanksLinks[i].setAttribute('href', linkUrl.toString());
+        }
+    }
+};
+
+/**
+ * Determines if marketing opt-out logic should run,
+ * based on existing attribution requirements.
+ * @returns {Boolean}
+ */
+MarketingOptOut.meetsRequirements = () => {
+    return (
+        typeof window.Mozilla.StubAttribution !== 'undefined' &&
+        window.Mozilla.StubAttribution.meetsRequirements()
+    );
+};
+
+/**
+ * Initializes marketing opt-out flow
+ * @returns {Boolean}.
+ */
+MarketingOptOut.init = () => {
+    if (!MarketingOptOut.meetsRequirements()) {
+        return false;
+    }
+
+    if (MarketingOptOut.shouldShowCheckbox()) {
+        MarketingOptOut.showCheckbox();
+        MarketingOptOut.bindEvents();
+        return true;
+    }
+
+    return false;
+};
+
+export default MarketingOptOut;

--- a/media/js/firefox/landing/get/marketing-opt-out-v2.es6.js
+++ b/media/js/firefox/landing/get/marketing-opt-out-v2.es6.js
@@ -42,7 +42,7 @@ MarketingOptOut.processAttributionRequest = (checked) => {
                     ? previousPreferenceCookie
                     : true
         });
-        window.Mozilla.StubAttribution.init(() => {
+        window.Mozilla.DownloadAttribution.initAnalytics(true, () => {
             /**
              * Rebind event listeners only after attribution
              * request has been successful.
@@ -62,7 +62,7 @@ MarketingOptOut.processAttributionRequest = (checked) => {
                     ? previousPreferenceCookie
                     : true
         });
-        window.Mozilla.StubAttribution.removeAttributionData();
+        window.Mozilla.DownloadAttribution.removeAttributionData();
         MarketingOptOut.bindEvents();
 
         // Remove param to download /thanks links sharing consent state with /thanks page
@@ -158,7 +158,7 @@ MarketingOptOut.shouldShowCheckbox = () => {
      */
     if (dntEnabled() || gpcEnabled()) {
         show = false;
-    } else if (window.Mozilla.StubAttribution.hasCookie()) {
+    } else if (window.Mozilla.DownloadAttribution.hasSignedCookie()) {
         /**
          * Does the visitor have an existing attribution cookie?
          */
@@ -218,8 +218,8 @@ MarketingOptOut.showCheckbox = () => {
  */
 MarketingOptOut.meetsRequirements = () => {
     return (
-        typeof window.Mozilla.StubAttribution !== 'undefined' &&
-        window.Mozilla.StubAttribution.meetsRequirements()
+        typeof window.Mozilla.DownloadAttribution !== 'undefined' &&
+        window.Mozilla.DownloadAttribution.meetsFunctionalRequirements()
     );
 };
 

--- a/springfield/firefox/templates/firefox/all/base-flare26.html
+++ b/springfield/firefox/templates/firefox/all/base-flare26.html
@@ -48,5 +48,9 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('firefox_all') }}
+  {% if switch('enable_attribution_refactor') %}
+    {{ js_bundle('firefox_all-v2') }}
+  {% else %}
+    {{ js_bundle('firefox_all') }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary
WT-1282: Apply /all v2 JS to Flare26 template, fix JS selector
WT-1284: Restore opt-out v2 JS logic

## Significant changes and points to review



## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1282
https://mozilla-hub.atlassian.net/browse/WT-1284


## Testing
Go to http://localhost:8000/en-US/download/all/desktop-release/osx/ with consent not required geo
- confirm no download button is in `main` content
- confirm download attribution cookies exist
- select a language and confirm a download button appears in the final step
- confirm download button has `attribution_code` and `attribution_sig` parameters

Go to http://localhost:8000/en-US/landing/get/ with consent not required geo (ensure you do not have pre-existing stub attribution / download attribution cookie in browser first) 
- confirm opt-out checkbox appears checked & raw download attribution analytics cookie exists
- uncheck the checkbox to confirm all download attribution cookies are removed

Go to http://localhost:8000/en-US/landing/get/ with consent required geo (ensure you do not have pre-existing stub attribution / download attribution cookie in browser first) 
- confirm consent banner appears
- click Accept & confirm download attribution cookies are added
- click Deny & confirm no cookies are added