### PR TITLE
Wrap home kit banner buttons in .fl-buttons

### DIFF
--- a/springfield/cms/templates/cms/blocks/sections/home-kit-banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/home-kit-banner.html
@@ -29,10 +29,12 @@
 
     {% if value.buttons %}
       <content:content>
-        {% for button in value.buttons %}
-          {% set block_position = block_position ~ ".button-" ~ loop.index %}
-          {% include_block button %}
-        {% endfor %}
+        <div class="fl-buttons">
+          {% for button in value.buttons %}
+            {% set block_position = block_position ~ ".button-" ~ loop.index %}
+            {% include_block button %}
+          {% endfor %}
+        </div>
       </content:content>
     {% endif %}
   </include:kit-banner>


### PR DESCRIPTION
Fixes minor regression on button on homepage (padding/margin).

Wrap the button include loop in a <div class="fl-buttons"> container in home-kit-banner.html so the rendered buttons can be targeted as a group for styling/layout (e.g., flex or spacing). No behavioral changes to the button blocks themselves—just markup grouping and indentation cleanup.

Before:
<img width="619" height="589" alt="image" src="https://github.com/user-attachments/assets/1c2d7e89-c7fa-4d22-8e35-f62fddb4da49" />


After:
<img width="746" height="609" alt="image" src="https://github.com/user-attachments/assets/c6d99dc2-51c6-46b9-af22-276f797cbc10" />
