### PR TITLE
[WT-1266] Skip last visible banner if `:has()` unsupported

### DIFF
--- a/media/js/cms/components/flare26-last-visible-banner.es6.js
+++ b/media/js/cms/components/flare26-last-visible-banner.es6.js
@@ -38,6 +38,9 @@ function updateLastVisibleBanner(section) {
 }
 
 function setupLastVisibleBanner() {
+    // Skip if `:has()` is not supported
+    if (!CSS.supports('selector(:has(+ *))')) return;
+
     const sections = document.querySelectorAll(
         '.fl-split-page-lower, .fl-main:not(:has(.fl-split-page-lower))'
     );


### PR DESCRIPTION
## One-line summary

The use of `:has()` in a `document.querySelectorAll()` call was causing an uncaught error for older browsers (namely Firefox ESR 115), this PR checks for support early and skips the enhancement if unsupported.

## Significant changes and points to review

- This is a simple feature check and early return.
- I did consider if we could leverage the newer-yet-widely-supported `:nth-last-child(<nth> of <complex-selector>)` syntax to entirely replace the JS component, but I did not understand how the conditional display option works well enough (i.e. what can be selected with CSS to infer content is hidden) and since the `.is-last-visible` class is used in a few places it would be a complicated selector to be copying around without the help of Sass.
- The lack of the design enhancement for unsupporting browsers seems inconsequential.

## Issue / Bugzilla link

- Ticket: https://mozilla-hub.atlassian.net/browse/WT-1266
- First occurred as a result of: https://github.com/mozmeao/springfield/pull/1370

## Testing

Find an old browser (like Firefox ESR 115) or a browser that still has a feature flag that can be disabled for `:has()` and check that the console error is no longer there.
