### PR TITLE
Adjust video aspect ratio inside card to 17/20

### DIFF
--- a/media/css/cms/components/flare26-card.css
+++ b/media/css/cms/components/flare26-card.css
@@ -592,7 +592,7 @@ Illustration Card
 }
 
 .fl-illustration-card .fl-video {
-    aspect-ratio: 11/12;
+    aspect-ratio: 17/20;
     border-radius: var(--token-spacing-xl);
 }
 

--- a/media/css/cms/components/flare26-mediacontent.css
+++ b/media/css/cms/components/flare26-mediacontent.css
@@ -38,7 +38,7 @@
 }
 
 .fl-mediacontent.is-narrow .fl-video {
-    aspect-ratio: 11/12;
+    aspect-ratio: 17/20;
 }
 
 .fl-mediacontent.is-narrow .fl-video video {


### PR DESCRIPTION
Change .fl-video aspect-ratio from 11/12 to 17/20 in flare26-card.css and flare26-mediacontent.css to correct video proportions for illustration cards and narrow media content.

We currently have no videos inside cards, and the expected ratio is 17/20, not 11/12
