### PR TITLE
Add reduced-motion fallback for animated videos

### DIFF
--- a/media/css/cms/components/flare26-media.css
+++ b/media/css/cms/components/flare26-media.css
@@ -114,6 +114,26 @@
     position: absolute;
 }
 
+.fl-video-reduced-motion-fallback {
+    display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fl-video-is-animation video,
+    .fl-video-is-animation .fl-video-play {
+        display: none;
+    }
+
+    .fl-video-is-animation .fl-video-reduced-motion-fallback {
+        block-size: 100%;
+        display: block;
+        inline-size: 100%;
+        inset: 0;
+        object-fit: cover;
+        position: absolute;
+    }
+}
+
 /* Animation component with playback modes */
 .fl-animation video {
     margin: 0;

--- a/springfield/cms/templates/components/animation.html
+++ b/springfield/cms/templates/components/animation.html
@@ -17,6 +17,9 @@
     <source src="{{ video_url }}" type="video/webm">
     <img src="{{ poster }}" alt="{{ alt }}" class="fl-video-poster" />
   </video>
+  {% if poster %}
+    <img src="{{ poster }}" alt="{{ alt }}" class="fl-video-reduced-motion-fallback" />
+  {% endif %}
   {% if show_pause_button %}
     <button
       class="fl-video-play js-animation-pause"


### PR DESCRIPTION
## Summary

When a user has `prefers-reduced-motion: reduce` set (OS or browser preference), autoplaying webm animations rendered via the `animation` component now swap to their static poster image instead of playing. Pure CSS, no JS bundle.

## Why

The `animation` component's `autoplay_loop` mode currently autoplays regardless of the user's motion preference, across every flare26 surface that uses it (kit-banner, smart-window hero, CMS animation blocks in cards/intros/media-content, sliding carousel). This is a WCAG 2.3.3 gap.


## Changes

**`springfield/cms/templates/components/animation.html`**
- In the `autoplay_loop` branch only, add a sibling `<img class="fl-video-reduced-motion-fallback">` after `</video>`, using the same `poster` URL and `alt` text the component already requires.
- Guarded by `{% if poster %}` so authors who omit the poster (allowed by `AnimationBlock(required=False)` inside `MediaBlock`) degrade gracefully rather than render a broken-image icon.
- `autoplay_once` branch is unchanged — it requires user interaction, so it already respects motion preferences.

**`media/css/cms/components/flare26-media.css`**
- New rule block under `.fl-video iframe, .fl-video video`:
  - Default: `.fl-video-reduced-motion-fallback { display: none }` — fallback img hidden for users without the preference.
  - Under `@media (prefers-reduced-motion: reduce)`: hides the `<video>` and pause button via `display: none`, shows the fallback img positioned to fill the wrapper via `inset: 0; object-fit: cover`.
- Scoped to `.fl-video-is-animation` so click-to-play videos, YouTube embeds, and other `.fl-video` contexts are untouched.

## Scope

One template change + one CSS rule block covers all four animation surfaces:

- `springfield/cms/templates/components/kit-banner.html:34` — kit-banner animations
- `springfield/cms/templates/cms/smart_window_page.html:210` — smart-window intro hero
- `springfield/cms/templates/cms/blocks/animation.html:9` — generic CMS animation block (any block accepting animation media)
- `springfield/cms/templates/pattern-library/components/flare-26/sliding-carousel/sliding-carousel.html:43` — pattern-library demo

## Accessibility

- Under reduced-motion: video is `display: none` (removed from a11y tree); fallback `<img>` carries the same `alt` text the video had.
- Pause button is hidden via CSS since it has no purpose when video isn't playing.

## Notes / follow-ups

- `display: none` on `<video>` hides it visually and removes it from the a11y tree, but the browser may still load metadata for `autoplay` elements. The user sees no motion (WCAG 2.3.3 satisfied) but network/CPU may not be saved. Acceptable trade-off for a CSS-only fix.
- No Playwright coverage today because the suite doesn't emulate `prefers-reduced-motion`. Suggest a follow-up to add `page.emulateMedia({ reducedMotion: 'reduce' })` to one spec.
- Suggest a follow-up to tighten `MediaBlock.animation` to require `poster` (`springfield/cms/blocks.py:1397`) so posterless animations can't be authored.

## Test plan

- [ ] DevTools → Rendering → set "Emulate CSS media feature `prefers-reduced-motion`" → `reduce`
- [ ] Load `/smart-window/` locally — intro hero animation should be replaced by its poster image, no pause button visible
- [ ] Load a page with a kit-banner using the curious-animation theme — same result: static poster, no pause button
- [ ] Load a CMS page with an illustration-card-2026 animation block — same result
- [ ] Load `/pattern-library/render-pattern/pattern-library/components/flare-26/sliding-carousel/sliding-carousel.html` — animation panels show posters only
- [ ] Switch DevTools emulation back to `no-preference` and reload each — animations play normally, no extra image visible
- [ ] OS-level test (macOS): System Settings → Accessibility → Display → enable "Reduce motion" → verify same behavior in a real browser without DevTools emulation
- [ ] VoiceOver / screen-reader: with reduced-motion ON, navigate to an animation — alt text should be announced from the visible `<img>`, not from the hidden `<video>`
- [ ] Edge case: author a CMS animation block with the poster left blank → verify it doesn't crash; under reduced-motion the wrapper is empty (no broken-image icon)
- [ ] Visual regression suite (`npx playwright test specs/visual-regression/`) — should pass unchanged (no reduced-motion emulation in default specs)