### PR TITLE
[WT-1289] Fix main nav menus accessibility

### DIFF
--- a/media/css/cms/components/flare-navigation.css
+++ b/media/css/cms/components/flare-navigation.css
@@ -190,6 +190,13 @@ html {
     text-decoration: none;
 }
 
+.fl-menu-title:where(button) {
+    background: none;
+    border-radius: 0;
+    margin-block-end: 0;
+    padding: 0;
+}
+
 .fl-menu-subtitle {
     font-family: var(--fl-theme-font-family-headline);
 }

--- a/media/css/cms/components/flare-navigation.css
+++ b/media/css/cms/components/flare-navigation.css
@@ -190,11 +190,15 @@ html {
     text-decoration: none;
 }
 
-.fl-menu-title:where(button) {
+.fl-menu-title:where(button, [role='button']) {
     background: none;
     border-radius: 0;
     margin-block-end: 0;
     padding: 0;
+}
+
+.fl-menu-title:is(a:not(:any-link):hover) {
+    text-decoration: none;
 }
 
 .fl-menu-subtitle {

--- a/media/js/cms/flare-navigation.es6.js
+++ b/media/js/cms/flare-navigation.es6.js
@@ -8,6 +8,8 @@
 import { createFocusTrap } from 'focus-trap';
 
 (function () {
+    const desktopMediaQuery = window.matchMedia('(min-width: 900px)');
+
     const headerEl = document.querySelector('.fl-header.enable-sticky');
 
     if (headerEl) {
@@ -53,89 +55,159 @@ import { createFocusTrap } from 'focus-trap';
         });
     }
 
+    const nav = document.querySelector('.fl-nav');
+
     // Menu panels
     const menuCategories = document.querySelectorAll('.fl-menu-category');
 
     for (const category of menuCategories) {
-        let title = category.querySelector('.fl-menu-title');
+        const title = category.querySelector('.fl-menu-title');
         const panel = category.querySelector('.fl-menu-panel');
 
         /* ESSENTIAL SEMANTICS: Convert link menu titles to buttons */
-        if (title.matches(':any-link')) {
-            const button = document.createElement('button');
-            button.append(...title.childNodes);
-            button.classList.add(...title.classList);
-            button.type = 'button';
-            button.ariaExpanded = 'false';
-            button.setAttribute('aria-controls', panel.id);
-            button.dataset.testid = title.dataset.testid;
-            title.replaceWith(button);
-            title = button;
-        }
-
-        /* ESSENTIAL INTERACTION */
-
-        /* Menu titles toggle their associated panels */
-        title.addEventListener('click', () => {
-            const activeCategory = getActiveCategory();
-            if (category !== activeCategory) {
-                toggleCategory(getActiveCategory(), false);
+        if (title.matches('a') && desktopMediaQuery.matches) {
+            if (title.hasAttribute('href')) {
+                title.dataset.href = title.getAttribute('href');
+                title.removeAttribute('href');
             }
-            toggleCategory(category);
-        });
-
-        /* BONUS INTERACTION */
-
-        /* Panels auto-close when focus leaves */
-        panel.addEventListener(
-            'blur',
-            (event) => {
-                if (!panel.contains(event.relatedTarget)) {
-                    toggleCategory(getActiveCategory(), false);
-                }
-            },
-            true
-        );
-
-        /* Reveal menu on hover */
-        category.addEventListener('mouseenter', () => {
-            // If a menu has been opened with other interaction types, ignore.
-            if (category.matches('.is-active')) return;
-
-            toggleCategory(getActiveCategory(), false);
-            toggleCategory(category, true);
-
-            /* This gets added once and is called once */
-            category.addEventListener(
-                'mouseleave',
-                () => toggleCategory(category, false),
-                { once: true }
-            );
-        });
+            title.setAttribute('tabindex', 0);
+            title.setAttribute('role', 'button');
+            title.setAttribute('aria-expanded', 'false');
+            title.setAttribute('aria-controls', panel.id);
+        }
     }
 
-    /* Closes the active panel and returns focus to the title (if focus was within the panel) */
-    document.addEventListener('keyup', (event) => {
+    // Perform initial event listener setup
+    setupEventListeners();
+
+    desktopMediaQuery.addEventListener('change', (event) => {
+        const isDesktop = event.matches;
+        const titleButtons = document.querySelectorAll(
+            '.fl-menu-category .fl-menu-title'
+        );
+
+        for (const titleButton of titleButtons) {
+            if (isDesktop) {
+                titleButton.removeAttribute('href');
+                titleButton.setAttribute('tabindex', 0);
+                titleButton.setAttribute('role', 'button');
+                titleButton.setAttribute('aria-expanded', 'false');
+                titleButton.setAttribute(
+                    'aria-controls',
+                    getPanelForCategory(getCategory(titleButton)).id
+                );
+            } else {
+                if (titleButton.dataset.href) {
+                    titleButton.setAttribute('href', titleButton.dataset.href);
+                }
+                titleButton.removeAttribute('tabindex');
+                titleButton.removeAttribute('role');
+                titleButton.removeAttribute('aria-expanded');
+                titleButton.removeAttribute('aria-controls');
+            }
+        }
+
+        setupEventListeners();
+    });
+
+    /* Sets up and tears down delegated event listeners based on desktop media query */
+    function setupEventListeners() {
+        if (desktopMediaQuery.matches) {
+            nav.addEventListener('click', handleCategoryToggle);
+            nav.addEventListener('keydown', handleNonLinkAnchorClick);
+            nav.addEventListener('keyup', handleNonLinkAnchorClick);
+            nav.addEventListener('blur', handleAutoClose, true);
+            nav.addEventListener('mouseenter', handleCategoryHoverReveal, true);
+            document.addEventListener('keydown', handleDismissActiveCategory);
+        } else {
+            nav.removeEventListener('click', handleCategoryToggle);
+            nav.removeEventListener('keydown', handleNonLinkAnchorClick);
+            nav.removeEventListener('keyup', handleNonLinkAnchorClick);
+            nav.removeEventListener('blur', handleAutoClose, true);
+            nav.removeEventListener(
+                'mouseenter',
+                handleCategoryHoverReveal,
+                true
+            );
+            document.removeEventListener(
+                'keydown',
+                handleDismissActiveCategory
+            );
+        }
+    }
+
+    /* DELEGATED EVENT HANDLERS */
+
+    function handleNonLinkAnchorClick(event) {
+        if (event.type === 'keydown' && event.key === ' ') {
+            event.target.closest('[role="button"]').click();
+        }
+        if (event.type === 'keyup' && event.key === 'Enter') {
+            event.target.closest('[role="button"]').click();
+        }
+    }
+
+    /**
+     * Handles toggling panels on click.
+     */
+    function handleCategoryToggle(event) {
+        if (!event.target.closest('.fl-menu-title')) return;
+        const category = getCategory(event.target);
+        const activeCategory = getActiveCategory();
+        if (category !== activeCategory) {
+            toggleCategory(getActiveCategory(), false);
+        }
+        toggleCategory(category);
+    }
+
+    /**
+     * Dismisses an active panel when the Escape key is pressed
+     */
+    function handleDismissActiveCategory(event) {
         if (event.key === 'Escape') {
             const activeCategory = getActiveCategory();
 
             if (!activeCategory) return;
 
-            const activeCategoryTitle =
-                activeCategory.querySelector('.fl-menu-title');
+            const title = getTitleForCategory(activeCategory);
             const focusedElement = document.activeElement;
 
             toggleCategory(activeCategory, false);
 
             if (activeCategory.contains(focusedElement)) {
-                activeCategoryTitle.focus();
+                title.focus();
             }
         }
-    });
-
-    function getActiveCategory() {
-        return document.querySelector('.fl-menu-category.is-active');
     }
+
+    /**
+     * Auto-closes open panels on blur.
+     */
+    function handleAutoClose(event) {
+        const category = getCategory(event.target);
+        const panel = getPanelForCategory(category);
+        if (!panel.contains(event.relatedTarget)) {
+            toggleCategory(category, false);
+        }
+    }
+
+    function handleCategoryHoverReveal(event) {
+        // If a menu has been opened with other interaction types, ignore.
+        if (!event.target.matches('.fl-menu-category:not(.is-active)')) return;
+
+        toggleCategory(getActiveCategory(), false);
+        toggleCategory(event.target, true);
+
+        event.target.addEventListener(
+            'mouseleave',
+            (event) => {
+                toggleCategory(getCategory(event.target), false);
+            },
+            { once: true }
+        );
+    }
+
+    /* TOGGLING LOGIC */
 
     /* Toggles panel visibility and trigger aria-expanded */
     function toggleCategory(
@@ -143,8 +215,26 @@ import { createFocusTrap } from 'focus-trap';
         force = category && !category.classList.contains('is-active')
     ) {
         if (!category) return;
-        const title = category.querySelector('.fl-menu-title');
+        const title = getTitleForCategory(category);
         category.classList.toggle('is-active', force);
         title.setAttribute('aria-expanded', force ? 'true' : 'false');
+    }
+
+    /* RELATIVE QUERY HELPERS */
+
+    function getActiveCategory() {
+        return document.querySelector('.fl-menu-category.is-active');
+    }
+
+    function getCategory(node) {
+        return node.closest('.fl-menu-category');
+    }
+
+    function getPanelForCategory(category) {
+        return category.querySelector('.fl-menu-panel');
+    }
+
+    function getTitleForCategory(category) {
+        return category.querySelector('.fl-menu-title');
     }
 })();

--- a/media/js/cms/flare-navigation.es6.js
+++ b/media/js/cms/flare-navigation.es6.js
@@ -56,89 +56,95 @@ import { createFocusTrap } from 'focus-trap';
     // Menu panels
     const menuCategories = document.querySelectorAll('.fl-menu-category');
 
-    menuCategories.forEach(function (category) {
-        // keyboard is being used
-        category.addEventListener('keyup', function (event) {
-            if (event.key === 'Escape') {
-                menuCategories.forEach(function (category) {
-                    category.classList.remove('is-active');
-                });
+    for (const category of menuCategories) {
+        let title = category.querySelector('.fl-menu-title');
+        const panel = category.querySelector('.fl-menu-panel');
+
+        /* ESSENTIAL SEMANTICS: Convert link menu titles to buttons */
+        if (title.matches(':any-link')) {
+            const button = document.createElement('button');
+            button.append(...title.childNodes);
+            button.classList.add(...title.classList);
+            button.type = 'button';
+            button.ariaExpanded = 'false';
+            button.setAttribute('aria-controls', panel.id);
+            button.dataset.testid = title.dataset.testid;
+            title.replaceWith(button);
+            title = button;
+        }
+
+        /* ESSENTIAL INTERACTION */
+
+        /* Menu titles toggle their associated panels */
+        title.addEventListener('click', () => {
+            const activeCategory = getActiveCategory();
+            if (category !== activeCategory) {
+                toggleCategory(getActiveCategory(), false);
             }
+            toggleCategory(category);
         });
 
-        // mouse is being used
-        category.addEventListener('mouseover', function () {
-            menuCategories.forEach(function (category) {
-                category.classList.remove('is-active');
-            });
-            category.classList.add('is-active');
-        });
-        category.addEventListener('mouseout', function () {
-            category.classList.remove('is-active');
-        });
-    });
+        /* BONUS INTERACTION */
 
-    const menuTitles = document.querySelectorAll('.fl-menu-title');
-    let focusedMenu = null;
-
-    // keyboard is being used
-    menuTitles.forEach(function (title) {
-        // when focusing a menu title, close all menus
-        title.addEventListener('focus', function () {
-            menuCategories.forEach(function (category) {
-                if (category.classList.contains('is-active')) {
-                    focusedMenu = category;
+        /* Panels auto-close when focus leaves */
+        panel.addEventListener(
+            'blur',
+            (event) => {
+                if (!panel.contains(event.relatedTarget)) {
+                    toggleCategory(getActiveCategory(), false);
                 }
-                category.classList.remove('is-active');
-            });
-        });
-
-        // when leaving the last link of a menu, close all menus
-        const menuLinks = title
-            .closest('.fl-menu-category')
-            .querySelectorAll('a');
-
-        menuLinks[menuLinks.length - 1].addEventListener(
-            'keydown',
-            function (event) {
-                if (event.key === 'Tab' && !event.shiftKey) {
-                    menuCategories.forEach(function (category) {
-                        category.classList.remove('is-active');
-                    });
-                }
-            }
+            },
+            true
         );
 
-        // when clicking or pressing enter, toggle the menu
-        title.addEventListener('click', function (event) {
-            event.preventDefault();
+        /* Reveal menu on hover */
+        category.addEventListener('mouseenter', () => {
+            // If a menu has been opened with other interaction types, ignore.
+            if (category.matches('.is-active')) return;
 
-            const menuPanel = event.target.closest('.fl-menu-category');
+            toggleCategory(getActiveCategory(), false);
+            toggleCategory(category, true);
 
-            // focus runs first then click. if we click a menu that was closed
-            // by focus don't open it again immediately
-            if (focusedMenu === menuPanel) {
-                focusedMenu = null;
-                return;
-            }
-
-            if (menuPanel.classList.contains('is-active')) {
-                menuPanel.classList.remove('is-active');
-            } else {
-                menuPanel.classList.add('is-active');
-            }
+            /* This gets added once and is called once */
+            category.addEventListener(
+                'mouseleave',
+                () => toggleCategory(category, false),
+                { once: true }
+            );
         });
+    }
+
+    /* Closes the active panel and returns focus to the title (if focus was within the panel) */
+    document.addEventListener('keyup', (event) => {
+        if (event.key === 'Escape') {
+            const activeCategory = getActiveCategory();
+
+            if (!activeCategory) return;
+
+            const activeCategoryTitle =
+                activeCategory.querySelector('.fl-menu-title');
+            const focusedElement = document.activeElement;
+
+            toggleCategory(activeCategory, false);
+
+            if (activeCategory.contains(focusedElement)) {
+                activeCategoryTitle.focus();
+            }
+        }
     });
 
-    const menuPanelCloseButtons = document.querySelectorAll(
-        '.fl-menu-close-button'
-    );
+    function getActiveCategory() {
+        return document.querySelector('.fl-menu-category.is-active');
+    }
 
-    menuPanelCloseButtons.forEach(function (button) {
-        button.addEventListener('click', function (event) {
-            event.preventDefault();
-            const menuPanel = event.target.closest('.fl-menu-category');
-            menuPanel.classList.remove('is-active');
-        });
-    });
+    /* Toggles panel visibility and trigger aria-expanded */
+    function toggleCategory(
+        category,
+        force = category && !category.classList.contains('is-active')
+    ) {
+        if (!category) return;
+        const title = category.querySelector('.fl-menu-title');
+        category.classList.toggle('is-active', force);
+        title.setAttribute('aria-expanded', force ? 'true' : 'false');
+    }
 })();

--- a/media/js/cms/flare-navigation.es6.js
+++ b/media/js/cms/flare-navigation.es6.js
@@ -8,9 +8,11 @@
 import { createFocusTrap } from 'focus-trap';
 
 (function () {
-    const desktopMediaQuery = window.matchMedia('(min-width: 900px)');
+    /* Custom media: --viewport-md-up */
+    const viewportMdUpQuery = window.matchMedia('(min-width: 900px)');
 
     const headerEl = document.querySelector('.fl-header.enable-sticky');
+    const nav = document.querySelector('.fl-nav');
 
     if (headerEl) {
         const sentinel = document.createElement('div');
@@ -29,15 +31,14 @@ import { createFocusTrap } from 'focus-trap';
 
     // Hamburger menu
     const buttonEl = document.querySelector('.fl-show-mobile-menu');
-    const mobileNavEl = document.querySelector('.fl-nav');
     const trap = createFocusTrap(headerEl);
 
-    if (buttonEl && mobileNavEl) {
+    if (buttonEl && nav) {
         buttonEl.addEventListener('click', function (e) {
             e.preventDefault();
             const mobileNavIsOpen =
                 e.currentTarget.classList.contains('is-open');
-            const elements = [e.currentTarget, mobileNavEl];
+            const elements = [e.currentTarget, nav];
 
             if (mobileNavIsOpen) {
                 elements.forEach(function (el) {
@@ -55,55 +56,31 @@ import { createFocusTrap } from 'focus-trap';
         });
     }
 
-    const nav = document.querySelector('.fl-nav');
-
     // Menu panels
     const menuCategories = document.querySelectorAll('.fl-menu-category');
 
     for (const category of menuCategories) {
         const title = category.querySelector('.fl-menu-title');
-        const panel = category.querySelector('.fl-menu-panel');
 
-        /* ESSENTIAL SEMANTICS: Convert link menu titles to buttons */
-        if (title.matches('a') && desktopMediaQuery.matches) {
-            if (title.hasAttribute('href')) {
-                title.dataset.href = title.getAttribute('href');
-                title.removeAttribute('href');
-            }
-            title.setAttribute('tabindex', 0);
-            title.setAttribute('role', 'button');
-            title.setAttribute('aria-expanded', 'false');
-            title.setAttribute('aria-controls', panel.id);
+        /* ESSENTIAL SEMANTICS: Convert anchor menu titles to buttons */
+        if (title.matches('a') && viewportMdUpQuery.matches) {
+            applyButtonSemanticsToAnchor(title);
         }
     }
 
     // Perform initial event listener setup
     setupEventListeners();
 
-    desktopMediaQuery.addEventListener('change', (event) => {
-        const isDesktop = event.matches;
-        const titleButtons = document.querySelectorAll(
+    viewportMdUpQuery.addEventListener('change', (event) => {
+        const menuTitles = document.querySelectorAll(
             '.fl-menu-category .fl-menu-title'
         );
 
-        for (const titleButton of titleButtons) {
-            if (isDesktop) {
-                titleButton.removeAttribute('href');
-                titleButton.setAttribute('tabindex', 0);
-                titleButton.setAttribute('role', 'button');
-                titleButton.setAttribute('aria-expanded', 'false');
-                titleButton.setAttribute(
-                    'aria-controls',
-                    getPanelForCategory(getCategory(titleButton)).id
-                );
+        for (const title of menuTitles) {
+            if (event.matches) {
+                applyButtonSemanticsToAnchor(title);
             } else {
-                if (titleButton.dataset.href) {
-                    titleButton.setAttribute('href', titleButton.dataset.href);
-                }
-                titleButton.removeAttribute('tabindex');
-                titleButton.removeAttribute('role');
-                titleButton.removeAttribute('aria-expanded');
-                titleButton.removeAttribute('aria-controls');
+                removeButtonSemanticsFromAnchor(title);
             }
         }
 
@@ -112,7 +89,7 @@ import { createFocusTrap } from 'focus-trap';
 
     /* Sets up and tears down delegated event listeners based on desktop media query */
     function setupEventListeners() {
-        if (desktopMediaQuery.matches) {
+        if (viewportMdUpQuery.matches) {
             nav.addEventListener('click', handleCategoryToggle);
             nav.addEventListener('keydown', handleNonLinkAnchorClick);
             nav.addEventListener('keyup', handleNonLinkAnchorClick);
@@ -218,6 +195,38 @@ import { createFocusTrap } from 'focus-trap';
         const title = getTitleForCategory(category);
         category.classList.toggle('is-active', force);
         title.setAttribute('aria-expanded', force ? 'true' : 'false');
+    }
+
+    /* SEMANTIC SETUP */
+
+    /* Applies button semantics to menu title (anchor) */
+    function applyButtonSemanticsToAnchor(anchor) {
+        if (anchor.hasAttribute('href')) {
+            anchor.dataset.href = anchor.getAttribute('href');
+            // Remove the link semantics
+            anchor.removeAttribute('href');
+        }
+        // Remove button semantics (apply link semantics)
+        anchor.setAttribute('tabindex', 0);
+        anchor.setAttribute('role', 'button');
+        anchor.setAttribute('aria-expanded', 'false');
+        anchor.setAttribute(
+            'aria-controls',
+            getPanelForCategory(getCategory(anchor)).id
+        );
+    }
+
+    /* Removes button semantics from the menu title (anchor) */
+    function removeButtonSemanticsFromAnchor(anchor) {
+        // Restore the href if the title was originally a link
+        if (anchor.dataset.href) {
+            anchor.setAttribute('href', anchor.dataset.href);
+        }
+        // Remove button semantics
+        anchor.removeAttribute('tabindex');
+        anchor.removeAttribute('role');
+        anchor.removeAttribute('aria-expanded');
+        anchor.removeAttribute('aria-controls');
     }
 
     /* RELATIVE QUERY HELPERS */

--- a/media/js/cms/flare-navigation.es6.js
+++ b/media/js/cms/flare-navigation.es6.js
@@ -117,6 +117,7 @@ import { createFocusTrap } from 'focus-trap';
 
     function handleNonLinkAnchorClick(event) {
         if (event.type === 'keydown' && event.key === ' ') {
+            event.preventDefault();
             event.target.closest('[role="button"]').click();
         }
         if (event.type === 'keyup' && event.key === 'Enter') {

--- a/springfield/cms/templates/cms/includes/flare-menus/browser.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/browser.html
@@ -7,9 +7,10 @@
 {% set params='?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=browser' %}
 
 <li class="fl-menu-category" data-testid="menu-category-browser">
-  <span
+  <button
     class="fl-menu-title"
-    aria-haspopup="true"
+    type="button"
+    aria-expanded="false"
     aria-controls="fl-menu-panel-browser"
     data-testid="navigation-link-browser"
   >
@@ -17,12 +18,8 @@
       {{ ftl('navigation-browser')}}
       <span class="fl-icon fl-icon-chevron-down"></span>
     </span>
-  </span>
+  </button>
   <div class="fl-menu-panel" id="fl-menu-panel-browser" data-testid="navigation-menu-browser">
-    <button class="fl-menu-close-button">
-      <span class="fl-icon fl-icon-close fl-menu-close-button-content">{{ ftl('navigation-close-menu') }}</span>
-    </button>
-
 
     <div class="fl-menu-panel-content">
       <div class="fl-menu-panel-content-column">

--- a/springfield/cms/templates/cms/includes/flare-menus/browser.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/browser.html
@@ -7,18 +7,15 @@
 {% set params='?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=browser' %}
 
 <li class="fl-menu-category" data-testid="menu-category-browser">
-  <button
+  <a
     class="fl-menu-title"
-    type="button"
-    aria-expanded="false"
-    aria-controls="fl-menu-panel-browser"
     data-testid="navigation-link-browser"
   >
     <span class="fl-menu-heading">
       {{ ftl('navigation-browser')}}
       <span class="fl-icon fl-icon-chevron-down"></span>
     </span>
-  </button>
+  </a>
   <div class="fl-menu-panel" id="fl-menu-panel-browser" data-testid="navigation-menu-browser">
 
     <div class="fl-menu-panel-content">

--- a/springfield/cms/templates/cms/includes/flare-menus/features.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/features.html
@@ -8,8 +8,6 @@
   <a
     class="fl-menu-title"
     href="{{ url('firefox.features.index') }}"
-    aria-haspopup="true"
-    aria-controls="fl-menu-panel-features"
   >
     <span class="fl-menu-heading">
       {{ ftl('navigation-features') }}

--- a/springfield/cms/templates/cms/includes/flare-menus/features.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/features.html
@@ -17,9 +17,6 @@
     </span>
   </a>
   <div class="fl-menu-panel" id="fl-menu-panel-features" data-testid="menu-panel-features">
-    <button class="fl-menu-close-button">
-      <span class="fl-icon fl-icon-close fl-menu-close-button-content">{{ ftl('navigation-close-menu') }}</span>
-    </button>
     <div class="fl-menu-panel-content">
       <div class="fl-menu-panel-content-column">
         <ul>

--- a/springfield/cms/templates/cms/includes/flare-menus/resources.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/resources.html
@@ -8,10 +8,7 @@
 
 <li class="fl-menu-category" data-testid="menu-category-resources">
   <a
-    href="#"
     class="fl-menu-title"
-    aria-haspopup="true"
-    aria-controls="fl-menu-panel-resources"
     data-testid="navigation-link-resources"
   >
     <span class="fl-menu-heading">

--- a/springfield/cms/templates/cms/includes/flare-menus/resources.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/resources.html
@@ -20,10 +20,6 @@
     </span>
   </a>
   <div class="fl-menu-panel" id="fl-menu-panel-resources" data-testid="navigation-menu-resources">
-    <button class="fl-menu-close-button">
-      <span class="fl-icon fl-icon-close fl-menu-close-button-content">{{ ftl('navigation-close-menu') }}</span>
-    </button>
-
 
     <div class="fl-menu-panel-content">
       <div class="fl-menu-panel-content-column">


### PR DESCRIPTION
## One-line summary

The current nav menu is not fully keyboard accessible and has some issues for screen readers, so this PR fixes those issues without modifying the presentation or interaction pattern (except it removes the redundant close buttons).

## Significant changes and points to review

- **Since, the mobile and desktop views use the same markup (the major constraint for this approach), we need to apply the appropriate semantics for each view using JavaScript.**
    - On desktop, the category titles should be expand/collapse buttons (i.e. ARIA `button` role with an `aria-expanded` state).
        - `aria-haspopup` should not be used as these nav menus are not ARIA menus. `aria-haspopup=true` is a backwards compat equivalent to `aria-haspopup=menu` which expects that the target an ARIA `role=menu`. Those have particular expectations for focus management and keyboard shortcuts. These are not advisable for a site navigation.
    - On mobile, the category titles can just be text or a link.
        - Ideally, for this view they should be headings, but the entire mobile menu should be a modal `<dialog>`. For now, we can just present them as text/links.
    - It is easier to layer on button semantics on a `<a>` element than link/presention semantics on a `<button>`, so I’m using an `<a>` element for each of the category titles. Only *Features* is actually a link (i.e. it has an `href`). **On desktop, ARIA is used to apply button semantics.**
    - *In the future, it might be worth reconsidering if we want to use the same markup for the mobile and desktop nav, especially considering that we should be using a modal dialog for the mobile menu. There are some tricks using shadow DOM composition that could be leveraged to avoid markup duplication (e.g. re-slotting the light DOM content into a desktop/mobile specific structures).*
- This uses event delegation to avoid needing to add/remove many event listeners, especially as mobile and desktop have a different UX.
- The **close buttons were removed**. These provide little to no benefit for keyboard or assistive tech users as:
    1. The panels auto-close when focus leaves the panel.
        - Even if they didn’t auto close the original trigger can be used to close the panel and other triggers would cause the panels to close.
    2. The panels can be closed with <kbd>Escape</kbd> key — which is a standard user expectation.
- When opened with a keyboard, the “hover-to-open” interaction is ignored. The production site doesn’t do this, but it is quite annoying and unexpected.

## Issue / Bugzilla link

- https://mozilla-hub.atlassian.net/browse/WT-1289

## Testing

Compare against the current production deploy:

- Test keyboard navigation using the tab key and the <kbd>Escape</kbd> key.
- Test with a screen reader such as NVDA/JAWS/Narrator on Windows or VoiceOver on iOS or macOS or TalkBack on Android.
