### PR TITLE
Reject SVG uploads when sanitized output exceeds max size

### DIFF
--- a/springfield/cms/fields.py
+++ b/springfield/cms/fields.py
@@ -7,6 +7,7 @@ import os
 import re
 
 from django.core.exceptions import ValidationError
+from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
 
 import defusedxml.ElementTree as ET
@@ -136,6 +137,10 @@ class SanitizingWagtailImageField(WagtailImageField):
         )
 
         self.error_messages["svg_sanitization_error"] = _("Unable to process this SVG file. Please ensure it is a valid SVG.")
+
+        self.error_messages["svg_sanitized_too_large"] = _(
+            "This SVG file is too large after sanitization (%(file_size)s). Maximum filesize is %(max_filesize)s."
+        )
 
     def _is_svg_file(self, f) -> bool:
         """
@@ -286,6 +291,18 @@ class SanitizingWagtailImageField(WagtailImageField):
                 return ValidationError(
                     f"{self.error_messages['svg_sanitization_error']}: {ex}",
                     code="svg_sanitization_error",
+                )
+
+            # The upload size was validated before sanitization, but `filter_svg`
+            # can expand nested SVGs into a much larger file, so re-check it here.
+            if self.max_upload_size is not None and len(sanitized_content) > self.max_upload_size:
+                return ValidationError(
+                    self.error_messages["svg_sanitized_too_large"],
+                    code="svg_sanitized_too_large",
+                    params={
+                        "file_size": filesizeformat(len(sanitized_content)),
+                        "max_filesize": self.max_upload_size_text,
+                    },
                 )
 
             # Write the sanitized output back in place.

--- a/springfield/cms/tests/test_svg_sanitization.py
+++ b/springfield/cms/tests/test_svg_sanitization.py
@@ -478,7 +478,7 @@ class SVGSanitizationFieldTestCase(TestCase):
         self.assertEqual(svg_file.read(), CLEAN_SVG.encode("utf-8"))
 
     def test_deeply_nested_svg_rejected_when_sanitized_output_too_large(self):
-        """Regression: compact nested <g> SVG must not persist after ~1400x expansion."""
+        """Regression: compact nested <g> SVG must not persist after ~56x expansion."""
         compact = b"<svg xmlns='http://www.w3.org/2000/svg'>" + b"<g>" * 200 + b"<rect width='1' height='1'/>" + b"</g>" * 200 + b"</svg>"
         svg_file = SimpleUploadedFile(
             "nested.svg",

--- a/springfield/cms/tests/test_svg_sanitization.py
+++ b/springfield/cms/tests/test_svg_sanitization.py
@@ -457,3 +457,37 @@ class SVGSanitizationFieldTestCase(TestCase):
 
         # The encoded byte sequence from the fixture must not survive.
         self.assertNotIn(b"data:te&#x78;t/html", rewritten)
+
+    def test_sanitized_output_exceeding_max_upload_size_rejected(self):
+        """SVG whose sanitized output exceeds Wagtail max upload size is rejected."""
+        svg_file = SimpleUploadedFile(
+            "nested.svg",
+            CLEAN_SVG.encode("utf-8"),
+            content_type="image/svg+xml",
+        )
+        bloated = b"x" * 20_000
+
+        with mock.patch.object(self.field, "max_upload_size", 10_000):
+            with mock.patch("springfield.cms.fields.filter_svg", return_value=bloated):
+                result = self.field._sanitize_svg(svg_file)
+
+        self.assertIsInstance(result, ValidationError)
+        self.assertEqual(result.code, "svg_sanitized_too_large")
+        # Upload buffer must not be rewritten when rejected.
+        svg_file.seek(0)
+        self.assertEqual(svg_file.read(), CLEAN_SVG.encode("utf-8"))
+
+    def test_deeply_nested_svg_rejected_when_sanitized_output_too_large(self):
+        """Regression: compact nested <g> SVG must not persist after ~1400x expansion."""
+        compact = b"<svg xmlns='http://www.w3.org/2000/svg'>" + b"<g>" * 200 + b"<rect width='1' height='1'/>" + b"</g>" * 200 + b"</svg>"
+        svg_file = SimpleUploadedFile(
+            "nested.svg",
+            compact,
+            content_type="image/svg+xml",
+        )
+
+        with mock.patch.object(self.field, "max_upload_size", 50_000):
+            result = self.field._sanitize_svg(svg_file)
+
+        self.assertIsInstance(result, ValidationError)
+        self.assertEqual(result.code, "svg_sanitized_too_large")


### PR DESCRIPTION
After PR #1378, filter_svg output is persisted without a second size check. Deeply nested benign SVGs can expand far beyond Wagtail's upload limit. Re-validate len(sanitized_content) against max_upload_size before write-back and add regression tests.

## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
