### PR TITLE
WT-1252 expand domains for UTM addition

### DIFF
--- a/springfield/cms/templatetags/cms_tags.py
+++ b/springfield/cms/templatetags/cms_tags.py
@@ -103,7 +103,8 @@ def remove_tags(value: str) -> str:
 def add_utm_parameters(context: dict, value: str) -> str:
     """
     Appends UTM parameters to URLs that point to *.mozilla.org, *.mozillafoundation.org,
-    and *.firefox.com domains, except for www.firefox.com.
+    *.firefox.com, *.mozilla.ai, *.mozilla.vc, *.thunderbird.net, and *.mozilla.com
+    domains, except for www.firefox.com.
     """
 
     utm_parameters = context.get("utm_parameters", {})
@@ -116,7 +117,7 @@ def add_utm_parameters(context: dict, value: str) -> str:
         elif parsed_url.path:
             host = parsed_url.path.split("/")[0]
         pattern = re.compile(
-            r"^(\w+\.)?((mozilla.org)|(mozillafoundation.org)|(firefox.com))",
+            r"^(\w+\.)?((mozilla.org)|(mozillafoundation.org)|(firefox.com)|(mozilla.ai)|(mozilla.vc)|(thunderbird.net)|(mozilla.com))",
             re.IGNORECASE,
         )
         if host and host not in ["www.firefox.com", "firefox.com"] and pattern.match(host):

--- a/springfield/cms/templatetags/cms_tags.py
+++ b/springfield/cms/templatetags/cms_tags.py
@@ -104,7 +104,7 @@ def add_utm_parameters(context: dict, value: str) -> str:
     """
     Appends UTM parameters to URLs that point to *.mozilla.org, *.mozillafoundation.org,
     *.firefox.com, *.mozilla.ai, *.mozilla.vc, *.thunderbird.net, and *.mozilla.com
-    domains, except for www.firefox.com.
+    domains, except for www.firefox.com and firefox.com.
     """
 
     utm_parameters = context.get("utm_parameters", {})
@@ -117,9 +117,10 @@ def add_utm_parameters(context: dict, value: str) -> str:
         elif parsed_url.path:
             host = parsed_url.path.split("/")[0]
         pattern = re.compile(
-            r"^(\w+\.)?((mozilla.org)|(mozillafoundation.org)|(firefox.com)|(mozilla.ai)|(mozilla.vc)|(thunderbird.net)|(mozilla.com))",
+            r"^(\w+\.)?((mozilla\.org)|(mozillafoundation\.org)|(firefox\.com)|(mozilla\.ai)|(mozilla\.vc)|(thunderbird\.net)|(mozilla\.com))\Z",
             re.IGNORECASE,
         )
+        host = host.lower().rstrip(".")
         if host and host not in ["www.firefox.com", "firefox.com"] and pattern.match(host):
             query_string = parsed_url.query
             query = parse_qs(query_string)

--- a/springfield/cms/tests/test_templatetags.py
+++ b/springfield/cms/tests/test_templatetags.py
@@ -93,6 +93,22 @@ def test_remove_tags():
             "example.firefox.com/page",
             "example.firefox.com/page?utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign",
         ),
+        (
+            "https://example.mozilla.ai/page",
+            "https://example.mozilla.ai/page?utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign",
+        ),
+        (
+            "https://example.mozilla.vc/page",
+            "https://example.mozilla.vc/page?utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign",
+        ),
+        (
+            "https://example.thunderbird.net/page",
+            "https://example.thunderbird.net/page?utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign",
+        ),
+        (
+            "https://example.mozilla.com/page",
+            "https://example.mozilla.com/page?utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign",
+        ),
         ("https://www.firefox.com/page", "https://www.firefox.com/page"),
         ("www.firefox.com/page", "www.firefox.com/page"),
         ("firefox.com/page", "firefox.com/page"),
@@ -179,6 +195,22 @@ def test_richtext_parses_fxa_tag():
         ),
         (
             "example.firefox.com/page",
+            True,
+        ),
+        (
+            "example.mozilla.ai/page",
+            True,
+        ),
+        (
+            "example.mozilla.vc/page",
+            True,
+        ),
+        (
+            "example.thunderbird.net/page",
+            True,
+        ),
+        (
+            "example.mozilla.com/page",
             True,
         ),
         (


### PR DESCRIPTION
## One-line summary

This PR expands domains for UTM addition.

## Significant changes and points to review



## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1252

## Testing

1. edit any CMS page in Wagtail admin
2. update a URL to use any of the added domain
3. preview the link on the edited page
4. link should have the page slug as UTM campaign 