### PR TITLE
WT-1305 fix MS store badge size

### DIFF
--- a/media/css/cms/pages/flare26-download_all.css
+++ b/media/css/cms/pages/flare26-download_all.css
@@ -135,6 +135,10 @@
         line-height: 1;
     }
 
+    .download-ms-store-badge .ms-store-badge-img {
+        inline-size: 152px;
+    }
+
     @media (--viewport-xs) {
         /* Divider goes across entire first section */
         .fl-c-flow-steps {


### PR DESCRIPTION
## One-line summary

This PR fixes the overlarge Microsoft Store button on download/all page
 

## Significant changes and points to review

Microsoft Store button on download/all page

## Issue / Bugzilla link

[WT-1305](https://mozilla-hub.atlassian.net/browse/WT-1305)
https://github.com/mozmeao/springfield/issues/1348

## Testing

http://localhost:8000/en-US/download/all/desktop-release/win-store/