### PR TITLE
[WT-1250] Use `text-transform: uppercase` conditionally by language

### DIFF
--- a/media/css/cms/components/flare26-article.css
+++ b/media/css/cms/components/flare26-article.css
@@ -134,7 +134,10 @@ Stacked article list
 .fl-article-item .fl-superheading {
     color: var(--fl-theme-color-brand-text);
     font-size: var(--fl-theme-label-xs);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 /* =====================================================================
@@ -179,7 +182,10 @@ Related articles
 
 .fl-related-articles-header-link {
     font-size: var(--fl-theme-font-size-body-2xs);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 @media (--viewport-md-up) {

--- a/media/css/cms/components/flare26-banner.css
+++ b/media/css/cms/components/flare26-banner.css
@@ -126,10 +126,13 @@
 .fl-banner .fl-superheading {
     color: var(--fl-theme-color-link);
     font-size: var(--fl-theme-label-caps-sm);
-    letter-spacing: 0.0175rem;
     line-height: 1.2;
     margin-block-end: var(--token-spacing-md);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        letter-spacing: 0.0175rem;
+        text-transform: uppercase;
+    }
 }
 
 .fl-banner-media {

--- a/media/css/cms/components/flare26-card-gallery.css
+++ b/media/css/cms/components/flare26-card-gallery.css
@@ -39,7 +39,10 @@ Card Gallery - Flare 2026 Design System Card Gallery Component
     color: var(--fl-theme-card-superheading-color);
     font-size: var(--fl-theme-font-size-body-2xs);
     margin: 0;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-card-gallery-card .fl-buttons {

--- a/media/css/cms/components/flare26-card.css
+++ b/media/css/cms/components/flare26-card.css
@@ -109,7 +109,10 @@ Card Grid - Flare 2026 Design System Cards
     color: var(--fl-theme-card-superheading-color);
     font-size: var(--fl-theme-font-size-body-2xs);
     margin: 0;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-card-expand-link {
@@ -344,9 +347,12 @@ Sticker Card
     font-family: var(--fl-theme-font-family-body);
     font-size: var(--fl-theme-font-size-body-2xs);
     font-weight: var(--token-font-weight-medium);
-    letter-spacing: 0.02em;
     margin: 0 0 var(--token-spacing-xl);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+    }
 }
 
 .fl-sticker-card .fl-body > * {

--- a/media/css/cms/components/flare26-footer.css
+++ b/media/css/cms/components/flare26-footer.css
@@ -219,7 +219,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     max-inline-size: var(--token-width-desktop-layout);
     padding: var(--token-spacing-lg);
     position: relative;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-footer-secondary a:hover,

--- a/media/css/cms/components/flare26-intro.css
+++ b/media/css/cms/components/flare26-intro.css
@@ -39,7 +39,10 @@
 
 .fl-intro .fl-superheading {
     color: var(--fl-theme-color-link);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-intro .fl-heading,
@@ -190,7 +193,10 @@
     margin: 0 auto var(--token-spacing-xl);
     padding: var(--token-spacing-sm) var(--token-spacing-md);
     position: relative;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .superheading-is-pill .fl-superheading:has(a:hover) {
@@ -233,7 +239,10 @@
     font-style: normal;
     margin-inline-end: var(--token-spacing-sm);
     padding: var(--token-spacing-2xs) var(--token-spacing-xs);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-home-intro .fl-superheading {

--- a/media/css/cms/components/flare26-mediacontent.css
+++ b/media/css/cms/components/flare26-mediacontent.css
@@ -34,7 +34,10 @@
 .fl-mediacontent-content .fl-superheading {
     color: var(--fl-theme-color-brand-text);
     font-size: var(--fl-theme-label-caps-sm);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-mediacontent.is-narrow .fl-video {

--- a/media/css/cms/components/flare26-pencil-banner.css
+++ b/media/css/cms/components/flare26-pencil-banner.css
@@ -60,7 +60,10 @@
     font-style: normal;
     font-weight: var(--fl-theme-font-weight-headline);
     padding: var(--token-spacing-xs) var(--token-spacing-xs);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-pencil-banner-description {

--- a/media/css/cms/components/flare26-pricing-heading.css
+++ b/media/css/cms/components/flare26-pricing-heading.css
@@ -12,5 +12,8 @@
 
 .fl-pricing-heading .fl-superheading {
     margin: 0;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }

--- a/media/css/cms/components/flare26-roadmap-list-section.css
+++ b/media/css/cms/components/flare26-roadmap-list-section.css
@@ -80,7 +80,10 @@
     inline-size: max-content;
     line-height: 1;
     padding: var(--token-spacing-xs) var(--token-spacing-sm);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-roadmap-status::before {

--- a/media/css/cms/components/flare26-sliding-carousel.css
+++ b/media/css/cms/components/flare26-sliding-carousel.css
@@ -66,7 +66,10 @@
     color: var(--fl-theme-card-outline-superheading-color);
     font-size: var(--fl-theme-font-size-body-2xs);
     margin-block-end: var(--token-spacing-lg);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-sliding-carousel-control.is-active

--- a/media/css/cms/components/flare26-tag.css
+++ b/media/css/cms/components/flare26-tag.css
@@ -60,7 +60,9 @@ a.fl-tag:hover .fl-tag {
 }
 
 .fl-tag.is-uppercase {
-    text-transform: uppercase;
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 /* red */

--- a/media/css/cms/components/flare26-timeline.css
+++ b/media/css/cms/components/flare26-timeline.css
@@ -61,7 +61,10 @@
     color: var(--theme-numbered-list-counter-color);
     font-size: var(--fl-theme-font-size-subheading-xs);
     margin-block-end: var(--token-spacing-lg);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-two-column-card .fl-timeline-item .fl-heading-group {

--- a/media/css/cms/components/flare26-two-column-cards.css
+++ b/media/css/cms/components/flare26-two-column-cards.css
@@ -99,9 +99,12 @@
     inset-block-start: calc(var(--token-spacing-md) * -1);
     inset-inline-start: 50%;
     position: absolute;
-    text-transform: uppercase;
     transform: translateX(-50%);
     z-index: 1;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-two-column-card[class*='image-is-stuck'] {

--- a/media/css/cms/components/flare26-typography.css
+++ b/media/css/cms/components/flare26-typography.css
@@ -172,7 +172,9 @@ h2.fl-heading.fl-heading-sm {
 
 /* Label all caps class */
 .fl-label-allcaps {
-    text-transform: uppercase;
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-label-md.fl-label-allcaps {

--- a/media/css/cms/flare26-defaults.css
+++ b/media/css/cms/flare26-defaults.css
@@ -17,6 +17,17 @@ theme layer.
 
 html {
     font-size: var(--fl-theme-font-size-body-sm);
+
+    /**
+     * Only allow uppercase text transform for supported languages.
+     *
+     * Use a container style query to apply uppercase and related styles.
+     *
+     * See: https://mozilla-l10n.github.io/documentation/localization/dev_best_practices.html#css-issues
+     */
+    &:is(:lang(de), :lang(en), :lang(fr)) {
+        --lang-supports-uppercase: true;
+    }
 }
 
 body {

--- a/media/css/cms/flare26-utilities.css
+++ b/media/css/cms/flare26-utilities.css
@@ -44,7 +44,9 @@ style rules should have any fallbacks needed for IE8+ and Safari 12.1+
 }
 
 .fl-u-text-uppercase {
-    text-transform: uppercase;
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .hidden {

--- a/media/css/cms/pages/flare26-blog.css
+++ b/media/css/cms/pages/flare26-blog.css
@@ -56,7 +56,10 @@
     gap: var(--token-spacing-xs);
     position: relative;
     text-decoration: none;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-blog-topic-link:hover .fl-blog-topic-name {
@@ -70,7 +73,10 @@
 .fl-blog-topics-all {
     inline-size: 100%;
     margin-block-start: auto;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-article-back {
@@ -80,7 +86,10 @@
 .fl-blog-back-link {
     color: var(--fl-theme-color-link-fade);
     text-decoration: none;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-blog-back-link:hover {
@@ -95,7 +104,10 @@
     background-color: var(--notification-stacked-color);
     color: var(--notification-bg);
     font-size: var(--fl-theme-font-size-body-xs);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 .fl-tag.fl-blog-selected-topic .close-button {
@@ -236,7 +248,10 @@
     color: var(--fl-theme-color-brand-text);
     font-size: var(--fl-theme-label-xs);
     font-weight: var(--token-font-weight-medium);
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 /* More articles */
@@ -255,7 +270,10 @@
 .fl-blog-cards-list-link {
     font-size: var(--fl-theme-font-size-body-2xs);
     margin-inline-start: auto;
-    text-transform: uppercase;
+
+    @container style(--lang-supports-uppercase: true) {
+        text-transform: uppercase;
+    }
 }
 
 /* Pagination */


### PR DESCRIPTION
## One-line summary

`text-transform: uppercase` can have a negative effect for some locales, so instead we’ll apply it conditionally using `:lang()` and style queries (since `letter-spacing` is often paired with `text-transform`).

## Significant changes and points to review

This change only affects the Flare26 styles.

- `:lang(en)` works as a wildcard by default, so `en` will match `en-US`, `en-CA`, `en-GB`.
- Future syntax changes to `:lang()` that could be useful:
  - We can use comma-separated `:lang()` once it’s widely supported (e.g. `:lang(en, fr)`. Currently only Firefox and Safari supports this. https://caniuse.com/mdn-css_selectors_lang_argument_list
  - We can use a different wildcard format to target text based on script or other factors (e.g. `:lang(*-Latn)` will match latin script). Currently, Firefox and Safari support this. https://caniuse.com/mdn-css_selectors_lang_wildcards
- Uses a style query for the custom property matching `--lang-supports-uppercase: true`.
  - As style queries only recently became Baseline Newly Available as of Firefox 151 (https://caniuse.com/css-container-queries-style — the partial support is likely due to style queries originally being spec’d to support more than just custom properties, but custom properties are supported in all Baseline browsers), this means **Firefox versions prior to a few weeks ago will get the non-uppercased design. Since this is just stylistic, I think this is a good use of progressive enhancement.**
  
Future uses of uppercased text should use:

```css
.thing {
  @container style(--lang-supports-uppercase: true) {
    text-transform: uppercase;
    /* Then any additional design considerations for the uppercased text */
    letter-spacing: 0.02em;
  }
}
```

This is something we could add to the docs and perhaps create a lint rule for (I don’t know how easy it is to do custom stuff like that with Stylelint).

## Issue / Bugzilla link

- https://mozilla-hub.atlassian.net/browse/WT-1250
- https://github.com/mozmeao/springfield/issues/1426

## Testing

- Affected pages (incomplete list):
  - Global footer small legal links at the very bottom.
  - `/download/all/`
  - `/channel/desktop/developer/` “Firefox Developer Edition” eyebrow above “The browser made for developers” in second section.
  - `/features/protection/`, `/features/control/`, `/features/focus/`, `/user-privacy/` eyebrow in the main heading of the hero.