### PR TITLE
Switch to complex `:not()` notation

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -36,7 +36,6 @@
                 ]
             }
         ],
-        "selector-not-notation": "simple",
         "media-feature-range-notation": "prefix",
         "scss/operator-no-newline-after": null
     },

--- a/media/css/cms/components/flare26-button.css
+++ b/media/css/cms/components/flare26-button.css
@@ -61,13 +61,11 @@ Button - Flare 2026 Design System Buttons
     opacity: 1;
 }
 
-/* stylelint-disable-next-line selector-not-notation */
 .fl-button:not(:disabled, [disabled]):hover {
     background-color: var(--button-bg-color-hover);
     color: var(--button-text-color-hover);
 }
 
-/* stylelint-disable-next-line selector-not-notation */
 .fl-button:not(:disabled, [disabled]):active {
     background-color: var(--button-bg-color-active);
     border-color: var(--button-bg-color-active);

--- a/media/css/cms/components/flare26-button.css
+++ b/media/css/cms/components/flare26-button.css
@@ -381,7 +381,8 @@ I propose we move to "Filled (Primary)", "Outline (Secondary)", and
 }
 
 .fl-main
-    > .fl-buttons:not(.fl-buttons-spacing-large):not(
+    > .fl-buttons:not(
+        .fl-buttons-spacing-large,
         .fl-buttons-spacing-small
     ):last-of-type {
     margin-block-end: var(--token-layout-sm);

--- a/media/css/cms/components/flare26-media.css
+++ b/media/css/cms/components/flare26-media.css
@@ -91,7 +91,7 @@
     z-index: 1;
 }
 
-.fl-video:not(.fl-animation):not(.fl-video-is-animation) .fl-video-play-icon {
+.fl-video:not(.fl-animation, .fl-video-is-animation) .fl-video-play-icon {
     block-size: 48px;
     inline-size: 48px;
     inset-block-start: 50%;


### PR DESCRIPTION
## One-line summary

This drops our override of the `selector-not-notation` stylelint rule which was set to `simple` and goes with the default which is `complex`, since there is good enough support for it and it helps keep specificity in check as opposed to the `simple` rule which can cause ever increasing specificity.

## Significant changes and points to review

The `selector-not-notation` rule set to `simple` is mainly for backwards compatibility. For Bedrock this was added in 2022 (https://github.com/mozilla/bedrock/pull/12464). Since then `:not()` with a list of complex selectors is widely supported and we rely on newer selector like `:where()`.

Chaining `:not()` increases specificity and for situations where numerous values need to be set as different selectors, this means the specificity will increase by 0,1,0 for each option. An example is #1479 where each language is added would need `:not()` (e.g. `:not(:lang(en)):not(:lang(fr))`). In that PR, I could’ve used `:is()` within a single `:not()` to avoid that, but that’s just adding clutter and `:is()` is newer syntax than what the lint rule is trying to support.

I’ve push a commit that fixes the two cases that include chained `:not()` selectors. This does affect specificity so this could have an effect. We shouldn’t ignore the rev for the change since it does affect specificity (and is so small).

## Issue / Bugzilla link

None

## Testing

Run `npm run lint`. There should be no errors.