### PR TITLE
Revert essential campaign update

### DIFF
--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -51,13 +51,7 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
     DLSOURCE: 'fxdotcom',
     // This is an extra precaution to ensure we never mix essential and analytics campaigns
     // Any campaign can be added from the CMS, but Essential campaigns must be validated in code
-    ESSENTIAL_CAMPAIGNS: [
-        'rtamo',
-        'SET_AS_DEFAULT',
-        'smart_window',
-        'kick',
-        'sidekick'
-    ],
+    ESSENTIAL_CAMPAIGNS: ['rtamo', 'SET_AS_DEFAULT', 'smart_window'],
 
     /**
      * Custom event handler callback globals. These can be defined as functions when

--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -51,6 +51,8 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
     DLSOURCE: 'fxdotcom',
     // This is an extra precaution to ensure we never mix essential and analytics campaigns
     // Any campaign can be added from the CMS, but Essential campaigns must be validated in code
+    // Essential campaigns require coordination with product to provide a user-facing feature on download
+    // NOTE: new descriptive fields (i.e. "product_context", "install_options") will replace this shared use of campaign
     ESSENTIAL_CAMPAIGNS: ['rtamo', 'SET_AS_DEFAULT', 'smart_window'],
 
     /**


### PR DESCRIPTION
## One-line summary

Unnecessary update. Inline context for "essential" campaign and how it will evolve in future

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
n/a - the campaigns are not used with `force` attribute in CMS