### PR TITLE
Fix download as default campaign name

### DIFF
--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -53,7 +53,7 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
     // Any campaign can be added from the CMS, but Essential campaigns must be validated in code
     // Essential campaigns require coordination with product to provide a user-facing feature on download
     // NOTE: new descriptive fields (i.e. "product_context", "install_options") will replace this shared use of campaign
-    ESSENTIAL_CAMPAIGNS: ['rtamo', 'SET_AS_DEFAULT', 'smart_window'],
+    ESSENTIAL_CAMPAIGNS: ['rtamo', 'SET_DEFAULT_BROWSER', 'smart_window'],
 
     /**
      * Custom event handler callback globals. These can be defined as functions when

--- a/media/js/firefox/download/desktop/download-as-default-v2.es6.js
+++ b/media/js/firefox/download/desktop/download-as-default-v2.es6.js
@@ -5,7 +5,7 @@
  */
 
 const DownloadAsDefault = {};
-DownloadAsDefault.CAMPAIGN = 'SET_AS_DEFAULT';
+DownloadAsDefault.CAMPAIGN = 'SET_DEFAULT_BROWSER';
 
 window.Mozilla.DownloadAsDefault = DownloadAsDefault;
 

--- a/tests/playwright/specs/download-attribution/update.spec.js
+++ b/tests/playwright/specs/download-attribution/update.spec.js
@@ -346,7 +346,7 @@ test.describe.skip('essential download attribution', () => {
                 // Navigate to new page with different essential campaign
                 await page.addInitScript(
                     forceEssentialCampaign,
-                    'SET_AS_DEFAULT'
+                    'SET_DEFAULT_BROWSER'
                 );
 
                 await openPage(`/fr/?geo=fr`, page, browserName);
@@ -372,7 +372,9 @@ test.describe.skip('essential download attribution', () => {
                 const essentialCookieData = JSON.parse(
                     decodeURIComponent(essentialCookie.value)
                 );
-                expect(essentialCookieData.utm_campaign).toBe('SET_AS_DEFAULT');
+                expect(essentialCookieData.utm_campaign).toBe(
+                    'SET_DEFAULT_BROWSERT'
+                );
 
                 // Confirm new essential data was sent to stub attribution service
                 expect(capture.params.utm_campaign).toBe(

--- a/tests/playwright/specs/download-attribution/update.spec.js
+++ b/tests/playwright/specs/download-attribution/update.spec.js
@@ -373,7 +373,7 @@ test.describe.skip('essential download attribution', () => {
                     decodeURIComponent(essentialCookie.value)
                 );
                 expect(essentialCookieData.utm_campaign).toBe(
-                    'SET_DEFAULT_BROWSERT'
+                    'SET_DEFAULT_BROWSER'
                 );
 
                 // Confirm new essential data was sent to stub attribution service


### PR DESCRIPTION
## One-line summary

The correct name is `SET_DEFAULT_BROWSER` as described in original docs: https://mozmeao.github.io/platform-docs/firefox-downloads/desktop-download-as-default/

## Significant changes and points to review



## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1316


## Testing

In Windows OS, go to http://localhost:8000/ and confirm Set as default browser checkbox is checked (if it doesn't appear, go to CMS admin and check the SETTING for that first DOWNLOAD BUTTON block as the download as default option checked)

Check download attribution data has correct campaign name

<img width="1102" height="262" alt="set-default-browser" src="https://github.com/user-attachments/assets/c379515e-1af4-4ab9-942d-2644cad6e8ee" />
