### PR TITLE
Keep dlsource as essential field

### DIFF
--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -55,7 +55,7 @@ _STUB_VALUE_NAMES = [
     ("ua", "(not set)"),
     ("client_id_ga4", "(not set)"),
     ("session_id", "(not set)"),
-    ("dlsource", "(not set)"),
+    ("dlsource", "fxdotcom"),
 ]
 _STUB_VALUE_NAMES_LEGACY = [
     # name, default value
@@ -134,9 +134,6 @@ def stub_attribution_code(request):
     if waffle.switch("ENABLE_ATTRIBUTION_REFACTOR"):
         if not codes["client_id_ga4"] == "(not set)":
             # set basic defaults
-            if codes["dlsource"] == "(not set)":
-                codes["dlsource"] = "fxdotcom"
-
             if codes["medium"] == "(not set)":
                 codes["medium"] = "(direct)"
 


### PR DESCRIPTION
## One-line summary

This change has no effect when analytics is granted.
When analytics is denied, it continues to set `dlsource` as `fxdotcom` (a hardcoded string) to verify source of installation. 

## Significant changes and points to review



## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1318

## Testing
Pull prod data & run locally with US geo
http://localhost:8000/en-US/privacy/websites/cookie-settings/
- deny Analytics and save (confirm you have the `moz-consent-pref` cookie)

in non-Firefox browser, go to http://localhost:8000/en-US/smart-window/
- you should have the download view

Click download button

Check the network request & [decode](https://www.base64decode.org/) the `attribution_code` param to check you see the expected `dlsource`, `campaign` and no other set values