### PR TITLE
Fix failing local stub attribution code tests

### DIFF
--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -45,8 +45,8 @@ class TestStubAttributionCode(TestCase):
 
     def test_no_valid_param_names(self):
         final_params = {
-            "source": "www.firefox.com",
-            "medium": "(none)",
+            "source": "(not set)",
+            "medium": "(not set)",
             "campaign": "(not set)",
             "content": "(not set)",
             "experiment": "(not set)",
@@ -68,7 +68,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b85e2288e54169c8b3ffecc48ae53ffadcb899637c5d81320caaae16f25b04e",
+            "5b2e69aa3875d26f109f0501ac56ba3b817b39968ea72225541036f13fa572c7",
         )
 
     def test_no_valid_param_data(self):
@@ -82,8 +82,8 @@ class TestStubAttributionCode(TestCase):
             "dlsource": "fs<a>44fn</a>",
         }
         final_params = {
-            "source": "www.firefox.com",
-            "medium": "(none)",
+            "source": "(not set)",
+            "medium": "(not set)",
             "campaign": "(not set)",
             "content": "(not set)",
             "experiment": "(not set)",
@@ -105,11 +105,11 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b85e2288e54169c8b3ffecc48ae53ffadcb899637c5d81320caaae16f25b04e",
+            "5b2e69aa3875d26f109f0501ac56ba3b817b39968ea72225541036f13fa572c7",
         )
 
     def test_some_valid_param_data(self):
-        params = {"utm_source": "brandt", "utm_content": "ae<t>her", "dlsource": "fxdotcom"}
+        params = {"utm_source": "brandt", "utm_content": "ae<t>her", "dlsource": "fxdotcom", "session_id": "1234567890"}
         final_params = {
             "source": "brandt",
             "medium": "(direct)",
@@ -119,7 +119,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
-            "session_id": "(not set)",
+            "session_id": "1234567890",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -134,7 +134,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "1045ac6652da1cf26a16298192fb7c24fa7633008dd74f7b6ee70de104552cc4",
+            "4efe0673174ddf76e6150ae25c5156ebe111fdf1cbdbd83ebb55a4cabe2cdcb6",
         )
 
     def test_campaign_data_too_long(self):
@@ -238,7 +238,7 @@ class TestStubAttributionCode(TestCase):
         )
 
     def test_handles_referrer(self):
-        params = {"utm_source": "brandt", "referrer": "https://duckduckgo.com/privacy"}
+        params = {"utm_source": "brandt", "referrer": "https://duckduckgo.com/privacy", "session_id": "1234567890"}
         final_params = {
             "source": "brandt",
             "medium": "(direct)",
@@ -248,7 +248,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
-            "session_id": "(not set)",
+            "session_id": "1234567890",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -263,14 +263,11 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "1045ac6652da1cf26a16298192fb7c24fa7633008dd74f7b6ee70de104552cc4",
+            "4efe0673174ddf76e6150ae25c5156ebe111fdf1cbdbd83ebb55a4cabe2cdcb6",
         )
 
     def test_handles_referrer_no_source(self):
-        params = {
-            "referrer": "https://example.com:5000/searchin",
-            "utm_medium": "aether",
-        }
+        params = {"referrer": "https://example.com:5000/searchin", "utm_medium": "aether", "session_id": "1234567890"}
         final_params = {
             "source": "example.com:5000",
             "medium": "referral",
@@ -280,7 +277,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
-            "session_id": "(not set)",
+            "session_id": "1234567890",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -295,7 +292,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "1791839786fe22e61e20e570ff0860082b16527cc9f982564461d0b33afed4b8",
+            "ec97d9206561d925c778ddeeaf9e94e77dcd84b6d7f6698225ede54f70a3129b",
         )
 
     def test_handles_referrer_utf8(self):
@@ -305,7 +302,7 @@ class TestStubAttributionCode(TestCase):
         non-ascii domain names in the referrer. The allowed list for bouncer
         doesn't include any such domains anyway, so we should just ignore them.
         """
-        params = {"referrer": "http://youtubê.com/sorry/"}
+        params = {"referrer": "http://youtubê.com/sorry/", "session_id": "1234567890"}
         final_params = {
             "source": "www.firefox.com",
             "medium": "(none)",
@@ -315,7 +312,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id_ga4": "(not set)",
-            "session_id": "(not set)",
+            "session_id": "1234567890",
             "dlsource": "fxdotcom",
         }
         req = self._get_request(params)
@@ -330,7 +327,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b85e2288e54169c8b3ffecc48ae53ffadcb899637c5d81320caaae16f25b04e",
+            "126ffdd4c7959d0ff42e2dea728d4cf21edb70a79c186449b90d129d382ffb64",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -25,6 +25,7 @@ from springfield.firefox.views import detect_download_platform, download_redirec
     STUB_ATTRIBUTION_RATE=1,
     STUB_ATTRIBUTION_MAX_LEN=600,
 )
+@override_switch("ENABLE_ATTRIBUTION_REFACTOR", active=True)
 class TestStubAttributionCode(TestCase):
     def _get_request(self, params):
         rf = RequestFactory()

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -116,6 +116,7 @@ def stub_attribution_code(request):
     data = request.GET
     codes = OrderedDict()
     has_value = False
+    fallback_fields = ["medium", "source"]
     stub_value_names = _STUB_VALUE_NAMES if waffle.switch("ENABLE_ATTRIBUTION_REFACTOR") else _STUB_VALUE_NAMES_LEGACY
     for name, default_value in stub_value_names:
         val = data.get(name, "")
@@ -125,19 +126,21 @@ def stub_attribution_code(request):
 
         if val and STUB_VALUE_RE.match(val):
             codes[name] = val
-            has_value = True
+            if name in fallback_fields:
+                # we don't need the fallbacks
+                has_value = True
         else:
             codes[name] = default_value
 
     # Only provide default analytics data if analytics data is allowed
-    # (as indicated by set ga4 client value)
+    # (as indicated by set session_id value)
     if waffle.switch("ENABLE_ATTRIBUTION_REFACTOR"):
-        if not codes["client_id_ga4"] == "(not set)":
-            # set basic defaults
+        if not codes["session_id"] == "(not set)":
+            # set basic fallbacks
             if codes["medium"] == "(not set)":
                 codes["medium"] = "(direct)"
 
-            # try more advanced defaults
+            # try more advanced fallbacks
             if codes["source"] == "(not set)" and "referrer" in data:
                 try:
                     domain = urlparse(data["referrer"]).netloc


### PR DESCRIPTION
## One-line summary

Fixes local tests after updates to default python stub attribution code values

## Significant changes and points to review

Views update:
- Switch analytics granted check to look for session_id field rather than ga4 field (ga4 could be null and stripped out of request, session_id should always be set if analytics is granted)
- Only apply fallback values if analytics are granted and those fields are not set

Test update:
- When no session id, expect all fields except dlsource to be (not set)
- Add session_id param on tests where analytics fields should be set. In these cases, expectations should remain the same.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1323

## Testing
`pytest springfield/firefox/tests/test_views.py::TestStubAttributionCode` should show no errors