### PR TITLE
Enterprise and mobile design regressions

### DIFF
--- a/media/css/cms/components/flare26-section.css
+++ b/media/css/cms/components/flare26-section.css
@@ -78,3 +78,9 @@
 .fl-freeform-2026-page .fl-split-page-upper > .fl-section:first-child {
     padding-block-start: 0;
 }
+
+.fl-freeform-2026-page
+    .fl-split-page-upper
+    > .fl-section.fl-mobile-store-qr-section:first-child {
+    padding-block-start: var(--token-layout-lg);
+}

--- a/media/css/cms/pages/flare26-enterprise.css
+++ b/media/css/cms/pages/flare26-enterprise.css
@@ -44,6 +44,10 @@
         max-inline-size: 100%;
     }
 
+    .fl-2026-enterprise .fl-banner-container {
+        padding-inline: var(--fl-section-h-padding);
+    }
+
     .fl-2026-enterprise .fl-banner-kit .fl-heading,
     .fl-2026-enterprise .fl-banner-kit .fl-subheading {
         max-inline-size: 840px;
@@ -79,14 +83,6 @@
         text-align: center;
     }
 
-    .fl-2026-enterprise-documentation {
-        color: var(--fl-theme-color-brand-text);
-
-        .fl-heading {
-            color: var(--fl-theme-color-brand-text);
-        }
-    }
-
     .fl-2026-enterprise .fl-card-grid {
         padding: 0 var(--fl-section-h-padding);
     }
@@ -100,6 +96,10 @@
     .fl-section-download h2.fl-heading {
         margin: 60px auto;
         text-align: center;
+    }
+
+    .fl-card-grid + .fl-banner-container {
+        margin-block-start: var(--token-layout-md);
     }
 
     .fl-section-download .fl-body {

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -35,17 +35,12 @@
 {% block content %}
 <div class="{% if switch("flare26_enabled") %}fl-main has-gradient-bottom fl-2026-enterprise{% endif %}">
   {% if switch("flare26_enabled") %}
-    {% set superheading_text %}
-      <span class="fl-logo-fx"></span>
-    {% endset %}
-
     <div class="fl-section-container">
-    <include:intro slim vertical media_position="right">
+    <include:intro media_position="right">
       <content:heading>
         <include:heading
           level="h1"
-          superheading_text="{{superheading_text}}"
-          heading_size="fl-heading-size-1"
+          heading_size="fl-heading-lg"
           heading_text="{{ftl('firefox-enterprise-use-as-your-enterprise-browser')}}"
           subheading_text="{{ ftl('firefox-enterprise-secure-at-scale') }}"
         />
@@ -78,7 +73,7 @@
       <include:heading
         level="h2"
         heading_text="{{ ftl('firefox-enterprise-support-for-organizations') }}"
-        heading_size="fl-heading-size-2"
+        heading_size="fl-heading-lg"
         subheading_text="{{ ftl('firefox-enterprise-early-access-is-v2', fallback='firefox-enterprise-early-access-is') }}"
         subheading_size="fl-subheading-4"
       />
@@ -160,8 +155,7 @@
     </include:card>
   </include:cards-list>
   <include:banner
-      theme="outlined"
-      media_after="false"
+      theme="dark-purple-gradient-inverted"
     >
       <content:heading>
         <include:heading


### PR DESCRIPTION
Design regression fixes, and slight cleanup on https://www.firefox.com/en-US/browsers/enterprise/

<img width="1616" height="805" alt="Screenshot 2026-06-09 at 1 23 54 PM" src="https://github.com/user-attachments/assets/aeeca68d-689f-4074-a3ed-486d874c89a6" />

<img width="1657" height="1148" alt="Screenshot 2026-06-09 at 1 23 48 PM" src="https://github.com/user-attachments/assets/6d907058-9f6b-4b45-8a96-cda0a1f7459d" />

Top padding fix on mobile. I don't love the surgical fix here – we need to clean up some of these page-specific overrides. 

<img width="940" height="631" alt="Screenshot 2026-06-09 at 1 35 10 PM" src="https://github.com/user-attachments/assets/d5083873-d894-4f07-a0e3-955363a4f7ea" />
