### PR TITLE
Fix console errors when UI Tour isn't available

### DIFF
--- a/media/js/cms/components/flare26-conditional-display.es6.js
+++ b/media/js/cms/components/flare26-conditional-display.es6.js
@@ -74,7 +74,9 @@ function initDefaultBrowserConditionalDisplay() {
                 }
             });
         })
-        .catch();
+        .catch(() => {
+            /* UITour not available */
+        });
 }
 
 function initAiControlsConditionalDisplay() {
@@ -92,7 +94,9 @@ function initAiControlsConditionalDisplay() {
                 }
             });
         })
-        .catch();
+        .catch(() => {
+            /* UITour not available */
+        });
 }
 
 export default function setupConditionalDisplay() {

--- a/media/js/cms/components/flare26-ui-tour-helpers.es6.js
+++ b/media/js/cms/components/flare26-ui-tour-helpers.es6.js
@@ -7,6 +7,12 @@
 export const isUITourEnabled = function (timeout) {
     const delay = timeout || 500;
     return new window.Promise(function (resolve, reject) {
+        if (
+            !Mozilla ||
+            !Mozilla.UITour ||
+            typeof Mozilla.UITour.ping !== 'function'
+        )
+            return reject();
         const timer = window.setTimeout(reject, delay);
         Mozilla.UITour.ping(function () {
             window.clearTimeout(timer);


### PR DESCRIPTION
## One-line summary

Verify that UI Tour is defined before calling it, and handle the promise rejection on the call that verifies if UI Tour is enabled.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1341

## Testing

Open any page in Chrome (UI Tour isn't available) and check that no errors show up in the console