### PR TITLE
Fix double-prefixed primaryImageOfPage URL in homepage JSON-LD

### DIFF
--- a/springfield/cms/templates/cms/home_page.html
+++ b/springfield/cms/templates/cms/home_page.html
@@ -8,9 +8,9 @@
 
 {% block structured_data %}
 {%- if page and page.og_image %}
-{%- set og_image_url = settings.CANONICAL_URL ~ image(page.og_image, "width-1200").url %}
+{%- set og_image_url = image(page.og_image, "width-1200").url|absolute_url %}
 {%- else %}
-{%- set og_image_url = settings.CANONICAL_URL ~ static('img/firefox/flare/og.png') %}
+{%- set og_image_url = static('img/firefox/flare/og.png')|absolute_url %}
 {%- endif %}
 {%- set webpage_url = settings.CANONICAL_URL + '/' + CANONICAL_LANG + canonical_path %}
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary

The homepage's JSON-LD `WebPage` entity emits `primaryImageOfPage` with the site origin doubled:

```
"primaryImageOfPage": "https://www.firefox.comhttps://www.firefox.com/media/img/firefox/flare/og.4d50d9b1674b.png"
```

Introduced in #1376. `springfield/cms/templates/cms/home_page.html` builds the value by concatenating `settings.CANONICAL_URL` onto `static(...)` / `image(...).url`. In production those helpers resolve to absolute URLs (via the staticfiles/CDN backend), so the origin gets prepended a second time. The bug is invisible locally because `static()` returns a relative path in dev.

The neighboring `og:image` meta tag in the same page is correct because it routes through the existing `absolute_url` Jinja filter (`springfield/firefox/templatetags/misc.py`), which is idempotent — bare paths get `CANONICAL_URL` prepended, absolute URLs are returned unchanged.

## Fix

Route both branches of the `og_image_url` set in `home_page.html` through `|absolute_url` — same helper the og:image meta tag already uses.

```diff
 {%- if page and page.og_image %}
-{%- set og_image_url = settings.CANONICAL_URL ~ image(page.og_image, "width-1200").url %}
+{%- set og_image_url = image(page.og_image, "width-1200").url|absolute_url %}
 {%- else %}
-{%- set og_image_url = settings.CANONICAL_URL ~ static('img/firefox/flare/og.png') %}
+{%- set og_image_url = static('img/firefox/flare/og.png')|absolute_url %}
 {%- endif %}
```

Audited the other URL fields in the same JSON-LD emission: all hardcoded absolute URLs (Organization / Brand / WebSite / SoftwareApplication entries), and `webpage_url` is built from `canonical_path` (a path), so they're unaffected.

## Test plan

- [x] `pytest springfield/cms/tests/test_structured_data.py` — existing 6 tests still pass
- [x] `pre-commit run --files springfield/cms/templates/cms/home_page.html` clean
- [ ] After deploy: view-source on a prod-like environment, confirm `primaryImageOfPage` has exactly one `https://www.firefox.com` prefix
- [ ] Paste rendered JSON-LD into https://search.google.com/test/rich-results — no errors on `WebPage`
- [ ] Paste into https://validator.schema.org/ — no errors