### PR TITLE
WT-1215: Fixes for RTAMO download attribution

### DIFF
--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -63,6 +63,7 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
     timeoutCallback: undefined,
     requestComplete: false,
     inFlightXHR: null,
+    gettingAnalyticsData: false,
 
     /**
      * Determines if session falls within the predefined download attribution sample rate.
@@ -413,6 +414,10 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
      * @param {Object} data - utm params and referrer.
      */
     requestAuthentication: (data) => {
+        // Avoid unnecessary essential-only request if imminent essential + analytics request
+        if (DownloadAttribution.gettingAnalyticsData) {
+            return;
+        }
         // Cancel any prior in-flight request so a later trigger with a more
         // complete payload always wins
         if (DownloadAttribution.inFlightXHR) {
@@ -893,6 +898,7 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
                 return;
             }
 
+            DownloadAttribution.gettingAnalyticsData = true;
             DownloadAttribution.waitForGoogleAnalyticsThen(() => {
                 const params = new window._SearchParams();
                 const analytics = DownloadAttribution.getAnalyticsData(
@@ -909,6 +915,7 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
                     DownloadAttribution.COOKIE_ESSENTIAL_RAW_ID
                 );
 
+                DownloadAttribution.gettingAnalyticsData = false;
                 DownloadAttribution.requestCombinedAuth(essential, analytics);
 
                 if (analytics.client_id_ga4) {

--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -750,6 +750,13 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
         }
 
         if (!DownloadAttribution.hasValidData(combined)) {
+            // clean out raw cookies and do nothing
+            DownloadAttribution.removeRawCookie(
+                DownloadAttribution.COOKIE_ESSENTIAL_RAW_ID
+            );
+            DownloadAttribution.removeRawCookie(
+                DownloadAttribution.COOKIE_ANALYTICS_RAW_ID
+            );
             return;
         }
 

--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -639,6 +639,18 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
             pageCampaign &&
             DownloadAttribution.ESSENTIAL_CAMPAIGNS.includes(pageCampaign)
         ) {
+            // apply content and referrer for Return to AMO
+            // these fields are required for extra validation checks
+            if (pageCampaign === 'rtamo') {
+                const params = new window._SearchParams();
+                const utms = params.utmParams();
+
+                return {
+                    utm_content: utms.utm_content,
+                    referrer: document.referrer
+                };
+            }
+
             return {
                 utm_campaign: pageCampaign
             };

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -32,6 +32,7 @@ from wagtail_thumbnail_choice_block import ThumbnailRadioSelect
 
 from lib import l10n_utils
 from lib.l10n_utils.fluent import ftl, ftl_lazy
+from springfield.base import waffle
 from springfield.base.geo import get_country_from_request
 from springfield.cms.blocks import (
     HEADING_TEXT_FEATURES,
@@ -516,7 +517,10 @@ class ThanksPage(UTMParamsMixin, QRCodeFloatingSnippetMixin, AbstractSpringfield
 
     def get_template(self, request, *args, **kwargs):
         if request.GET.get("s") == "direct":
-            return "cms/thanks_page__direct.html"
+            if waffle.switch("ENABLE_ATTRIBUTION_REFACTOR"):
+                return "firefox/download/rtamo.html"
+            else:
+                return "cms/thanks_page__direct.html"
 
         return "cms/thanks_page.html"
 

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -357,6 +357,7 @@ class TestStubAttributionCode(TestCase):
 
 
 @override_settings(DEV=False)
+@override_switch("ENABLE_ATTRIBUTION_REFACTOR", active=True)
 @patch("springfield.firefox.views.l10n_utils.render", return_value=HttpResponse())
 class TestFirefoxDownload(TestCase):
     def test_post(self, render_mock):
@@ -462,7 +463,7 @@ class TestFirefoxDownload(TestCase):
         view = views.DownloadThanksView.as_view()
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/download/desktop/thanks_direct.html"]
+        assert template == ["firefox/download/rtamo.html"]
 
     @patch.object(views, "ftl_file_is_active", lambda *x: False)
     def test_thanks_basic_direct(self, render_mock):
@@ -471,7 +472,7 @@ class TestFirefoxDownload(TestCase):
         view = views.DownloadThanksView.as_view()
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/download/basic/thanks_direct.html"]
+        assert template == ["firefox/download/rtamo.html"]
 
     # end /thanks?s=direct URL - issue 10520
 

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -481,7 +481,7 @@ class DownloadThanksView(L10nTemplateView):
                 if waffle.switch("ENABLE_ATTRIBUTION_REFACTOR"):
                     template = "firefox/download/rtamo.html"
                 else:
-                    template = "firefox/download/basic/thanks_direct.html"
+                    template = "firefox/download/desktop/thanks_direct.html"
             else:
                 template = "firefox/download/desktop/thanks.html"
         else:

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -477,7 +477,10 @@ class DownloadThanksView(L10nTemplateView):
 
         if ftl_file_is_active("firefox/download/desktop") and experience != "basic":
             if source == "direct":
-                template = "firefox/download/desktop/thanks_direct.html"
+                if waffle.switch("ENABLE_ATTRIBUTION_REFACTOR"):
+                    template = "firefox/download/rtamo.html"
+                else:
+                    template = "firefox/download/basic/thanks_direct.html"
             else:
                 template = "firefox/download/desktop/thanks.html"
         else:

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -450,6 +450,7 @@ class DownloadThanksView(L10nTemplateView):
         "firefox/download/basic/thanks_direct.html": ["firefox/download/download"],
         "firefox/download/desktop/thanks.html": ["firefox/download/desktop"],
         "firefox/download/desktop/thanks_direct.html": ["firefox/download/desktop"],
+        "firefox/download/rtamo.html": ["firefox/download/desktop"],
     }
     activation_files = [
         "firefox/download/download",

--- a/tests/playwright/specs/download-attribution/create.spec.js
+++ b/tests/playwright/specs/download-attribution/create.spec.js
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe.skip('analytics download attribution', () => {
+test.describe('analytics download attribution', () => {
     test('has expected cookie values', async ({ page, browserName }) => {
         await page.addInitScript(mockGetGtagClientID);
 
@@ -379,8 +379,8 @@ test.describe.skip('analytics download attribution', () => {
     );
 });
 
-test.describe.skip('essential download attribution', () => {
-    const url = '/en-US/?geo=us';
+test.describe('essential download attribution', () => {
+    const url = '/en-US/?geo=fr';
 
     test('has expected cookie values', async ({ page, browserName }) => {
         await page.addInitScript(forceEssentialCampaign);
@@ -539,7 +539,7 @@ test.describe.skip('essential download attribution', () => {
     );
 });
 
-test.describe.skip('essential and analytics download attribution', () => {
+test.describe('essential and analytics download attribution', () => {
     const url =
         '/en-US/?geo=us&utm_source=newsletter&utm_campaign=test&utm_medium=email';
 

--- a/tests/playwright/specs/download-attribution/download-links.spec.js
+++ b/tests/playwright/specs/download-attribution/download-links.spec.js
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe.skip('attribution cookies exist', () => {
+test.describe('attribution cookies exist', () => {
     test('add to links', async ({ page, browserName }) => {
         await page.addInitScript(mockGetGtagClientID);
 
@@ -58,7 +58,7 @@ test.describe.skip('attribution cookies exist', () => {
     });
 });
 
-test.describe.skip('attribution cookies do not exist', () => {
+test.describe('attribution cookies do not exist', () => {
     test('download links unchanged', async ({ page, browserName }) => {
         await page.addInitScript(mockGetGtagClientID);
 

--- a/tests/playwright/specs/download-attribution/remove.spec.js
+++ b/tests/playwright/specs/download-attribution/remove.spec.js
@@ -20,7 +20,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe.skip('analytics download attribution', () => {
+test.describe('analytics download attribution', () => {
     test.describe(
         'user action denies consent',
         {
@@ -155,7 +155,7 @@ test.describe.skip('analytics download attribution', () => {
     );
 });
 
-test.describe.skip('essential download attribution', () => {
+test.describe('essential download attribution', () => {
     test.describe('new page with no essential data', () => {
         test('cookie removed', async ({ page, browserName }) => {
             const capture = { params: null };

--- a/tests/playwright/specs/download-attribution/update.spec.js
+++ b/tests/playwright/specs/download-attribution/update.spec.js
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
     await removeDownloadAsDefault(page);
 });
 
-test.describe.skip('analytics download attribution', () => {
+test.describe('analytics download attribution', () => {
     test.describe(
         'essential data added',
         {
@@ -211,7 +211,7 @@ test.describe.skip('analytics download attribution', () => {
     );
 });
 
-test.describe.skip('essential download attribution', () => {
+test.describe('essential download attribution', () => {
     test.describe(
         'analytics data added',
         {
@@ -385,7 +385,7 @@ test.describe.skip('essential download attribution', () => {
     );
 });
 
-test.describe.skip('conflict management', () => {
+test.describe('conflict management', () => {
     const url =
         '/en-US/?geo=us&utm_source=newsletter&utm_campaign=test&utm_medium=email';
 


### PR DESCRIPTION
## One-line summary

Return to AMO functionality should work for `www.firefox.com` links

## Significant changes and points to review

Template rendering
- when `s=direct` is in URL, all possible paths should render the `rtamo` template

FTL 
- `rtamo` template should use `download/desktop` FTL file

Validation
- the content is more important than the campaign for installer
   - when campaign is `rtamo`
       - essential only: add content param instead of campaign
       - essential and analytics: use UTM values (essential campaign will be used internally for validation, but UTM campaign will be passed to installer)

Order of operations
- if essential request happens first, and returns before analytics request is triggered, the download does not wait for analytics: it initiates as part of essential success callback, with essential-only information 
    - fix ensures essential-only flow is aware of incoming analytics request and does not proceed to make request. Only the combined essential + analytics request is made.

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1215


## Testing

Local
- remove [document.referrer](https://github.com/mozmeao/springfield/pull/1507/changes#diff-ffdc92868013461974feefe6c79bc4314c1c3c78056d486551683bf72fda3552R650) and hardcode `'https://addons.mozilla.org'` 

These URLs check CMS => rtamo template render (`rtamo` in HTML force campaign attribute)

consent required
go to http://localhost:8000/en-US/thanks/?s=direct&utm_campaign=amo-fx-cta-607454&utm_content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&utm_medium=referral&utm_source=addons.mozilla.org&geo=FR 
- [x] `attribution_code` attached to download link should include essential only information (content, dlsource)

consent not required
http://localhost:8000/en-US/thanks/?s=direct&utm_campaign=amo-fx-cta-607454&utm_content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&utm_medium=referral&utm_source=addons.mozilla.org&geo=US
- [x] `attribution_code` attached to download link should include essential + analytics information  (all UTMs, dlsource, session id, ga4 client id)

The following two checks should show `rtamo` in an HTML force campaign attribute

Static (non-CMS) => rtamo template
- [x] http://localhost:8000/fi/thanks/?s=direct&utm_campaign=amo-fx-cta-607454&utm_content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&utm_medium=referral&utm_source=addons.mozilla.org

Static (non-CMS) basic experience => rtamo template
- [x] http://localhost:8000/fi/thanks/?s=direct&utm_campaign=amo-fx-cta-607454&utm_content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&utm_medium=referral&utm_source=addons.mozilla.org&xv=basic

Demo 4
Setup [extension](https://docs.google.com/document/d/1cAUFF9hozAST2JyUlb7kiSdvyfocbFdfpOFGiOj4vXg/edit?tab=t.0#heading=h.pv18ccwnp44g) [moz only] to test with production addons site: download links should point to `www-demo4.springfield.moz.works/thanks`

Go to https://addons.mozilla.org/en-US/firefox/addon/amo-info/ in non-Firefox browser

Click download and check the following
- [x] the rendered demo page has `rtamo` campaign in HTML data attributes
- [x] the download auto-starts (network request has expected `attribution_code` param)
- [x] the try again download link has an `attribution_code` param that decodes to show content prefixed with `rta`

After deployed to prod (easier to test referer header from `www.firefox.com`)
- [ ] when download is loaded to [attribution reader](https://williamdurand.fr/fx-attribution-data-reader/), it shows the same attribution code data (i.e. content prefixed with `rta`)
- [ ] when download is opened, there is special onboarding to install the extension from the adds ons page
    - note: this requires the download link to have a [valid referrer](https://github.com/mozilla-services/stubattribution/blob/master/attributioncode/validator.go#L20) (`www.firefox.com`)
