### PR TITLE
Adding merch store to footer

### DIFF
--- a/l10n/en/footer-firefox.ftl
+++ b/l10n/en/footer-firefox.ftl
@@ -47,6 +47,8 @@ footer-learn = Learn
 footer-support = Support
 footer-addons = Add-ons
 footer-blog = Blog
+# Link to Mozilla's merch store. Link points to https://shop.mozilla.com/
+footer-merch-store = Merch store
 
 ## Links to social media
 

--- a/springfield/base/templates/includes/footer/footer.html
+++ b/springfield/base/templates/includes/footer/footer.html
@@ -61,6 +61,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-position="footer" data-link-text="Compare">{{ ftl('footer-compare') }}</a></li>
             <li><a href="{{ url('firefox.notes') }}" data-link-position="footer" data-link-text="Release Notes">{{ ftl('footer-release-notes') }}</a></li>
             <li><a href="{{ url('firefox.more.index') }}" data-link-position="footer" data-link-text="Learn">{{ ftl('footer-learn') }}</a></li>
+            <li><a href="https://shop.mozilla.com/{{params}}" data-link-position="footer" data-link-text="Merch Store">{{ ftl('footer-merch-store') }}</a></li>
             <li><a href="https://support.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/{{params}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
             <li><a href="https://community.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>

--- a/springfield/cms/templates/cms/includes/flare26-footer/resources.html
+++ b/springfield/cms/templates/cms/includes/flare26-footer/resources.html
@@ -12,6 +12,7 @@
     <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-position="footer" data-link-text="Compare">{{ ftl('footer-compare') }}</a></li>
     <li><a href="{{ url('firefox.notes') }}" data-link-position="footer" data-link-text="Release Notes">{{ ftl('footer-release-notes') }}</a></li>
     <li><a href="{{ url('firefox.more.index') }}" data-link-position="footer" data-link-text="Learn">{{ ftl('footer-learn') }}</a></li>
+    <li><a href="https://shop.mozilla.com/{{params}}" data-link-position="footer" data-link-text="Merch Store">{{ ftl('footer-merch-store') }}</a></li>
     <li><a href="https://support.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Support">{{ ftl('footer-support') }}</a></li>
     <li><a href="https://addons.mozilla.org/firefox/{{params}}" data-link-position="footer" data-link-text="Add ons">{{ ftl('footer-addons') }}</a></li>
     <li><a href="https://community.mozilla.org/{{params}}" data-link-position="footer" data-link-text="Community">{{ ftl('footer-community') }}</a></li>


### PR DESCRIPTION
## Summary

Adds a "Merch store" link to the firefox.com footer Resources section, between Learn and Support, pointing to https://shop.mozilla.com/.

- New Fluent string `footer-merch-store` in `l10n/en/footer-firefox.ftl`
- Link added to both the Flare26 footer (`flare26-footer/resources.html`) and the Protocol footer (`includes/footer/footer.html`) so it shows consistently across pages
- Outbound icon renders automatically via the existing `a[href^='http']::after` CSS in both footers — no markup or class needed
- Untranslated locales fall back to English until Pontoon syncs


## Test plan

- [ ] Load a Flare26 page (e.g. homepage) — "Merch store" appears between Learn and Support with the outbound icon, link goes to shop.mozilla.com with footer UTM params
- [ ] Load a Protocol-based page — same check
- [ ] `data-link-text="Merch Store"` and `data-link-position="footer"` present on the rendered `<a>` (for GA)
