### PR TITLE
Add condensed heading styles to smart window H1

### DIFF
--- a/springfield/cms/templates/cms/smart_window_page.html
+++ b/springfield/cms/templates/cms/smart_window_page.html
@@ -148,8 +148,8 @@
         <div class="fl-smart-window-intro-content">
           <hgroup class="fl-heading-group">
             <img src="/media/img/firefox/flare/smart-window-logo.svg" alt="Smart Window Icon" class="fl-smart-window-heading-logo">
-            <h1 class="fl-heading fl-heading-xl fl-smart-window-heading-default">{{ page.heading_text|richtext|remove_p_tag }}</h1>
-            <h1 class="fl-heading fl-heading-xl fl-smart-window-heading-success">{{ page.thank_you_heading|richtext|remove_p_tag }}</h1>
+            <h1 class="fl-heading fl-heading-xl fl-heading-condensed fl-smart-window-heading-default">{{ page.heading_text|richtext|remove_p_tag }}</h1>
+            <h1 class="fl-heading fl-heading-xl fl-heading-condensed fl-smart-window-heading-success">{{ page.thank_you_heading|richtext|remove_p_tag }}</h1>
             <p class="fl-subheading fl-smart-window-subheading-default">{{ page.subheading_text|richtext|remove_p_tag }}</p>
           </hgroup>
 


### PR DESCRIPTION
## One-line summary

This is a targeted fix for Smart Window case

## Significant changes and points to review

There's a bigger fix to consider around whether this is the desired default typography for all `fl-heading-xl` cases (similar to `fl-heading-lg`): https://github.com/mozmeao/springfield/blob/a0aaebf0ed87bbe37ecab23929403b9e9018420e/media/css/cms/components/flare26-typography.css#L27

## Issue / Bugzilla link
reported in slack


## Testing
http://localhost:8000/en-US/smart-window/ 
any view will show the updated H1 styles