### PR TITLE
Preserve query string in release-notes and sysreq redirects

### DIFF
--- a/springfield/releasenotes/tests/test_views.py
+++ b/springfield/releasenotes/tests/test_views.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from springfield.releasenotes.views import releases_index, show_android_sys_req
+from springfield.releasenotes.views import latest_notes, latest_sysreq, releases_index, show_android_sys_req
 
 
 @pytest.mark.parametrize(
@@ -161,3 +161,44 @@ def test_releases_index__product_other_than_firefox(render_mock, rf):
         "someproduct/releases/index.html",
         {"releases": []},
     )
+
+
+@pytest.mark.parametrize(
+    "view_func, url_method",
+    [
+        (latest_notes, "get_absolute_url"),
+        (latest_sysreq, "get_sysreq_url"),
+    ],
+)
+@patch("springfield.releasenotes.views.latest_release")
+def test_latest_redirects_preserve_query_params(view_func, url_method, latest_release_mock, rf):
+    mock_release = latest_release_mock.return_value
+    mock_release.get_sysreq_url.return_value = "/firefox/ios/152.0/system-requirements/"
+    mock_release.get_absolute_url.return_value = "/en-US/firefox/ios/152.0/releasenotes/"
+
+    request = rf.get("/?redirect_source=mozilla-org")
+    response = view_func(request)
+
+    assert response.status_code == 302
+    expected_url = getattr(mock_release, url_method)()
+    assert response.url == f"{expected_url}?redirect_source=mozilla-org"
+
+
+@pytest.mark.parametrize(
+    "view_func, url_method",
+    [
+        (latest_notes, "get_absolute_url"),
+        (latest_sysreq, "get_sysreq_url"),
+    ],
+)
+@patch("springfield.releasenotes.views.latest_release")
+def test_latest_redirects_without_query_params(view_func, url_method, latest_release_mock, rf):
+    mock_release = latest_release_mock.return_value
+    mock_release.get_sysreq_url.return_value = "/firefox/ios/152.0/system-requirements/"
+    mock_release.get_absolute_url.return_value = "/en-US/firefox/ios/152.0/releasenotes/"
+
+    request = rf.get("/")
+    response = view_func(request)
+
+    assert response.status_code == 302
+    assert response.url == getattr(mock_release, url_method)()

--- a/springfield/releasenotes/views.py
+++ b/springfield/releasenotes/views.py
@@ -244,13 +244,19 @@ def latest_release(product="firefox", platform=None, channel=None):
 @require_safe
 def latest_notes(request, product="firefox", platform=None, channel=None):
     release = latest_release(product, platform, channel)
-    return HttpResponseRedirect(release.get_absolute_url())
+    url = release.get_absolute_url()
+    if request.META.get("QUERY_STRING"):
+        url = f"{url}?{request.META['QUERY_STRING']}"
+    return HttpResponseRedirect(url)
 
 
 @require_safe
 def latest_sysreq(request, product="firefox", platform=None, channel=None):
     release = latest_release(product, platform, channel)
-    return HttpResponseRedirect(release.get_sysreq_url())
+    url = release.get_sysreq_url()
+    if request.META.get("QUERY_STRING"):
+        url = f"{url}?{request.META['QUERY_STRING']}"
+    return HttpResponseRedirect(url)
 
 
 @require_safe


### PR DESCRIPTION
## Description

When `latest_notes` or `latest_sysreq` redirect to the versioned release URL, the incoming query string is dropped. This causes the `redirect_source` parameter (used during the mozilla.org → firefox.com split) to be lost on the final hop.

Fixes #1520

## Changes

- **`springfield/releasenotes/views.py`**: Both `latest_notes` and `latest_sysreq` now append the incoming query string to the redirect target when present.
- **`springfield/releasenotes/tests/test_views.py`**: Added parameterized tests covering both views with and without query params.

## Testing

- `pytest springfield/releasenotes/tests/` passes
- The fix mirrors the [suggested approach](https://github.com/mozmeao/springfield/issues/1520#issue-2893495032) from the issue