### PR TITLE
adding a "horizontal slim" option to intro for CMS pages

### DIFF
--- a/media/css/cms/components/flare26-intro.css
+++ b/media/css/cms/components/flare26-intro.css
@@ -64,6 +64,11 @@
     max-inline-size: 1440px;
 }
 
+.fl-intro.is-horizontal-slim.fl-intro-media-left,
+.fl-intro.is-horizontal-slim.fl-intro-media-right {
+    max-inline-size: var(--token-width-desktop-wide-banner);
+}
+
 .fl-intro.fl-intro-media-left .fl-intro-content,
 .fl-intro.fl-intro-media-right .fl-intro-content {
     align-items: center;

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -2438,7 +2438,14 @@ class IntroBlockSettings(blocks.StructBlock):
         default=False,
         label="Slim Layout",
         inline_form=True,
-        help_text="Use a more compact layout with reduced spacing.",
+        help_text="Reduce vertical spacing around the section.",
+    )
+    horizontal_slim = blocks.BooleanBlock(
+        required=False,
+        default=False,
+        label="Horizontal Slim",
+        inline_form=True,
+        help_text="Narrow the section to a more compact horizontal width. Only applies to Media Left / Media Right layouts.",
     )
     anchor_id = blocks.CharBlock(
         required=False,
@@ -2450,7 +2457,7 @@ class IntroBlockSettings(blocks.StructBlock):
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Layout: {layout} - Slim: {slim} - Anchor ID: {anchor_id}"
+        label_format = "Layout: {layout} - Slim: {slim} - H-Slim: {horizontal_slim} - Anchor ID: {anchor_id}"
         form_classname = "compact-form struct-block"
 
 

--- a/springfield/cms/fixtures/intro_fixtures.py
+++ b/springfield/cms/fixtures/intro_fixtures.py
@@ -23,6 +23,7 @@ def get_intro_variants() -> list[dict]:
                 "settings": {
                     "layout": "vertical",
                     "slim": False,
+                    "horizontal_slim": False,
                     "anchor_id": "",
                 },
                 "media": [],
@@ -43,13 +44,14 @@ def get_intro_variants() -> list[dict]:
             },
             "id": "2026int1-0000-0000-0000-000000000001",
         },
-        # Media right layout, with image, anchor_id
+        # Media right layout, with image, anchor_id, horizontal_slim
         {
             "type": "intro",
             "value": {
                 "settings": {
                     "layout": "right",
                     "slim": False,
+                    "horizontal_slim": True,
                     "anchor_id": "intro-image-right",
                 },
                 "media": [
@@ -94,6 +96,7 @@ def get_intro_variants() -> list[dict]:
                 "settings": {
                     "layout": "left",
                     "slim": True,
+                    "horizontal_slim": False,
                     "anchor_id": "",
                 },
                 "media": [
@@ -133,6 +136,7 @@ def get_intro_variants() -> list[dict]:
                 "settings": {
                     "layout": "vertical",
                     "slim": False,
+                    "horizontal_slim": False,
                     "anchor_id": "intro-video",
                 },
                 "media": [videos["youtube"]],
@@ -159,6 +163,7 @@ def get_intro_variants() -> list[dict]:
                 "settings": {
                     "layout": "right",
                     "slim": False,
+                    "horizontal_slim": False,
                     "anchor_id": "",
                 },
                 "media": [videos["animation"]],
@@ -185,6 +190,7 @@ def get_intro_variants() -> list[dict]:
                 "settings": {
                     "layout": "left",
                     "slim": False,
+                    "horizontal_slim": False,
                     "anchor_id": "intro-qr-code",
                 },
                 "media": [

--- a/springfield/cms/fixtures/kit_intro_fixtures.py
+++ b/springfield/cms/fixtures/kit_intro_fixtures.py
@@ -32,6 +32,7 @@ def get_bottom_section() -> list[dict]:
             "settings": {
                 "layout": "vertical",
                 "slim": False,
+                "horizontal_slim": False,
                 "anchor_id": "",
             },
             "media": [],

--- a/springfield/cms/templates/cms/blocks/sections/intro.html
+++ b/springfield/cms/templates/cms/blocks/sections/intro.html
@@ -15,6 +15,7 @@
   anchor_id="{{ value.settings.anchor_id }}"
   vertical="{{ value.settings.layout == 'vertical' }}"
   slim="{{ value.settings.slim }}"
+  horizontal_slim="{{ value.settings.horizontal_slim }}"
   remove_border_radius="{{ value.settings.remove_border_radius }}"
   full_width="{{ value.settings.full_width }}"
 >

--- a/springfield/cms/templates/components/intro.html
+++ b/springfield/cms/templates/components/intro.html
@@ -10,6 +10,7 @@
   vertical=""
   full_width=""
   slim=""
+  horizontal_slim=""
   superheading_is_pill=False
   remove_border_radius=False
 #}
@@ -22,6 +23,7 @@
     {% if vertical %}fl-intro-vertical{% endif %}
     {% if full_width %}fl-intro-full-width{% endif %}
     {% if slim %}is-slim{% endif %}
+    {% if horizontal_slim and not vertical %}is-horizontal-slim{% endif %}
     {% if remove_border_radius %}remove-border-radius-from-media{% endif %}
     {% if superheading_is_pill %}superheading-is-pill{% endif %}
   "

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -1778,6 +1778,12 @@ def test_intro_block(index_page, placeholder_images, rf):
             else:
                 assert "is-slim" not in intro_classes
 
+            # Settings: horizontal_slim — only emitted on non-vertical layouts
+            if value["settings"]["horizontal_slim"] and value["settings"]["layout"] != "vertical":
+                assert "is-horizontal-slim" in intro_classes
+            else:
+                assert "is-horizontal-slim" not in intro_classes
+
             # Settings: anchor_id
             anchor_id = value["settings"]["anchor_id"]
             if anchor_id:


### PR DESCRIPTION
## Summary

Adds a "Horizontal Slim" toggle to the Intro block Settings that narrows media-left/right hero layouts from 1440px to 1170px (`--token-width-desktop-wide-banner`), addressing reports that the default hero feels too wide on large viewports.

## Screenshots

Before:
<img width="1915" height="1340" alt="image" src="https://github.com/user-attachments/assets/e91bd8ef-998a-4636-8989-c332fb1832a0" />

WIth Horizontal Slim:
<img width="1912" height="1344" alt="image" src="https://github.com/user-attachments/assets/62f0597a-187f-4b80-aa1e-1300b4766558" />


## Files affected

- `springfield/cms/blocks.py` — new `horizontal_slim` BooleanBlock on `IntroBlockSettings`; refined `slim` help_text; updated `label_format`
- `springfield/cms/templates/cms/blocks/sections/intro.html` — pass new prop to component
- `springfield/cms/templates/components/intro.html` — receive prop, emit `is-horizontal-slim` class (guarded to non-vertical layouts)
- `media/css/cms/components/flare26-intro.css` — new selector capping `.fl-intro.is-horizontal-slim` on media-left/right
- `springfield/cms/fixtures/intro_fixtures.py`, `kit_intro_fixtures.py` — add `horizontal_slim` to existing fixtures
- `springfield/cms/tests/test_blocks.py` — mirror assertion, aware of the vertical-layout guard

No data migration required — Wagtail fills missing keys with the BooleanBlock default (`False`) for existing pages.

## How to test

1. In Wagtail admin, open a `FreeFormPage2026` (or any page with an Intro block).
2. Edit an Intro block, set **Layout = Media Left** or **Media Right**, toggle **Horizontal Slim** on, save, publish.
3. View the page on a wide viewport (≥1440px). The hero wrapper should cap at 1170px instead of 1440px.
4. Confirm orthogonality:
   - **Horizontal Slim + Vertical layout**: no visual change (class is intentionally suppressed).
   - **Horizontal Slim + Full Width**: outer wrapper stays at 1170px; inner text column still fills it.
   - **Horizontal Slim + Slim Layout**: both effects compose — narrower wrapper *and* reduced vertical padding.
5. Run `pytest springfield/cms/tests/test_blocks.py` — 94 tests should pass.