### PR TITLE
Update essential RTAMO fields

### DIFF
--- a/media/js/base/download-attribution/download-attribution.es6.js
+++ b/media/js/base/download-attribution/download-attribution.es6.js
@@ -644,13 +644,14 @@ const DownloadAttribution = window.Mozilla.DownloadAttribution || {
             pageCampaign &&
             DownloadAttribution.ESSENTIAL_CAMPAIGNS.includes(pageCampaign)
         ) {
-            // apply content and referrer for Return to AMO
-            // these fields are required for extra validation checks
+            // Return to AMO requires extra fields for special validation
             if (pageCampaign === 'rtamo') {
                 const params = new window._SearchParams();
                 const utms = params.utmParams();
 
                 return {
+                    utm_campaign: utms.utm_campaign,
+                    utm_source: utms.utm_source,
                     utm_content: utms.utm_content,
                     referrer: document.referrer
                 };


### PR DESCRIPTION
## One-line summary

QA testing failed for the essential-only path. In order to get the expected AMO onboarding, we need to include more fields.

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
Consent required GEO: http://localhost:8000/en-US/thanks/?s=direct&utm_campaign=amo-fx-cta-607454&utm_content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&utm_medium=referral&utm_source=addons.mozilla.org&geo=FR

`attribution_code` param on download link decodes to include values for source, campaign, content, and dlsource
```
source=addons.mozilla.org&medium=(not set)&campaign=amo-fx-cta-607454&content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&experiment=(not set)&variation=(not set)&ua=(not set)&client_id_ga4=(not set)&session_id=(not set)&dlsource=fxdotcom
```

Not consent required GEO
http://localhost:8000/en-US/thanks/?s=direct&utm_campaign=amo-fx-cta-607454&utm_content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&utm_medium=referral&utm_source=addons.mozilla.org&geo=US
`attribution_code` param decodes to
```
source=addons.mozilla.org&medium=referral&campaign=amo-fx-cta-607454&content=rta%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ&experiment=(not set)&variation=(not set)&ua=chrome&client_id_ga4=XXXXX.XXXXX&session_id=XXXXX&dlsource=fxdotcom
```
(where X stands in for actual numbers)