### PR TITLE
WT-953 Fix enterprise links

### DIFF
--- a/springfield/cms/templates/cms/blocks/firefox-focus-button.html
+++ b/springfield/cms/templates/cms/blocks/firefox-focus-button.html
@@ -12,7 +12,7 @@
   label="{{ value.label }}"
   size_class="{{ value.size_class() }}"
   link="{{ link }}"
-  external="true"
+  external="{{ True }}"
   icon_name="{{ value.settings.icon }}"
   icon_position="{{ value.settings.icon_position }}"
   analytics_text="{{ block_text }}"

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -44,7 +44,7 @@
             label="{{ ftl('download-button-download') }}"
             link="#download"
             theme_class=""
-            external="false"
+            external="{{ False }}"
             icon_name="downloads"
             icon_position="right"
           />
@@ -76,7 +76,7 @@
           label="{{ ftl('firefox-enterprise-contact-sales') }}"
           link="https://qsurvey.mozilla.com/s3/firefox-support-plan?src=firefox-enterprise-cta"
           theme_class="button-tertiary"
-          external="false"
+          external="{{ False }}"
           alignment_class="fl-2026-enterprise-support"
         />
       </div>
@@ -166,7 +166,7 @@
             label="{{ ftl('firefox-enterprise-support-plan') }}"
             link="https://assets.mozilla.net/pdf/Firefox_Enterprise_Support_Plan.pdf"
             theme_class=""
-            external="false"
+            external="{{ False }}"
             icon_name="downloads"
             icon_position="right"
           />


### PR DESCRIPTION
## One-line summary

This PR fixes the issue that primary button renders with `target="_blank" rel="external noopener"` when it shouldn't.

## Significant changes and points to review

Boolean type will be preserved with `external="{{ True }}" ` or `external="{{ False }}"`  instead of a string type

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-953

## Testing

http://localhost:8000/en-US/browsers/enterprise/