### PR TITLE
Release workflow: stop hanging on retries after a no-op push to stage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,42 +319,39 @@ jobs:
           ref: ${{ needs.preflight-checks.outputs.release_sha }}
           message: "Pushing to Springfield stage"
 
-      - name: Push to stage and record push time
-        id: stage-push
+      - name: Push to stage
         env:
           RELEASE_SHA: ${{ needs.preflight-checks.outputs.release_sha }}
           GHA_PAT: ${{ secrets.SPRINGFIELD_GHA_RELEASE_WORKFLOW_PAT }}
         run: |
-          STAGE_PUSH_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "stage_push_time=${STAGE_PUSH_TIME}" >> "$GITHUB_OUTPUT"
           git remote set-url origin "https://x-access-token:${GHA_PAT}@github.com/mozmeao/springfield.git"
+          # No-op if stage already points at $RELEASE_SHA (e.g. retry of a partial prior run);
+          # the wait steps below tolerate that by reusing the existing build / test runs.
           git push origin "${RELEASE_SHA}:refs/heads/stage"
-          echo "Pushed $RELEASE_SHA to stage at $STAGE_PUSH_TIME"
+          echo "Pushed $RELEASE_SHA to stage"
 
       - name: Wait — Docker build for stage
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.preflight-checks.outputs.release_sha }}
-          STAGE_PUSH_TIME: ${{ steps.stage-push.outputs.stage_push_time }}
         run: |
-          echo "Waiting for build-and-push on stage for $RELEASE_SHA (after $STAGE_PUSH_TIME)..."
+          echo "Waiting for build-and-push on stage for $RELEASE_SHA..."
           TIMEOUT=3600
           INTERVAL=30
           ELAPSED=0
+          # Query is intentionally not time-filtered: a release retry against a SHA already on
+          # stage produces a no-op push and no fresh build run — we want the prior success.
           while [ $ELAPSED -lt $TIMEOUT ]; do
             RESULT=$(gh run list \
               --repo mozmeao/springfield \
               --workflow build-and-push.yml \
               --branch stage \
               --json headSha,conclusion,status,createdAt,updatedAt \
-              | jq --arg sha "$RELEASE_SHA" --arg since "$STAGE_PUSH_TIME" \
-                  '[.[] | select(.headSha == $sha) | select(.createdAt >= $since)]')
+              | jq --arg sha "$RELEASE_SHA" '[.[] | select(.headSha == $sha)]')
             CONCLUSION=$(echo "$RESULT" | jq -r '.[0].conclusion // empty')
             STATUS=$(echo "$RESULT" | jq -r '.[0].status // "not found"')
             if [ "$CONCLUSION" = "success" ]; then
-              STAGE_BUILD_DONE_TIME=$(echo "$RESULT" | jq -r '.[0].updatedAt')
-              echo "stage_build_done_time=${STAGE_BUILD_DONE_TIME}" >> "$GITHUB_ENV"
-              echo "✓ Docker build completed for stage (finished at $STAGE_BUILD_DONE_TIME)"
+              echo "✓ Docker build completed for stage"
               break
             elif [ -n "$CONCLUSION" ] && [ "$CONCLUSION" != "null" ]; then
               echo "::error::Docker build failed for stage (conclusion: $CONCLUSION)"
@@ -373,20 +370,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.preflight-checks.outputs.release_sha }}
-          STAGE_BUILD_DONE_TIME: ${{ env.stage_build_done_time }}
         run: |
-          echo "Waiting for 2 integration test runs on stage (dispatched after build at $STAGE_BUILD_DONE_TIME)..."
+          echo "Waiting for 2 integration test runs on stage for $RELEASE_SHA..."
           TIMEOUT=3600
           INTERVAL=30
           ELAPSED=0
           REQUIRED=2
+          # Query is intentionally not time-filtered: a release retry may rely on integration
+          # test runs that were dispatched (by external infra) during a prior partial run.
           while [ $ELAPSED -lt $TIMEOUT ]; do
             RUNS=$(gh run list \
               --repo mozmeao/springfield \
               --workflow integration_tests.yml \
               --json displayTitle,conclusion,status,createdAt \
-              | jq --arg sha "$RELEASE_SHA" --arg since "$STAGE_BUILD_DONE_TIME" \
-                  '[.[] | select(.displayTitle | contains("Integration tests for stage @ " + $sha)) | select(.createdAt >= $since)]')
+              | jq --arg sha "$RELEASE_SHA" \
+                  '[.[] | select(.displayTitle | contains("Integration tests for stage @ " + $sha))]')
             SUCCESS_COUNT=$(echo "$RUNS" | jq '[.[] | select(.conclusion == "success")] | length')
             FAILED_COUNT=$(echo "$RUNS" | jq '[.[] | select(.conclusion | . == "failure" or . == "cancelled" or . == "timed_out" or . == "startup_failure")] | length')
             TOTAL=$(echo "$RUNS" | jq 'length')


### PR DESCRIPTION
## Summary

- The stage build-wait and integration-tests-wait steps in the Release workflow each filter their `gh run list` queries by `createdAt >= <push time>` / `>= <build done time>`. That works on the happy path, but breaks on retries: if a prior release run already pushed the SHA to stage, the next push is a git no-op, no new `build-and-push` run fires, and the wait step hangs for the full 3600s timeout looking for a run that will never appear.
- Dropping the time filters from both stage wait queries lets the loop pick up the prior successful runs (or fail fast on a prior failure) instead of hanging. The `(workflow, branch=stage, headSha)` and `displayTitle "Integration tests for stage @ <sha>"` filters already pin the queries to the exact release, so the time filter was only ever protecting against an aliasing case that can't actually happen.
- Also removes the now-unused `STAGE_PUSH_TIME` / `STAGE_BUILD_DONE_TIME` plumbing and adds short comments in the two wait steps so a future reader doesn't "fix" the time filter back in.

Mirrors the equivalent change shipping in [mozilla/bedrock#17246](https://github.com/mozilla/bedrock/pull/17246), where the bug was hit in the wild.

Preflight (only observes main's existing build, doesn't push) and deploy-to-prod (each retry pushes a fresh date-suffixed tag, so the push always fires a fresh build event) don't have this bug and aren't touched.

## Test plan

- [ ] Confirm the next normal release run still proceeds through stage as before (happy path: fresh push → fresh build run picked up by the loop).
- [ ] Manually re-trigger Release against a SHA that's already on stage from a prior run and confirm the wait steps find the existing successful runs immediately rather than hanging.