### PR TITLE
Ignore `play()` rejections to stop Sentry noise

### DIFF
--- a/media/js/cms/pages/flare26-kick-page.es6.js
+++ b/media/js/cms/pages/flare26-kick-page.es6.js
@@ -48,11 +48,8 @@ const setupKickPage = () => {
     // play and pause to trigger the first frame to be loaded
     const playPromise = video.play();
     if (playPromise !== undefined) {
-        playPromise.catch((err) => {
-            if (err.name !== 'AbortError') {
-                // AbortError is expected when the browser cancels the fetch — ignore it
-                throw err;
-            }
+        playPromise.catch(() => {
+            // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
         });
     }
 

--- a/media/js/cms/pages/flare26-kick-page.es6.js
+++ b/media/js/cms/pages/flare26-kick-page.es6.js
@@ -46,7 +46,16 @@ const setupKickPage = () => {
     });
 
     // play and pause to trigger the first frame to be loaded
-    video.play();
+    const playPromise = video.play();
+    if (playPromise !== undefined) {
+        playPromise.catch((err) => {
+            if (err.name !== 'AbortError') {
+                // AbortError is expected when the browser cancels the fetch — ignore it
+                throw err;
+            }
+        });
+    }
+
     video.pause();
 };
 


### PR DESCRIPTION
## One-line summary
Sentry errors are flooding in due to video playing issues. This PR fixes it.

## Testing
- [ ] Open https://www.firefox.com/en-US/whatsnew/152/
- [ ] Open inspect element tools, console. Observe the error
- [ ] Open the debugger tab
- [ ] Right click the highlighted file in the image below and add script override saving the file somewhere
- [ ] Open the saved file and replace it with the ENTIRE file from https://github.com/mozmeao/springfield/blob/1cfc5a6da88ede361c4eb63281f0a714f92deebb/media/js/cms/pages/flare26-kick-page.es6.js
- [ ] Reload the page
- [ ] Hover over the logo in the top left and keep your mouse there. The animation should still play
- [ ] Open the console tab and observe the error has disappeared and doesn't come back if you refresh

<img width="403" height="424" alt="image" src="https://github.com/user-attachments/assets/bafabe4b-9f63-425d-8c4e-0809f0526ccc" />
