### PR TITLE
WT-1339: Firefox Enterprise Newsletter page

### DIFF
--- a/l10n/en/newsletter/newsletters.ftl
+++ b/l10n/en/newsletter/newsletters.ftl
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# This Source Code Form is subject to the terms of the { -brand-name-mozilla } Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 ### URL: https://www-dev.springfield.moz.works/newsletter/
 
 # Headline for /newsletter/
@@ -9,3 +13,20 @@ newsletters-make-the-most = Make the most out of { -brand-name-firefox }
 
 # Subtitle for /newsletter/
 newsletters-sign-up-to-receive-monthly = Sign up to receive monthly updates from { -brand-name-firefox } and internet trends that shape your life online.
+
+# Enterprise
+
+newsletter-enterprise-title = Subscribe to { -brand-name-mozilla } Enterprise Updates
+newsletter-enterprise-description = Stay informed about { -brand-name-firefox } Enterprise, { -brand-name-firefox } for Organizations Support, as well as relevant webinars, events, and product updates for IT, security, and compliance professionals.
+newsletter-enterprise-description-consent = You decide which topics { -brand-name-mozilla } Enterprise may contact you about by email. After submitting this form, you will receive a confirmation email. You will only be added to the mailing list after confirming your email address.
+newsletter-enterprise-description-note = Note: Your subscription is voluntary and can be withdrawn at any time.
+
+# Consent checkbox label in the enterprise newsletter form
+newsletter-enterprise-form-consent = I would like to receive emails from { -brand-name-mozilla } Enterprise about the topics I selected above.
+newsletter-enterprise-form-consent-details = These emails may include information about { -brand-name-firefox } Enterprise, { -brand-name-firefox } for Organizations Support, webinars, events, product updates, and feature updates for IT, security, and compliance topics. I can withdraw my consent at any time with effect for the future.
+
+# Privacy notice section below the enterprise newsletter form
+newsletter-enterprise-privacy-statement = { -brand-name-mozilla } will process the information you provide in order to send you the selected email communications and to document your consent. Further information is available in { -brand-name-mozilla }'s privacy notice.
+newsletter-enterprise-privacy-link = Privacy Notice
+newsletter-enterprise-legal-link = Legal Notice
+newsletter-enterprise-contact-link = Contact

--- a/media/css/cms/components/flare26-newsletterform.css
+++ b/media/css/cms/components/flare26-newsletterform.css
@@ -37,6 +37,16 @@
         display: grid;
         grid-template-columns: 1fr 1fr;
     }
+
+    .enterprise-newsletter-page
+        .fl-newsletterform-cta:has(.fl-newsletterform-illustration) {
+        align-items: start;
+        grid-template-columns: 1fr 2fr;
+    }
+
+    .enterprise-newsletter-page .fl-newsletterform-content {
+        max-inline-size: 600px;
+    }
 }
 
 .fl-newsletterform-illustration {

--- a/media/css/cms/components/flare26-newsletterform.css
+++ b/media/css/cms/components/flare26-newsletterform.css
@@ -324,3 +324,7 @@
 .newsletter-page .fl-newsletterform-cta {
     padding-block-start: var(--token-layout-xl);
 }
+
+.fl-newsletter-enterprise .fl-newsletterform-consent {
+    text-align: start;
+}

--- a/media/js/cms/contact-form.js
+++ b/media/js/cms/contact-form.js
@@ -23,8 +23,20 @@
         }
     }
 
+    function setCorrectLeadSource() {
+        var leadSourceQueryParam = new URLSearchParams(
+            window.location.search
+        ).get('ls');
+        var leadSourceInput = document.querySelector('input[name=lead_source]');
+        if (!leadSourceInput || !leadSourceQueryParam) {
+            return;
+        }
+        leadSourceInput.value = leadSourceQueryParam;
+    }
+
     function init() {
         window.setTimeout(setCorrectFormAction, 3000);
+        window.setTimeout(setCorrectLeadSource, 3000);
     }
 
     if (document.readyState !== 'loading') {

--- a/springfield/cms/templates/cms/newsletter_enterprise_form.html
+++ b/springfield/cms/templates/cms/newsletter_enterprise_form.html
@@ -1,0 +1,124 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "newsletter/includes/macros.html" import email_form_thankyou with context %}
+
+{% if not success %}
+  <form id="newsletter-form" class="fl-newsletterform fl-newsletter-enterprise" action="{{ action }}" method="post" novalidate data-testid="newsletter-form">
+    {% if not is_multi_newsletter_form %}
+      <div hidden>
+        {{ form.newsletters|safe }}
+      </div>
+    {% endif %}
+    <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
+
+    <div class="fl-newsletterform-field">
+      <label class="fl-newsletterform-label" for="newsletter-email">{{ email_label|d(ftl('newsletter-form-your-email-address'), true) }}</label>
+      {% if email_placeholder %}
+        {% set placeholder = email_placeholder %}
+      {% else %}
+        {% set placeholder = ftl('newsletter-form-yournameexamplecom', fallback='newsletter-form-your-email-here') %}
+      {% endif %}
+      <input id="newsletter-email" class="fl-newsletterform-input" type="email" name="email" placeholder="{{ placeholder }}" autocomplete="email" data-testid="newsletter-email-input" />
+    </div>
+
+    {% if not include_language %}
+      <input type="hidden" name="lang" id="id_lang" value="en">
+    {% endif %}
+
+    <div id="newsletter-details" class="fl-newsletterform-details fl-newsletterform-row-hidden">
+      {% if include_country %}
+        <div class="fl-newsletterform-field">
+          <label for="{{ form.country.id_for_label }}" class="fl-newsletterform-label">{{ form.country.label }}</label>
+          <select class="fl-newsletterform-select" name="{{ form.country.name }}" id="{{ form.country.id_for_label }}" data-testid="newsletter-country-select">
+            <option value="" disabled selected>{{ ftl('newsletter-form-please-select-country') }}</option>
+            {% for choice in form.country.field.choices %}
+            {% if choice.0 %}
+            <option value="{{ choice.0 }}">{{ choice.1 }}</option>
+            {% endif %}
+            {% endfor %}
+          </select>
+          <svg class="fl-newsletterform-select-arrow" width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M4 6L8 10L12 6" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </div>
+      {% endif %}
+
+      {% if include_language %}
+      <div class="fl-newsletterform-field">
+        <label for="{{ form.lang.id_for_label }}" class="fl-newsletterform-label">{{ form.lang.label }}</label>
+        {% if LANG.startswith('en-') %}
+          {% set lang_default = 'en' %}
+        {% else %}
+          {% set lang_default = LANG %}
+        {% endif %}
+        <select class="fl-newsletterform-select" name="{{ form.lang.name }}" id="{{ form.lang.id_for_label }}">
+          {% for choice in form.lang.field.choices %}
+            {% if choice.0 %}
+              <option value="{{ choice.0 }}" {% if choice.0== lang_default  %}selected{% endif %}>{{ choice.1 }}</option>
+            {% endif %}
+          {% endfor %}
+        </select>
+        <svg class="fl-newsletterform-select-arrow" width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M4 6L8 10L12 6" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </div>
+      {% endif %}
+
+      <div class="fl-newsletterform-consent">
+        <label for="newsletter-privacy" class="fl-body fl-newsletterform-checkbox-label">
+          <input type="checkbox" id="newsletter-privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox">
+          <span class="fl-newsletterform-checkbox-text">{{ ftl('newsletter-enterprise-form-consent') }}</span>
+        </label>
+        <p class="fl-body">{{ ftl('newsletter-enterprise-form-consent-details') }}</p>
+        <div class="fl-newsletterform-privacy-notice">
+          <p class="fl-body">{{ ftl('newsletter-enterprise-privacy-statement') }}</p>
+          <p class="fl-body">
+            <a href="https://www.mozilla.org/privacy/websites/">{{ ftl('newsletter-enterprise-privacy-link') }}</a> |
+            <a href="https://www.mozilla.org/about/legal/terms/firefox/">{{ ftl('newsletter-enterprise-legal-link') }}</a> |
+            <a href="https://connect.mozilla.org/?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-enterprise-news">{{ ftl('newsletter-enterprise-contact-link') }}</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <button
+     id="newsletter-submit"
+     data-testid="newsletter-submit-button"
+     class="fl-button"
+     type="submit"
+     disabled
+     {% if analytics_id %}
+      data-cta-position="{{ analytics_position }}"
+      data-cta-text="{{ analytics_text }}"
+      data-cta-uid="{{ analytics_id }}"
+     {% endif %}
+    >{{ ftl('newsletter-form-button-cta') }}</button>
+    <div class="fl-body fl-newsletterform-feedback fl-newsletterform-error mzp-c-form-errors hidden" id="newsletter-errors" data-testid="newsletter-error-message">
+      <ul class="fl-newsletterform-error-list mzp-u-list-styled">
+        <li class="error-email-invalid hidden">{{ ftl('newsletter-form-please-enter-a-valid') }}</li>
+        <li class="error-try-again-later hidden">{{ ftl('newsletter-form-we-are-sorry-but-there') }}</li>
+      </ul>
+    </div>
+  </form>
+  <div id="newsletter-thanks" class="fl-newsletterform-success hidden" data-testid="newsletter-thanks-message"
+       {% if thankyou_head %}aria-label="{{ thankyou_head }}" {% endif %}
+       {% if thankyou_content %}aria-description="{{ thankyou_content }}" {% endif %}>
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <circle cx="40" cy="40" r="40" fill="white" />
+      <path d="M28 40L36 48L52 32" stroke="black" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
+    </svg>
+  </div>
+
+{% elif use_thankyou %}
+  <div class="fl-newsletterform-thanks">
+    {% if thankyou_content %}
+      <h3>{{ thankyou_head }}</h3>
+      <p>{{ thankyou_content }}</p>
+    {% else %}
+      {{ email_form_thankyou() }}
+    {% endif %}
+  </div>
+{% endif %}

--- a/springfield/cms/templates/components/newsletter-form.html
+++ b/springfield/cms/templates/components/newsletter-form.html
@@ -5,7 +5,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set template = template or "cms/newsletter_form.html" %}
+{% set form_template = form_template or "cms/newsletter_form.html" %}
 
 <div class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
   <div class="fl-newsletterform-illustration">
@@ -17,7 +17,7 @@
 
     {{ email_newsletter_form(
       newsletters=newsletters,
-      template=template,
+      template=form_template,
       include_country=true,
       include_language=true,
       footer=false,

--- a/springfield/cms/templates/components/newsletter-form.html
+++ b/springfield/cms/templates/components/newsletter-form.html
@@ -5,6 +5,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% set template = template or "cms/newsletter_form.html" %}
+
 <div class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
   <div class="fl-newsletterform-illustration">
     <img alt="" loading="lazy" src="/media/img/firefox/flare/kit-on-rock.png" />

--- a/springfield/cms/templates/components/newsletter-form.html
+++ b/springfield/cms/templates/components/newsletter-form.html
@@ -15,11 +15,12 @@
 
     {{ email_newsletter_form(
       newsletters=newsletters,
-      template="cms/newsletter_form.html",
+      template=template,
       include_country=true,
       include_language=true,
       footer=false,
       include_title=false
     ) }}
+
   </div>
 </div>

--- a/springfield/newsletter/templates/newsletter/enterprise.html
+++ b/springfield/newsletter/templates/newsletter/enterprise.html
@@ -1,0 +1,33 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "cms/base-flare26.html" %}
+
+{% set page_title_copy = ftl('newsletter-enterprise-title') %}
+{% set page_desc_copy = ftl('newsletter-enterprise-description') %}
+
+{% block page_title %}{{ page_title_copy }}{% endblock page_title %}
+{% block page_desc %}{{ page_desc_copy }}{% endblock %}
+
+{% block body_class %}{{ super() }} newsletter-mozilla{% endblock %}
+
+{% block content %}
+<div class="fl-main has-gradient-bottom newsletter-page">
+  {% set newsletters="firefox-enterprise-news" %}
+  {% set template="cms/newsletter_enterprise_form.html" %}
+
+  <include:newsletter-form>
+    <include:heading
+      level="h2"
+      heading_size="fl-heading-size-3"
+      heading_text="{{ page_title_copy }}"
+    />
+    <p class="fl-subheading">{{ ftl('newsletter-enterprise-description') }}</p>
+    <p class="fl-subheading">{{ ftl('newsletter-enterprise-description-consent') }}</p>
+    <p class="fl-subheading">{{ ftl('newsletter-enterprise-description-note') }}</p>
+  </include:newsletter-form>
+</div>
+{% endblock %}

--- a/springfield/newsletter/templates/newsletter/enterprise.html
+++ b/springfield/newsletter/templates/newsletter/enterprise.html
@@ -15,7 +15,7 @@
 {% block body_class %}{{ super() }} newsletter-mozilla{% endblock %}
 
 {% block content %}
-<div class="fl-main has-gradient-bottom newsletter-page">
+<div class="fl-main has-gradient-bottom newsletter-page enterprise-newsletter-page">
   {% set newsletters="firefox-enterprise-news" %}
   {% set template="cms/newsletter_enterprise_form.html" %}
 

--- a/springfield/newsletter/templates/newsletter/enterprise.html
+++ b/springfield/newsletter/templates/newsletter/enterprise.html
@@ -17,7 +17,7 @@
 {% block content %}
 <div class="fl-main has-gradient-bottom newsletter-page">
   {% set newsletters="firefox-enterprise-news" %}
-  {% set template="cms/newsletter_enterprise_form.html" %}
+  {% set form_template="cms/newsletter_enterprise_form.html" %}
 
   <include:newsletter-form>
     <include:heading

--- a/springfield/newsletter/templates/newsletter/index.html
+++ b/springfield/newsletter/templates/newsletter/index.html
@@ -39,8 +39,6 @@
 
 {% block content %}
 <div class="fl-main has-gradient-bottom newsletter-page">
-  {% set template="cms/newsletter_form.html" %}
-
   <include:newsletter-form>
     <include:heading
       level="h2"

--- a/springfield/newsletter/templates/newsletter/index.html
+++ b/springfield/newsletter/templates/newsletter/index.html
@@ -39,6 +39,8 @@
 
 {% block content %}
 <div class="fl-main has-gradient-bottom newsletter-page">
+  {% set template="cms/newsletter_enterprise_form.html" %}
+
   <include:newsletter-form>
     <include:heading
       level="h2"

--- a/springfield/newsletter/templates/newsletter/index.html
+++ b/springfield/newsletter/templates/newsletter/index.html
@@ -39,7 +39,7 @@
 
 {% block content %}
 <div class="fl-main has-gradient-bottom newsletter-page">
-  {% set template="cms/newsletter_enterprise_form.html" %}
+  {% set template="cms/newsletter_form.html" %}
 
   <include:newsletter-form>
     <include:heading

--- a/springfield/newsletter/urls.py
+++ b/springfield/newsletter/urls.py
@@ -13,4 +13,9 @@ urlpatterns = (
         ),
         name="newsletter",
     ),
+    path(
+        "newsletter/enterprise/",
+        VariationTemplateView.as_view(template_name="newsletter/enterprise.html", ftl_files=["newsletter/newsletters"]),
+        name="newsletter-enterprise",
+    ),
 )


### PR DESCRIPTION
## One-line summary

This PR adds a new Firefox Enterprise Newsletter page. It also enables passing an `ls` query param to override the `lead_source` field on contact forms.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1339

## Testing

Open the new newsletter page (http://localhost:8000/en-US/newsletter/enterprise/) and double check that the content and the submit request are correct.
Open the test contact page (http://localhost:8000/en-US/flare-docs/pages/test-contact-page/) with and without the `ls` query param and chech that the `lead_source` field value changes when it's present.