### PR TITLE
Ignore logo mouseover errors

### DIFF
--- a/media/js/cms/pages/flare26-kick-page.es6.js
+++ b/media/js/cms/pages/flare26-kick-page.es6.js
@@ -38,7 +38,12 @@ const setupKickPage = () => {
     logoLink.appendChild(wrapper);
 
     video.addEventListener('mouseover', () => {
-        video.play();
+        const playPromise = video.play();
+        if (playPromise !== undefined) {
+            playPromise.catch(() => {
+                // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
+            });
+        }
     });
     video.addEventListener('mouseout', () => {
         video.pause();

--- a/media/js/cms/pages/flare26-kick-page.es6.js
+++ b/media/js/cms/pages/flare26-kick-page.es6.js
@@ -33,36 +33,26 @@ const setupKickPage = () => {
     source.src = 'https://assets.mozilla.net/wc/logo-1-alpha.webm';
     source.type = 'video/webm';
 
-    let playPromise;
-
     video.appendChild(source);
     wrapper.appendChild(video);
     logoLink.appendChild(wrapper);
 
-    video.addEventListener('mouseover', () => {
-        playPromise = video.play();
-        if (playPromise !== undefined) {
-            playPromise.catch(() => {
-                // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
+    video.addEventListener(
+        'canplaythrough',
+        () => {
+            video.addEventListener('mouseover', () => {
+                video.play();
             });
-        }
-    });
-
-    video.addEventListener('mouseout', () => {
-        if (playPromise !== undefined) {
-            playPromise
-                .then(() => {
-                    video.pause();
-                    video.currentTime = 0;
-                })
-                .catch(() => {
-                    // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
-                });
-        }
-    });
+            video.addEventListener('mouseout', () => {
+                video.pause();
+                video.currentTime = 0;
+            });
+        },
+        { once: true }
+    );
 
     // Play and pause to trigger the first frame to be loaded
-    playPromise = video.play();
+    const playPromise = video.play();
     if (playPromise !== undefined) {
         playPromise
             .then(() => {

--- a/media/js/cms/pages/flare26-kick-page.es6.js
+++ b/media/js/cms/pages/flare26-kick-page.es6.js
@@ -33,32 +33,45 @@ const setupKickPage = () => {
     source.src = 'https://assets.mozilla.net/wc/logo-1-alpha.webm';
     source.type = 'video/webm';
 
+    let playPromise;
+
     video.appendChild(source);
     wrapper.appendChild(video);
     logoLink.appendChild(wrapper);
 
     video.addEventListener('mouseover', () => {
-        const playPromise = video.play();
+        playPromise = video.play();
         if (playPromise !== undefined) {
             playPromise.catch(() => {
                 // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
             });
         }
     });
+
     video.addEventListener('mouseout', () => {
-        video.pause();
-        video.currentTime = 0;
+        if (playPromise !== undefined) {
+            playPromise
+                .then(() => {
+                    video.pause();
+                    video.currentTime = 0;
+                })
+                .catch(() => {
+                    // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
+                });
+        }
     });
 
-    // play and pause to trigger the first frame to be loaded
-    const playPromise = video.play();
+    // Play and pause to trigger the first frame to be loaded
+    playPromise = video.play();
     if (playPromise !== undefined) {
-        playPromise.catch(() => {
-            // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
-        });
+        playPromise
+            .then(() => {
+                video.pause();
+            })
+            .catch(() => {
+                // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
+            });
     }
-
-    video.pause();
 };
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## One-line summary
Slow networks don't immediately load the logo SVG. Hovering over it before it's loaded still try to play it which flood Sentry with issues.

Changes copied from https://github.com/mozmeao/springfield/pull/1527/changes

## Testing
- [ ] Repeat steps from https://github.com/mozmeao/springfield/pull/1527 using the changes in this PR instead
- [ ] For the last 2 steps set your network throttling to Good 3G
- [ ] Hover in and out of the logo quickly as it's loading