### PR TITLE
feat(Plausible): product_download event addition

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import Plausible from './plausible/plausible.es6';
+
 const TrackProductDownload = {};
 const prodURL = /^https:\/\/download.mozilla.org/;
 const stageURL =
@@ -236,7 +238,26 @@ TrackProductDownload.sendEventFromURL = (downloadURL) => {
 
     if (eventObject) {
         // only send event for tracking if eventObject is valid (issue 14177)
+        // GA4
         TrackProductDownload.sendEvent(eventObject);
+        // Plausible
+        TrackProductDownload.sendPlausibleEvent(eventObject);
+    }
+};
+
+/**
+ * Sends the formatted download event to Plausible as a 'product_download' custom event
+ * @param {Object} - product details formatted into a product_download event
+ */
+TrackProductDownload.sendPlausibleEvent = (eventObject) => {
+    try {
+        // Forward every field except the GA4 event name as Plausible props.
+        const props = Object.assign({}, eventObject);
+        delete props.event;
+
+        Plausible.trackEvent('product_download', props);
+    } catch (error) {
+        // Don't let analytics break the download flow
     }
 };
 

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -246,8 +246,8 @@ TrackProductDownload.sendEventFromURL = (downloadURL) => {
 };
 
 /**
- * Sends the formatted download event to Plausible as a 'product_download' custom event
- * @param {Object} - product details formatted into a product_download event
+ * Sends the formatted download event to Plausible as a 'product_download' custom event.
+ * @param {Object} eventObject - product details formatted into a product_download event
  */
 TrackProductDownload.sendPlausibleEvent = (eventObject) => {
     try {

--- a/media/js/base/plausible/plausible.es6.js
+++ b/media/js/base/plausible/plausible.es6.js
@@ -66,7 +66,7 @@ Plausible.trackEvent = (name, props) => {
         return;
     }
 
-    if (gpcEnabled() || dntEnabled()) {
+    if (Plausible.analyticsDenied()) {
         return;
     }
 

--- a/media/js/base/plausible/plausible.es6.js
+++ b/media/js/base/plausible/plausible.es6.js
@@ -56,4 +56,25 @@ Plausible.init = () => {
     Plausible.loadScript();
 };
 
+/**
+ * Send a custom event to Plausible. No-ops when Plausible isn't loaded or the visitor has opted out.
+ * @param {String} name - the custom event name (e.g. 'product_download')
+ * @param {Object} [props] - optional custom properties
+ */
+Plausible.trackEvent = (name, props) => {
+    if (typeof window.plausible !== 'function') {
+        return;
+    }
+
+    if (gpcEnabled() || dntEnabled()) {
+        return;
+    }
+
+    if (props) {
+        window.plausible(name, { props: props });
+    } else {
+        window.plausible(name);
+    }
+};
+
 export default Plausible;

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -10,6 +10,7 @@
  */
 
 import TrackProductDownload from '../../../../media/js/base/datalayer-productdownload.es6.js';
+import Plausible from '../../../../media/js/base/plausible/plausible.es6.js';
 
 describe('TrackProductDownload.isValidDownloadURL', function () {
     it('should recognize downloads.m.o as a valid URL', function () {
@@ -467,5 +468,88 @@ describe('TrackProductDownload.handleLink', function () {
             release_channel: 'release',
             download_language: 'en-CA'
         });
+    });
+});
+
+describe('TrackProductDownload.sendPlausibleEvent', function () {
+    beforeEach(function () {
+        spyOn(Plausible, 'trackEvent');
+    });
+
+    it('should forward every dataLayer field except the event name', function () {
+        TrackProductDownload.sendPlausibleEvent({
+            event: 'firefox_download',
+            product: 'firefox',
+            platform: 'win64',
+            method: 'site',
+            release_channel: 'release',
+            download_language: 'en-CA'
+        });
+
+        expect(Plausible.trackEvent).toHaveBeenCalledWith('product_download', {
+            product: 'firefox',
+            platform: 'win64',
+            method: 'site',
+            release_channel: 'release',
+            download_language: 'en-CA'
+        });
+    });
+
+    it('should omit optional props that are not present', function () {
+        TrackProductDownload.sendPlausibleEvent({
+            event: 'focus_download',
+            product: 'focus',
+            platform: 'android',
+            method: 'store'
+        });
+
+        expect(Plausible.trackEvent).toHaveBeenCalledWith('product_download', {
+            product: 'focus',
+            platform: 'android',
+            method: 'store'
+        });
+    });
+
+    it('should pass through fields it does not know about', function () {
+        TrackProductDownload.sendPlausibleEvent({
+            event: 'firefox_download',
+            product: 'firefox',
+            future_field: 'should-be-included'
+        });
+
+        expect(Plausible.trackEvent).toHaveBeenCalledWith('product_download', {
+            product: 'firefox',
+            future_field: 'should-be-included'
+        });
+    });
+});
+
+describe('TrackProductDownload.sendEventFromURL', function () {
+    beforeEach(function () {
+        window.dataLayer = sinon.stub();
+        window.dataLayer.push = sinon.stub();
+        spyOn(TrackProductDownload, 'sendEvent').and.callThrough();
+        spyOn(TrackProductDownload, 'sendPlausibleEvent').and.callThrough();
+        spyOn(Plausible, 'trackEvent');
+    });
+
+    it('should fire both the GA4 and Plausible events for a valid URL', function () {
+        TrackProductDownload.sendEventFromURL(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US'
+        );
+
+        expect(TrackProductDownload.sendEvent).toHaveBeenCalled();
+        expect(TrackProductDownload.sendPlausibleEvent).toHaveBeenCalled();
+        expect(Plausible.trackEvent).toHaveBeenCalled();
+    });
+
+    it('should not fire any event for an invalid URL', function () {
+        TrackProductDownload.sendEventFromURL(
+            'https://example.com/not-a-download'
+        );
+
+        expect(TrackProductDownload.sendEvent).not.toHaveBeenCalled();
+        expect(TrackProductDownload.sendPlausibleEvent).not.toHaveBeenCalled();
+        expect(Plausible.trackEvent).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/spec/base/plausible/plausible.js
+++ b/tests/unit/spec/base/plausible/plausible.js
@@ -136,6 +136,52 @@ describe('plausible.es6.js', function () {
         });
     });
 
+    describe('trackEvent', function () {
+        it('should not call window.plausible when the queue is undefined', function () {
+            delete window.plausible;
+            // Should not throw.
+            Plausible.trackEvent('product_download');
+            expect(window.plausible).toBeUndefined();
+        });
+
+        it('should not send an event when GPC is enabled', function () {
+            window.plausible = sinon.stub();
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+
+            Plausible.trackEvent('product_download');
+            expect(window.plausible.called).toBe(false);
+        });
+
+        it('should not send an event when DNT is enabled', function () {
+            window.plausible = sinon.stub();
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+
+            Plausible.trackEvent('product_download');
+            expect(window.plausible.called).toBe(false);
+        });
+
+        it('should send the event name with no props', function () {
+            window.plausible = sinon.stub();
+
+            Plausible.trackEvent('product_download');
+            expect(window.plausible.calledOnce).toBe(true);
+            expect(window.plausible.calledWith('product_download')).toBe(true);
+        });
+
+        it('should send the event name with props when provided', function () {
+            window.plausible = sinon.stub();
+            const props = { product: 'firefox', platform: 'win' };
+
+            Plausible.trackEvent('product_download', props);
+            expect(window.plausible.calledOnce).toBe(true);
+            expect(
+                window.plausible.calledWith('product_download', {
+                    props: props
+                })
+            ).toBe(true);
+        });
+    });
+
     describe('defineQueueStub', function () {
         it('should create a window.plausible queue function', function () {
             Plausible.defineQueueStub();

--- a/tests/unit/spec/base/plausible/plausible.js
+++ b/tests/unit/spec/base/plausible/plausible.js
@@ -160,6 +160,16 @@ describe('plausible.es6.js', function () {
             expect(window.plausible.called).toBe(false);
         });
 
+        it('should not send an event when analytics consent was explicitly declined', function () {
+            window.plausible = sinon.stub();
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify({ analytics: false })
+            );
+
+            Plausible.trackEvent('product_download');
+            expect(window.plausible.called).toBe(false);
+        });
+
         it('should send the event name with no props', function () {
             window.plausible = sinon.stub();
 


### PR DESCRIPTION
## One-line summary

Forward `product_download` events to Plausible alongside the existing GA4/dataLayer events.

## Significant changes and points to review

- **New `Plausible.trackEvent(name, props)`** in `media/js/base/plausible/plausible.es6.js`: sends a custom event to Plausible. No-ops safely when the Plausible script isn't loaded (`window.plausible` not a function) or the visitor has opted out via GPC/DNT, reusing the existing `gpcEnabled()`/`dntEnabled()` consent helpers (same gate as `Plausible.init`).
- **New `TrackProductDownload.sendPlausibleEvent(eventObject)`** in `media/js/base/datalayer-productdownload.es6.js`: forwards every download field except the GA4 `event` name as Plausible props, fired from `sendEventFromURL` right after the existing GA4 `sendEvent` call. Wrapped in try/catch so analytics can't break the download flow.
- **Telemetry note:** this adds a new outbound analytics event:
  - Consent gating should be enforced at send time, not just load time.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1375

## Testing

- `npm run jasmine`:full front-end unit suite passes (**516 specs, 0 failures**), including new coverage for `Plausible.trackEvent` (queue-undefined, GPC, DNT, with/without props) and `TrackProductDownload.sendPlausibleEvent` / `sendEventFromURL` (fields forwarded, `event` dropped, both GA4 + Plausible fire on valid URLs, neither fires on invalid).
- `npx eslint`: clean on both changed source files.

