### PR TITLE
WT-1119: rework /healthz-cdn/ to render critical pages

### DIFF
--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -2,8 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from unittest.mock import patch
+
+from django.core.cache import cache
 
 import pytest
+from waffle.testutils import override_switch
 
 pytestmark = pytest.mark.django_db
 
@@ -21,6 +25,56 @@ def _test(
         assert expected_content in resp.text
 
 
+@pytest.fixture(autouse=True)
+def _clear_healthz_cdn_cache():
+    # The view caches its page-check result per-process; clear between tests so
+    # one test's success doesn't mask another's failure (or vice-versa).
+    from springfield.base.views import HEALTHZ_CDN_CACHE_KEY
+
+    cache.delete(HEALTHZ_CDN_CACHE_KEY)
+    yield
+    cache.delete(HEALTHZ_CDN_CACHE_KEY)
+
+
+@pytest.fixture
+def healthz_cdn_cms_pages(client):
+    """Bootstrap the Wagtail tree required for the production
+    HEALTHZ_CDN_CRITICAL_PATHS list to fully resolve in tests.
+
+    Only `/whatsnew/general/` needs CMS scaffolding — it doesn't match the
+    3-digit version regex in firefox/urls.py and so falls through to Wagtail's
+    catch-all. The homepage and versioned whatsnew render via static views
+    with no fixture needed, and `/de/...` falls back to en-US in this env.
+    """
+    import wagtail_factories
+    from wagtail.models import Site
+
+    from springfield.cms.tests.factories import (
+        GeneralWhatsNewPage2026Factory,
+        SimpleRichTextPageFactory,
+        WhatsNewIndexPageFactory,
+    )
+
+    root_page = SimpleRichTextPageFactory(slug="root_page", live=True)
+    hostname = client._base_environ()["SERVER_NAME"]
+    try:
+        site = Site.objects.get(is_default_site=True)
+        site.root_page = root_page
+        site.hostname = hostname
+        site.save()
+    except Site.DoesNotExist:
+        wagtail_factories.SiteFactory(
+            root_page=root_page,
+            is_default_site=True,
+            hostname=hostname,
+        )
+
+    index = WhatsNewIndexPageFactory(parent=root_page, slug="whatsnew")
+    general = GeneralWhatsNewPage2026Factory(parent=index)
+    general.save_revision().publish()
+    return general
+
+
 def test_healthz(client):
     _test(
         url="/healthz/",
@@ -36,55 +90,98 @@ def test_readiness(client):
     )
 
 
-# def test_healthz_cdn(client):
-#     _test(
-#         url="/healthz-cdn/",
-#         client=client,
-#         expected_content="pong",
-#     )
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn(client):
+    # Happy path: critical pages all return < 400, so the healthcheck returns "pong".
+    # Mock the inner check so the test doesn't depend on the homepage rendering
+    # successfully in the test environment.
+    with patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_content="pong",
+        )
 
 
-# def test_healthz_cdn_fails_when_migrations_pending(client):
-#     from django.db.migrations.executor import MigrationExecutor
-
-#     class FakeMigration:
-#         app_label = "fake_app"
-#         name = "0001_fake"
-
-#     with patch.object(MigrationExecutor, "migration_plan", return_value=[(FakeMigration(), False)]):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="migrations pending",
-#         )
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_actually_renders_critical_pages(client, healthz_cdn_cms_pages):
+    # End-to-end smoke test: no mocks on the inner check, so the view really
+    # invokes its inner django.test.Client against the live production
+    # HEALTHZ_CDN_CRITICAL_PATHS list. The healthz_cdn_cms_pages fixture stands
+    # up the one CMS-served path that doesn't otherwise resolve in CI; the
+    # other paths render via static views.
+    _test(
+        url="/healthz-cdn/",
+        client=client,
+        expected_content="pong",
+    )
 
 
-# def test_healthz_cdn_fails_when_history_inconsistent(client):
-#     from django.db.migrations.exceptions import InconsistentMigrationHistory
-#     from django.db.migrations.loader import MigrationLoader
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=False)
+def test_healthz_cdn_bypasses_page_check_when_switch_off(client):
+    # When the switch is off, the view returns 200 OK without rendering any internal
+    # pages, even if those pages would otherwise fail. Verify by patching the check
+    # to raise — if the bypass works, the patch is never reached.
+    with patch("springfield.base.views._check_critical_pages", side_effect=AssertionError("should not run")):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_content="pong",
+        )
 
-#     with patch.object(MigrationLoader, "check_consistent_history", side_effect=InconsistentMigrationHistory("test")):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="migration history inconsistent",
-#         )
+
+class _FakeClient:
+    """Stand-in for django.test.Client used by the view, so test patches don't
+    inadvertently intercept pytest-django's own client. Configure via class attrs."""
+
+    response_status_code = 200
+    raise_on_get = None
+
+    def __init__(self, **kwargs):
+        pass
+
+    def get(self, path, follow=False):
+        if self.raise_on_get is not None:
+            raise self.raise_on_get
+        return type("Resp", (), {"status_code": self.response_status_code})()
 
 
-# def test_healthz_cdn_fails_when_column_missing(client):
-#     from django.db import connection
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_fails_when_critical_page_returns_5xx(client):
+    # Simulate a critical-page render coming back as 500 (e.g. column-dropping
+    # migration applied, old code can't query the dropped column).
+    fake_client_class = type("Fake", (_FakeClient,), {"response_status_code": 500})
+    with patch("springfield.base.views.Client", fake_client_class):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="critical page failed",
+        )
 
-#     # Return empty column list for all tables — makes every managed model appear
-#     # to have all its columns missing, catching dropped-column schema drift.
-#     with patch.object(connection.introspection, "get_table_description", return_value=[]):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="schema mismatch",
-#         )
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_fails_when_critical_page_raises(client):
+    # If the internal page render raises despite raise_request_exception=False
+    # (e.g. DB connection dropped mid-request), we treat it as failed.
+    fake_client_class = type("Fake", (_FakeClient,), {"raise_on_get": RuntimeError("DB gone")})
+    with patch("springfield.base.views.Client", fake_client_class):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="critical page failed",
+        )
+
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_caches_result(client):
+    # The page-check result is cached per-process to absorb a Fastly burst into a
+    # single render. Verify it runs once across two back-to-back requests.
+    with patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")) as mocked:
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
+        assert mocked.call_count == 1
 
 
 def test_healthz_cron(client):

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -9,13 +9,11 @@ from datetime import datetime
 from os import getenv
 from time import time
 
-from django.apps import apps
 from django.conf import settings
-from django.db import connections
-from django.db.migrations.exceptions import InconsistentMigrationHistory
-from django.db.migrations.executor import MigrationExecutor
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.test import Client
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import TemplateView
@@ -119,61 +117,94 @@ def get_extra_server_info():
 logger = logging.getLogger(__name__)
 
 
+# How long the page-check result is cached per process. Production runs Granian
+# with 1 worker + 1 blocking thread per pod (see bin/run-prod.sh and the
+# webservices-infra Helm chart), so each pod renders the critical pages at most
+# once per this interval. Kept short enough that a freshly-broken site shows up
+# quickly via Fastly probes, but long enough to bound the steady-state load and
+# the slow-page blocking window — every cache miss ties up the pod's single
+# blocking thread for the duration of the renders.
+HEALTHZ_CDN_CACHE_KEY = "healthz-cdn:page-check"
+HEALTHZ_CDN_CACHE_TIMEOUT = 30
+
+# A small set of representative pages we expect to always serve. Anything other
+# than a sub-400 status from any of them flips the healthcheck to 500 and lets
+# Fastly fall back to its static page. Together these cover the download page,
+# a CMS-served whatsnew page (Wagtail page-lookup path), a version-specific
+# whatsnew, and a non-en-US locale — most causes of a real user-facing outage
+# (schema drift, template errors, broken context processors, DB outage) show
+# up in at least one of them.
+HEALTHZ_CDN_CRITICAL_PATHS = (
+    f"/{settings.LANGUAGE_CODE}/",
+    "/en-US/whatsnew/general/",
+    "/de/whatsnew/150/",
+)
+
+
+def _check_critical_pages():
+    """Return (status_code, body) by issuing internal GETs against critical pages.
+
+    Symptom-based rather than cause-based: if old code can still render a page
+    against a newer DB (benign migration), we pass; if it can't (destructive
+    schema change), we fail. This sidesteps the false-positive problem of
+    cause-based reverse-skew detection — where any rollout containing any
+    migration would have flipped Fastly to fallback during the brief window
+    before old pods were replaced.
+
+    The earlier per-model `get_table_description` approach was both expensive
+    (~200 DB queries per check, the cause of the original overload) and unable
+    to distinguish benign from destructive schema change. This is cheaper per
+    check (one page render against an in-process cache) and more accurate.
+    """
+    if settings.WATCHMAN_DISABLE_APM:
+        try:
+            from watchman.views import _disable_apm  # inline: _disable_apm is a private watchman API; guard defensively against upstream rename
+
+            _disable_apm()
+        except (ImportError, AttributeError):
+            logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
+
+    # raise_request_exception=False so a 500 from the view comes back as a normal
+    # response with status_code=500 rather than propagating — we want to handle
+    # both the same way (page broken → fail healthcheck).
+    client = Client(raise_request_exception=False)
+    for path in HEALTHZ_CDN_CRITICAL_PATHS:
+        try:
+            response = client.get(path, follow=False)
+        except Exception:
+            logger.exception("healthz_cdn: critical page %s raised", path)
+            return 500, "critical page failed"
+        if response.status_code >= 400:
+            logger.warning("healthz_cdn: critical page %s returned %s", path, response.status_code)
+            return 500, "critical page failed"
+    return 200, "pong"
+
+
 @require_safe
 @never_cache
 def healthz_cdn(request):
-    try:
-        if settings.WATCHMAN_DISABLE_APM:
-            try:
-                from watchman.views import _disable_apm
+    # Feature toggle: when the switch is off, behave like the simple ping. Lets us
+    # dial back the page-rendering behaviour without a deploy if it ever proves
+    # too costly again. Propagation is not instantaneous — each pod caches the
+    # switch state in its own LocMemCache (django-waffle default MAX_AGE is 30
+    # days), so if a flip needs to take effect on every pod immediately, restart
+    # the rollout. The switch helper defaults to settings.DEV when undefined, so
+    # local dev sees real page renders while a fresh prod deploy is safe by default.
+    if not switch("healthz-cdn-db-checks-enabled"):
+        return HttpResponse("pong", content_type="text/plain")
 
-                _disable_apm()
-            except (ImportError, AttributeError):
-                logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
-
-        connection = connections["default"]
-
-        # Check 1: migration records — catches new code deployed before migrations run,
-        # and applied migrations whose dependencies are missing (InconsistentMigrationHistory).
-        executor = MigrationExecutor(connection)
+    cached = cache.get(HEALTHZ_CDN_CACHE_KEY)
+    if cached is not None:
+        status, body = cached
+    else:
         try:
-            executor.loader.check_consistent_history(connection)
-        except InconsistentMigrationHistory as e:
-            logger.warning("healthz_cdn: inconsistent migration history: %s", e)
-            return HttpResponse("migration history inconsistent", content_type="text/plain", status=500)
-        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-        if plan:
-            unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
-            logger.warning("healthz_cdn: unapplied migrations: %s", unapplied)
-            return HttpResponse("migrations pending", content_type="text/plain", status=500)
+            status, body = _check_critical_pages()
+        except Exception:
+            logger.exception("healthz_cdn: check failed")
+            status, body = 500, "check error"
+        cache.set(HEALTHZ_CDN_CACHE_KEY, (status, body), HEALTHZ_CDN_CACHE_TIMEOUT)
 
-        # Check 2: schema introspection — catches old code running after a column-dropping
-        # migration. Compares each managed model's expected columns (_meta.local_fields,
-        # which reflects what the running code expects) against the actual DB schema.
-        # This correctly handles Wagtail MTI subclasses, which each have their own table.
-        with connection.cursor() as cursor:
-            for model in apps.get_models():
-                if not model._meta.managed or model._meta.proxy or model._meta.app_label == "wagtailsearch":
-                    continue
-                expected_cols = {f.column for f in model._meta.local_fields}
-                if not expected_cols:
-                    continue
-                actual_cols = {col.name for col in connection.introspection.get_table_description(cursor, model._meta.db_table)}
-                # SQLite's implicit rowid is never listed by PRAGMA table_info() but is
-                # always accessible on every table. Not needed in production (PostgreSQL)
-                # but allows local SQLite testing.
-                if connection.vendor == "sqlite":
-                    actual_cols.add("rowid")
-                missing = expected_cols - actual_cols
-                if missing:
-                    logger.warning("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)
-                    return HttpResponse("schema mismatch", content_type="text/plain", status=500)
-
-    except Exception:
-        logger.exception("healthz_cdn: check failed")
-        return HttpResponse("check error", content_type="text/plain", status=500)
-
-    return HttpResponse("pong", content_type="text/plain")
+    return HttpResponse(body, content_type="text/plain", status=status)
 
 
 @require_safe

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -474,7 +474,7 @@ SUPPORTED_NONLOCALES = [
     "robots.txt",
     ".well-known",
     "healthz",  # Needed for k8s
-    # "healthz-cdn",  # Needed for Fastly CDN health checks
+    "healthz-cdn",  # Needed for Fastly CDN health checks
     "readiness",  # Needed for k8s
     "healthz-cron",  # status dash
     "revision.txt",  # from root_files

--- a/springfield/urls.py
+++ b/springfield/urls.py
@@ -38,7 +38,7 @@ urlpatterns += (
     path("", include("springfield.base.nonlocale_urls")),
     path("", include("springfield.sitemaps.urls")),
     path("healthz/", watchman_views.ping, name="watchman.ping"),
-    # path("healthz-cdn/", base_views.healthz_cdn, name="healthz-cdn"),
+    path("healthz-cdn/", base_views.healthz_cdn, name="healthz-cdn"),
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("healthz-cron/", base_views.cron_health_check),
     path("_documents/", include(wagtaildocs_urls)),


### PR DESCRIPTION
## Summary

Replaces the previous `/healthz-cdn/` implementation (disabled in #1380 because it took down the site on first deploy) with a symptom-based check: render a small set of critical pages via an in-process `django.test.Client` and return 500 if any returns 4xx/5xx or raises. If old code can still render against a newer DB (benign migration), the check passes; if it can't (destructive schema change), it fails — without needing to model the DB state directly. Template errors, broken context processors, and DB outages all surface the same way.

## What's in here

- Re-enable the `/healthz-cdn/` route and the `SUPPORTED_NONLOCALES` entry.
- New `HEALTHZ_CDN_DB_CHECKS_ENABLED` Waffle switch that short-circuits the view to `200 pong` when off. Defaults to `settings.DEV`, so a fresh prod deploy is safe by default and operators opt in by creating/enabling the switch.
- `HEALTHZ_CDN_CRITICAL_PATHS = (homepage, /en-US/whatsnew/general/, /de/whatsnew/150/)` covering the download view, a CMS-served Wagtail page, and a locale-prefixed versioned whatsnew.
- 30s per-process cache (`SimpleDictCache`) so Fastly probe bursts collapse into one render per pod per interval. Production runs Granian with 1 worker × 1 blocking thread per pod (enforced in the webservices-infra Helm chart), so no in-pod thundering herd to design around.
- Inline-import of `_disable_apm` retained from the previous version (it's a private watchman API; guarded defensively against upstream rename).

## Why not the previous approach

The disabled version iterated `connection.introspection.get_table_description()` over every managed model on every probe — ~200 DB queries per healthcheck for Wagtail. Even at Fastly's nominal 5s interval this overwhelmed the DB. The new approach is intentionally cause-agnostic: we don't try to detect deploy-skew patterns directly (forward/reverse migration drift), because:

- It's easy to get wrong (reverse-skew detection false-positives on every rollout that includes any migration — even benign additive ones).
- It misses non-DB causes of outage.
- A "did the page render?" check is cheaper and more accurate at the same time.

## Trade-offs noted in the design

- Each healthcheck blocks the pod's single blocking thread for the duration of 3 page renders (~100–300ms healthy, several seconds if the DB is slow). The 30s cache TTL bounds how often that blocking window opens.
- The Waffle switch flip isn't instantaneous across pods (waffle caches per-process in `LocMemCache`); a `kubectl rollout restart` forces immediate propagation if needed.
- `LocMemCache` is per-pod, so check load scales linearly with pod count. At the 25–100 pod range it's small (~25–100 healthcheck-induced queries/sec fleet-wide). A separate branch will explore Redis as a shared cache to break the linear scaling.

## Test plan

- [x] `uv run pytest springfield/base/tests/test_urls.py` — 9 tests pass
- [x] `uv run pytest springfield/base/` — 339 tests pass
- [x] `uv run ruff check` clean on changed files
- [ ] Verify in dev / staging that `/healthz-cdn/` returns 200 with the switch on
- [ ] Verify that flipping `HEALTHZ_CDN_DB_CHECKS_ENABLED` off returns 200 pong without rendering
- [ ] Confirm Fastly probe behaviour against the new endpoint in dev