### PR TITLE
WT-1119: explore shared Redis cache for /healthz-cdn/ (on top of #1537)

### DIFF
--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -2,8 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from unittest.mock import patch
+
+from django.core.cache import cache
 
 import pytest
+from waffle.testutils import override_switch
 
 pytestmark = pytest.mark.django_db
 
@@ -21,6 +25,56 @@ def _test(
         assert expected_content in resp.text
 
 
+@pytest.fixture(autouse=True)
+def _clear_healthz_cdn_cache():
+    # The view caches its page-check result per-process; clear between tests so
+    # one test's success doesn't mask another's failure (or vice-versa).
+    from springfield.base.views import HEALTHZ_CDN_CACHE_KEY
+
+    cache.delete(HEALTHZ_CDN_CACHE_KEY)
+    yield
+    cache.delete(HEALTHZ_CDN_CACHE_KEY)
+
+
+@pytest.fixture
+def healthz_cdn_cms_pages(client):
+    """Bootstrap the Wagtail tree required for the production
+    HEALTHZ_CDN_CRITICAL_PATHS list to fully resolve in tests.
+
+    Only `/whatsnew/general/` needs CMS scaffolding — it doesn't match the
+    3-digit version regex in firefox/urls.py and so falls through to Wagtail's
+    catch-all. The homepage and versioned whatsnew render via static views
+    with no fixture needed, and `/de/...` falls back to en-US in this env.
+    """
+    import wagtail_factories
+    from wagtail.models import Site
+
+    from springfield.cms.tests.factories import (
+        GeneralWhatsNewPage2026Factory,
+        SimpleRichTextPageFactory,
+        WhatsNewIndexPageFactory,
+    )
+
+    root_page = SimpleRichTextPageFactory(slug="root_page", live=True)
+    hostname = client._base_environ()["SERVER_NAME"]
+    try:
+        site = Site.objects.get(is_default_site=True)
+        site.root_page = root_page
+        site.hostname = hostname
+        site.save()
+    except Site.DoesNotExist:
+        wagtail_factories.SiteFactory(
+            root_page=root_page,
+            is_default_site=True,
+            hostname=hostname,
+        )
+
+    index = WhatsNewIndexPageFactory(parent=root_page, slug="whatsnew")
+    general = GeneralWhatsNewPage2026Factory(parent=index)
+    general.save_revision().publish()
+    return general
+
+
 def test_healthz(client):
     _test(
         url="/healthz/",
@@ -36,55 +90,98 @@ def test_readiness(client):
     )
 
 
-# def test_healthz_cdn(client):
-#     _test(
-#         url="/healthz-cdn/",
-#         client=client,
-#         expected_content="pong",
-#     )
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn(client):
+    # Happy path: critical pages all return < 400, so the healthcheck returns "pong".
+    # Mock the inner check so the test doesn't depend on the homepage rendering
+    # successfully in the test environment.
+    with patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_content="pong",
+        )
 
 
-# def test_healthz_cdn_fails_when_migrations_pending(client):
-#     from django.db.migrations.executor import MigrationExecutor
-
-#     class FakeMigration:
-#         app_label = "fake_app"
-#         name = "0001_fake"
-
-#     with patch.object(MigrationExecutor, "migration_plan", return_value=[(FakeMigration(), False)]):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="migrations pending",
-#         )
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_actually_renders_critical_pages(client, healthz_cdn_cms_pages):
+    # End-to-end smoke test: no mocks on the inner check, so the view really
+    # invokes its inner django.test.Client against the live production
+    # HEALTHZ_CDN_CRITICAL_PATHS list. The healthz_cdn_cms_pages fixture stands
+    # up the one CMS-served path that doesn't otherwise resolve in CI; the
+    # other paths render via static views.
+    _test(
+        url="/healthz-cdn/",
+        client=client,
+        expected_content="pong",
+    )
 
 
-# def test_healthz_cdn_fails_when_history_inconsistent(client):
-#     from django.db.migrations.exceptions import InconsistentMigrationHistory
-#     from django.db.migrations.loader import MigrationLoader
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=False)
+def test_healthz_cdn_bypasses_page_check_when_switch_off(client):
+    # When the switch is off, the view returns 200 OK without rendering any internal
+    # pages, even if those pages would otherwise fail. Verify by patching the check
+    # to raise — if the bypass works, the patch is never reached.
+    with patch("springfield.base.views._check_critical_pages", side_effect=AssertionError("should not run")):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_content="pong",
+        )
 
-#     with patch.object(MigrationLoader, "check_consistent_history", side_effect=InconsistentMigrationHistory("test")):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="migration history inconsistent",
-#         )
+
+class _FakeClient:
+    """Stand-in for django.test.Client used by the view, so test patches don't
+    inadvertently intercept pytest-django's own client. Configure via class attrs."""
+
+    response_status_code = 200
+    raise_on_get = None
+
+    def __init__(self, **kwargs):
+        pass
+
+    def get(self, path, follow=False):
+        if self.raise_on_get is not None:
+            raise self.raise_on_get
+        return type("Resp", (), {"status_code": self.response_status_code})()
 
 
-# def test_healthz_cdn_fails_when_column_missing(client):
-#     from django.db import connection
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_fails_when_critical_page_returns_5xx(client):
+    # Simulate a critical-page render coming back as 500 (e.g. column-dropping
+    # migration applied, old code can't query the dropped column).
+    fake_client_class = type("Fake", (_FakeClient,), {"response_status_code": 500})
+    with patch("springfield.base.views.Client", fake_client_class):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="critical page failed",
+        )
 
-#     # Return empty column list for all tables — makes every managed model appear
-#     # to have all its columns missing, catching dropped-column schema drift.
-#     with patch.object(connection.introspection, "get_table_description", return_value=[]):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="schema mismatch",
-#         )
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_fails_when_critical_page_raises(client):
+    # If the internal page render raises despite raise_request_exception=False
+    # (e.g. DB connection dropped mid-request), we treat it as failed.
+    fake_client_class = type("Fake", (_FakeClient,), {"raise_on_get": RuntimeError("DB gone")})
+    with patch("springfield.base.views.Client", fake_client_class):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="critical page failed",
+        )
+
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_caches_result(client):
+    # The page-check result is cached per-process to absorb a Fastly burst into a
+    # single render. Verify it runs once across two back-to-back requests.
+    with patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")) as mocked:
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
+        assert mocked.call_count == 1
 
 
 def test_healthz_cron(client):

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -4,7 +4,7 @@
 
 from unittest.mock import patch
 
-from django.core.cache import cache
+from django.core.cache import caches
 
 import pytest
 from waffle.testutils import override_switch
@@ -27,13 +27,17 @@ def _test(
 
 @pytest.fixture(autouse=True)
 def _clear_healthz_cdn_cache():
-    # The view caches its page-check result per-process; clear between tests so
-    # one test's success doesn't mask another's failure (or vice-versa).
-    from springfield.base.views import HEALTHZ_CDN_CACHE_KEY
+    # The view caches its page-check result in the `healthz` cache; clear
+    # between tests so one test's success doesn't mask another's failure (or
+    # vice-versa). Also clear the lock key so single-flight starts fresh.
+    from springfield.base.views import HEALTHZ_CDN_CACHE_KEY, HEALTHZ_CDN_LOCK_KEY
 
-    cache.delete(HEALTHZ_CDN_CACHE_KEY)
+    healthz_cache = caches["healthz"]
+    healthz_cache.delete(HEALTHZ_CDN_CACHE_KEY)
+    healthz_cache.delete(HEALTHZ_CDN_LOCK_KEY)
     yield
-    cache.delete(HEALTHZ_CDN_CACHE_KEY)
+    healthz_cache.delete(HEALTHZ_CDN_CACHE_KEY)
+    healthz_cache.delete(HEALTHZ_CDN_LOCK_KEY)
 
 
 @pytest.fixture
@@ -176,12 +180,74 @@ def test_healthz_cdn_fails_when_critical_page_raises(client):
 
 @override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
 def test_healthz_cdn_caches_result(client):
-    # The page-check result is cached per-process to absorb a Fastly burst into a
-    # single render. Verify it runs once across two back-to-back requests.
+    # The page-check result is cached in the shared `healthz` cache, so a Fastly
+    # burst collapses into a single render. Verify it runs once across two
+    # back-to-back requests.
     with patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")) as mocked:
         _test(url="/healthz-cdn/", client=client, expected_content="pong")
         _test(url="/healthz-cdn/", client=client, expected_content="pong")
         assert mocked.call_count == 1
+
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_single_flight_lock_skips_render(client):
+    # When another caller holds the single-flight lock, this request returns
+    # 200 pong without invoking _check_critical_pages. With a shared (Redis)
+    # cache, this dedupes across all pods so a cold cache doesn't fan out into
+    # N concurrent renders.
+    from springfield.base.views import HEALTHZ_CDN_LOCK_KEY
+
+    caches["healthz"].set(HEALTHZ_CDN_LOCK_KEY, 1, 15)
+    with patch("springfield.base.views._check_critical_pages", side_effect=AssertionError("should not run")):
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
+
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_lock_released_after_check(client):
+    # After a successful check, the single-flight lock is released so the next
+    # cache-miss can run a fresh check rather than being permanently locked out
+    # until the lock TTL expires.
+    from springfield.base.views import HEALTHZ_CDN_CACHE_KEY, HEALTHZ_CDN_LOCK_KEY
+
+    healthz_cache = caches["healthz"]
+    with patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")):
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
+
+    assert healthz_cache.get(HEALTHZ_CDN_LOCK_KEY) is None
+    assert healthz_cache.get(HEALTHZ_CDN_CACHE_KEY) == (200, "pong")
+
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_lock_released_even_when_check_raises(client):
+    # The check itself may raise (caught by the outer try). Even then the lock
+    # must be released so the next probe isn't blocked from re-trying.
+    from springfield.base.views import HEALTHZ_CDN_LOCK_KEY
+
+    healthz_cache = caches["healthz"]
+    with patch("springfield.base.views._check_critical_pages", side_effect=RuntimeError("kaboom")):
+        _test(
+            url="/healthz-cdn/",
+            client=client,
+            expected_status=500,
+            expected_content="check error",
+        )
+    assert healthz_cache.get(HEALTHZ_CDN_LOCK_KEY) is None
+
+
+@override_switch("HEALTHZ_CDN_DB_CHECKS_ENABLED", active=True)
+def test_healthz_cdn_survives_cache_failure(client):
+    # If the shared cache is unreachable (e.g. Redis hiccup), the view should
+    # still run the check and return its result rather than 500ing on the
+    # cache error. We patch cache.get to raise to simulate a Redis outage.
+    healthz_cache = caches["healthz"]
+    with (
+        patch.object(healthz_cache, "get", side_effect=ConnectionError("redis down")),
+        patch.object(healthz_cache, "add", side_effect=ConnectionError("redis down")),
+        patch.object(healthz_cache, "set", side_effect=ConnectionError("redis down")),
+        patch.object(healthz_cache, "delete", side_effect=ConnectionError("redis down")),
+        patch("springfield.base.views._check_critical_pages", return_value=(200, "pong")),
+    ):
+        _test(url="/healthz-cdn/", client=client, expected_content="pong")
 
 
 def test_healthz_cron(client):

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -9,13 +9,11 @@ from datetime import datetime
 from os import getenv
 from time import time
 
-from django.apps import apps
 from django.conf import settings
-from django.db import connections
-from django.db.migrations.exceptions import InconsistentMigrationHistory
-from django.db.migrations.executor import MigrationExecutor
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.test import Client
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import TemplateView
@@ -119,61 +117,94 @@ def get_extra_server_info():
 logger = logging.getLogger(__name__)
 
 
+# How long the page-check result is cached per process. Production runs Granian
+# with 1 worker + 1 blocking thread per pod (see bin/run-prod.sh and the
+# webservices-infra Helm chart), so each pod renders the critical pages at most
+# once per this interval. Kept short enough that a freshly-broken site shows up
+# quickly via Fastly probes, but long enough to bound the steady-state load and
+# the slow-page blocking window — every cache miss ties up the pod's single
+# blocking thread for the duration of the renders.
+HEALTHZ_CDN_CACHE_KEY = "healthz-cdn:page-check"
+HEALTHZ_CDN_CACHE_TIMEOUT = 30
+
+# A small set of representative pages we expect to always serve. Anything other
+# than a sub-400 status from any of them flips the healthcheck to 500 and lets
+# Fastly fall back to its static page. Together these cover the download page,
+# a CMS-served whatsnew page (Wagtail page-lookup path), a version-specific
+# whatsnew, and a non-en-US locale — most causes of a real user-facing outage
+# (schema drift, template errors, broken context processors, DB outage) show
+# up in at least one of them.
+HEALTHZ_CDN_CRITICAL_PATHS = (
+    f"/{settings.LANGUAGE_CODE}/",
+    "/en-US/whatsnew/general/",
+    "/de/whatsnew/150/",
+)
+
+
+def _check_critical_pages():
+    """Return (status_code, body) by issuing internal GETs against critical pages.
+
+    Symptom-based rather than cause-based: if old code can still render a page
+    against a newer DB (benign migration), we pass; if it can't (destructive
+    schema change), we fail. This sidesteps the false-positive problem of
+    cause-based reverse-skew detection — where any rollout containing any
+    migration would have flipped Fastly to fallback during the brief window
+    before old pods were replaced.
+
+    The earlier per-model `get_table_description` approach was both expensive
+    (~200 DB queries per check, the cause of the original overload) and unable
+    to distinguish benign from destructive schema change. This is cheaper per
+    check (one page render against an in-process cache) and more accurate.
+    """
+    if settings.WATCHMAN_DISABLE_APM:
+        try:
+            from watchman.views import _disable_apm  # inline: _disable_apm is a private watchman API; guard defensively against upstream rename
+
+            _disable_apm()
+        except (ImportError, AttributeError):
+            logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
+
+    # raise_request_exception=False so a 500 from the view comes back as a normal
+    # response with status_code=500 rather than propagating — we want to handle
+    # both the same way (page broken → fail healthcheck).
+    client = Client(raise_request_exception=False)
+    for path in HEALTHZ_CDN_CRITICAL_PATHS:
+        try:
+            response = client.get(path, follow=False)
+        except Exception:
+            logger.exception("healthz_cdn: critical page %s raised", path)
+            return 500, "critical page failed"
+        if response.status_code >= 400:
+            logger.warning("healthz_cdn: critical page %s returned %s", path, response.status_code)
+            return 500, "critical page failed"
+    return 200, "pong"
+
+
 @require_safe
 @never_cache
 def healthz_cdn(request):
-    try:
-        if settings.WATCHMAN_DISABLE_APM:
-            try:
-                from watchman.views import _disable_apm
+    # Feature toggle: when the switch is off, behave like the simple ping. Lets us
+    # dial back the page-rendering behaviour without a deploy if it ever proves
+    # too costly again. Propagation is not instantaneous — each pod caches the
+    # switch state in its own LocMemCache (django-waffle default MAX_AGE is 30
+    # days), so if a flip needs to take effect on every pod immediately, restart
+    # the rollout. The switch helper defaults to settings.DEV when undefined, so
+    # local dev sees real page renders while a fresh prod deploy is safe by default.
+    if not switch("healthz-cdn-db-checks-enabled"):
+        return HttpResponse("pong", content_type="text/plain")
 
-                _disable_apm()
-            except (ImportError, AttributeError):
-                logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
-
-        connection = connections["default"]
-
-        # Check 1: migration records — catches new code deployed before migrations run,
-        # and applied migrations whose dependencies are missing (InconsistentMigrationHistory).
-        executor = MigrationExecutor(connection)
+    cached = cache.get(HEALTHZ_CDN_CACHE_KEY)
+    if cached is not None:
+        status, body = cached
+    else:
         try:
-            executor.loader.check_consistent_history(connection)
-        except InconsistentMigrationHistory as e:
-            logger.warning("healthz_cdn: inconsistent migration history: %s", e)
-            return HttpResponse("migration history inconsistent", content_type="text/plain", status=500)
-        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-        if plan:
-            unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
-            logger.warning("healthz_cdn: unapplied migrations: %s", unapplied)
-            return HttpResponse("migrations pending", content_type="text/plain", status=500)
+            status, body = _check_critical_pages()
+        except Exception:
+            logger.exception("healthz_cdn: check failed")
+            status, body = 500, "check error"
+        cache.set(HEALTHZ_CDN_CACHE_KEY, (status, body), HEALTHZ_CDN_CACHE_TIMEOUT)
 
-        # Check 2: schema introspection — catches old code running after a column-dropping
-        # migration. Compares each managed model's expected columns (_meta.local_fields,
-        # which reflects what the running code expects) against the actual DB schema.
-        # This correctly handles Wagtail MTI subclasses, which each have their own table.
-        with connection.cursor() as cursor:
-            for model in apps.get_models():
-                if not model._meta.managed or model._meta.proxy or model._meta.app_label == "wagtailsearch":
-                    continue
-                expected_cols = {f.column for f in model._meta.local_fields}
-                if not expected_cols:
-                    continue
-                actual_cols = {col.name for col in connection.introspection.get_table_description(cursor, model._meta.db_table)}
-                # SQLite's implicit rowid is never listed by PRAGMA table_info() but is
-                # always accessible on every table. Not needed in production (PostgreSQL)
-                # but allows local SQLite testing.
-                if connection.vendor == "sqlite":
-                    actual_cols.add("rowid")
-                missing = expected_cols - actual_cols
-                if missing:
-                    logger.warning("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)
-                    return HttpResponse("schema mismatch", content_type="text/plain", status=500)
-
-    except Exception:
-        logger.exception("healthz_cdn: check failed")
-        return HttpResponse("check error", content_type="text/plain", status=500)
-
-    return HttpResponse("pong", content_type="text/plain")
+    return HttpResponse(body, content_type="text/plain", status=status)
 
 
 @require_safe

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -10,7 +10,7 @@ from os import getenv
 from time import time
 
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import caches
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.test import Client
@@ -117,15 +117,18 @@ def get_extra_server_info():
 logger = logging.getLogger(__name__)
 
 
-# How long the page-check result is cached per process. Production runs Granian
-# with 1 worker + 1 blocking thread per pod (see bin/run-prod.sh and the
-# webservices-infra Helm chart), so each pod renders the critical pages at most
-# once per this interval. Kept short enough that a freshly-broken site shows up
-# quickly via Fastly probes, but long enough to bound the steady-state load and
-# the slow-page blocking window — every cache miss ties up the pod's single
-# blocking thread for the duration of the renders.
+# The page-check result is cached in the `healthz` Django cache, which in prod
+# is a Redis backend shared across all pods (see settings.CACHES). This means
+# the fleet runs ~one critical-page render per TTL instead of one per pod per
+# TTL, decoupling healthcheck cost from pod count. When REDIS_URL is unset
+# (local dev, CI), the `healthz` cache falls back to a per-process LocMemCache.
 HEALTHZ_CDN_CACHE_KEY = "healthz-cdn:page-check"
+HEALTHZ_CDN_LOCK_KEY = "healthz-cdn:page-check:lock"
 HEALTHZ_CDN_CACHE_TIMEOUT = 30
+# Lock TTL bounds how long a stuck check can hog the single-flight slot. Slightly
+# longer than the longest expected render so a healthy check always releases the
+# lock explicitly; the TTL is the backstop for a crashed/killed worker.
+HEALTHZ_CDN_LOCK_TIMEOUT = 15
 
 # A small set of representative pages we expect to always serve. Anything other
 # than a sub-400 status from any of them flips the healthcheck to 500 and lets
@@ -180,6 +183,43 @@ def _check_critical_pages():
     return 200, "pong"
 
 
+def _safe_cache_get(cache_obj, key):
+    """Wrap cache.get() so a Redis hiccup doesn't take down the healthcheck."""
+    try:
+        return cache_obj.get(key)
+    except Exception:
+        logger.exception("healthz_cdn: cache get failed")
+        return None
+
+
+def _safe_cache_add(cache_obj, key, value, timeout):
+    """Wrap cache.add() so a Redis hiccup doesn't take down the healthcheck.
+
+    Returns True when we claimed the slot (or couldn't tell because of an error
+    and chose to proceed anyway). False only when the slot is genuinely held by
+    another caller.
+    """
+    try:
+        return bool(cache_obj.add(key, value, timeout))
+    except Exception:
+        logger.exception("healthz_cdn: cache add failed; running check uncoordinated")
+        return True
+
+
+def _safe_cache_set(cache_obj, key, value, timeout):
+    try:
+        cache_obj.set(key, value, timeout)
+    except Exception:
+        logger.exception("healthz_cdn: cache set failed")
+
+
+def _safe_cache_delete(cache_obj, key):
+    try:
+        cache_obj.delete(key)
+    except Exception:
+        logger.exception("healthz_cdn: cache delete failed")
+
+
 @require_safe
 @never_cache
 def healthz_cdn(request):
@@ -193,16 +233,31 @@ def healthz_cdn(request):
     if not switch("healthz-cdn-db-checks-enabled"):
         return HttpResponse("pong", content_type="text/plain")
 
-    cached = cache.get(HEALTHZ_CDN_CACHE_KEY)
+    healthz_cache = caches["healthz"]
+
+    cached = _safe_cache_get(healthz_cache, HEALTHZ_CDN_CACHE_KEY)
     if cached is not None:
         status, body = cached
-    else:
+        return HttpResponse(body, content_type="text/plain", status=status)
+
+    # Cache miss. Single-flight via cache.add(): only the caller that claims the
+    # lock runs the render. Other concurrent cache-missers return 200 pong as a
+    # best-effort; the next probe after the winner populates the cache will see
+    # the real result. With a Redis-backed `healthz` cache this dedupes across
+    # the whole fleet, so a cold cache or simultaneous TTL expiry doesn't fan
+    # out into N renders against the DB.
+    if not _safe_cache_add(healthz_cache, HEALTHZ_CDN_LOCK_KEY, 1, HEALTHZ_CDN_LOCK_TIMEOUT):
+        return HttpResponse("pong", content_type="text/plain")
+
+    try:
         try:
             status, body = _check_critical_pages()
         except Exception:
             logger.exception("healthz_cdn: check failed")
             status, body = 500, "check error"
-        cache.set(HEALTHZ_CDN_CACHE_KEY, (status, body), HEALTHZ_CDN_CACHE_TIMEOUT)
+        _safe_cache_set(healthz_cache, HEALTHZ_CDN_CACHE_KEY, (status, body), HEALTHZ_CDN_CACHE_TIMEOUT)
+    finally:
+        _safe_cache_delete(healthz_cache, HEALTHZ_CDN_LOCK_KEY)
 
     return HttpResponse(body, content_type="text/plain", status=status)
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -474,7 +474,7 @@ SUPPORTED_NONLOCALES = [
     "robots.txt",
     ".well-known",
     "healthz",  # Needed for k8s
-    # "healthz-cdn",  # Needed for Fastly CDN health checks
+    "healthz-cdn",  # Needed for Fastly CDN health checks
     "readiness",  # Needed for k8s
     "healthz-cron",  # status dash
     "revision.txt",  # from root_files

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -108,6 +108,30 @@ CACHES = {
             "CULL_FREQUENCY": 4,  # 1/4 entries deleted if max reached
         },
     },
+    # Shared cache for cross-pod coordination. Used by /healthz-cdn/ so that
+    # all pods share one fleet-wide check result instead of each pod
+    # independently rendering the critical pages every TTL. When REDIS_URL is
+    # not set (local dev, CI), this falls back to the in-process LocMemCache
+    # so behaviour matches the default cache.
+    "healthz": (
+        {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            # DB 1 to keep healthcheck keys separate from the RQ queues on DB 0.
+            "LOCATION": f"{REDIS_URL}/1",
+            "KEY_PREFIX": "springfield-healthz",
+            "TIMEOUT": 30,
+        }
+        if REDIS_URL
+        else {
+            "BACKEND": "springfield.base.cache.SimpleDictCache",
+            "LOCATION": "healthz",
+            "TIMEOUT": 30,
+            "OPTIONS": {
+                "MAX_ENTRIES": 16,
+                "CULL_FREQUENCY": 4,
+            },
+        }
+    ),
 }
 
 # Logging

--- a/springfield/urls.py
+++ b/springfield/urls.py
@@ -38,7 +38,7 @@ urlpatterns += (
     path("", include("springfield.base.nonlocale_urls")),
     path("", include("springfield.sitemaps.urls")),
     path("healthz/", watchman_views.ping, name="watchman.ping"),
-    # path("healthz-cdn/", base_views.healthz_cdn, name="healthz-cdn"),
+    path("healthz-cdn/", base_views.healthz_cdn, name="healthz-cdn"),
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("healthz-cron/", base_views.cron_health_check),
     path("_documents/", include(wagtaildocs_urls)),


### PR DESCRIPTION
**Exploration / discussion PR — depends on #1537.** This branch is layered directly on top of `WT-1119--make-healthz-cdn-better`, so the diff against `main` includes the page-render work in #1537 plus the Redis layer; the [compare against the PR branch](https://github.com/mozmeao/springfield/compare/WT-1119--make-healthz-cdn-better...WT-1119--healthz-cdn-redis-cache) shows the Redis delta in isolation.

## Why

The LocMemCache approach in #1537 is per-pod, so check load scales linearly with pod count. At 45 pods that's ~45 healthcheck-induced query bursts per 30s across the fleet; at the 100-pod ceiling it's ~100. Each render holds the pod's single Granian blocking thread for the duration. A shared cache collapses the fleet to ~1 render per TTL regardless of pod count, and a single-flight mutex prevents cold-cache or simultaneous-expiry stampedes.

## What's in here (delta over #1537)

- New `healthz` named cache in `settings.CACHES`. Uses the existing `REDIS_URL` (Cloud Memorystore in prod, 1GB) on DB 1, keeping healthz keys separate from the RQ task queues on DB 0. Falls back to a per-process LocMemCache when `REDIS_URL` is unset (local dev, CI) so test behaviour is unchanged.
- `healthz_cdn` switches from the default `cache` to `caches[\"healthz\"]` and adds a `cache.add()` lock around the render. Lock holder runs the check and populates the cache; concurrent cache-missers return `200 pong` best-effort and let the winner's result land. The lock has a 15s TTL backstop in case a worker is killed mid-check.
- All cache operations are wrapped in `_safe_cache_*` helpers so a Redis hiccup never takes the healthcheck down: a failed get/add falls through to an uncoordinated check; a failed set/delete is logged but doesn't affect the response.

## Trade-offs to discuss vs the LocMemCache version in #1537

- Adds a soft dependency on Redis. With the safe wrappers it's not a hard dependency — Redis being down loses the cross-pod dedup and every pod runs its own check, but the healthcheck itself still works.
- Adds ~1–3ms of Redis round-trip per probe (one GET, plus SET and DELETE on the lock holder).
- Adds keys in DB 1 of the existing Redis instance — worth confirming the 1GB memory budget has headroom (it should: this cache holds at most one result tuple and one lock entry).
- The winner-takes-all approach can briefly delay detection of a fresh failure: if pod A wins the lock and is still rendering, pod B–Z return 200 pong best-effort even if the prior cached result was 500. Bounded by `HEALTHZ_CDN_LOCK_TIMEOUT` (15s).

## When this is worth it

My own read: marginal at 25–45 pods (the LocMemCache load is already small); a clearer win if you scale above ~100 or if connection pressure on Cloud SQL becomes a thing. Mostly here so we have a concrete shape to compare against, rather than a recommendation to land.

## Test plan

- [x] `uv run pytest springfield/base/tests/test_urls.py` — 13 tests pass
- [x] `uv run pytest springfield/base/` — 343 tests pass
- [x] `uv run ruff check` clean on changed files
- [ ] Confirm Memorystore DB 1 is reachable from the springfield namespace
- [ ] Verify behaviour in dev / staging with Redis present and Redis briefly stopped
- [ ] Compare check-rate metrics against the #1537 baseline