### PR TITLE
Wt 1375 plausible consent gating

### DIFF
--- a/media/js/base/plausible/plausible.es6.js
+++ b/media/js/base/plausible/plausible.es6.js
@@ -10,9 +10,7 @@ const Plausible = {};
 
 /**
  * Determines if the visitor has opted out of analytics, via GPC, DNT, or by
- * explicitly declining analytics in the consent banner. A missing cookie is
- * NOT a denial: Plausible runs cookieless by default (e.g. for EU visitors who
- * haven't made a choice yet), so only an explicit `analytics: false` opts out.
+ * explicitly declining analytics in the consent banner.
  * @returns {Boolean}
  */
 Plausible.analyticsDenied = () => {

--- a/media/js/base/plausible/plausible.es6.js
+++ b/media/js/base/plausible/plausible.es6.js
@@ -4,9 +4,25 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { dntEnabled, gpcEnabled } from '../consent/utils.es6';
+import { dntEnabled, getConsentCookie, gpcEnabled } from '../consent/utils.es6';
 
 const Plausible = {};
+
+/**
+ * Determines if the visitor has opted out of analytics, via GPC, DNT, or by
+ * explicitly declining analytics in the consent banner. A missing cookie is
+ * NOT a denial: Plausible runs cookieless by default (e.g. for EU visitors who
+ * haven't made a choice yet), so only an explicit `analytics: false` opts out.
+ * @returns {Boolean}
+ */
+Plausible.analyticsDenied = () => {
+    if (gpcEnabled() || dntEnabled()) {
+        return true;
+    }
+
+    const consent = getConsentCookie();
+    return !!consent && consent.analytics === false;
+};
 
 Plausible.defineQueueStub = () => {
     window.plausible =
@@ -35,7 +51,7 @@ Plausible.loadScript = () => {
 Plausible.init = () => {
     Plausible.defineQueueStub();
 
-    if (gpcEnabled() || dntEnabled()) {
+    if (Plausible.analyticsDenied()) {
         return;
     }
 

--- a/tests/unit/spec/base/plausible/plausible.js
+++ b/tests/unit/spec/base/plausible/plausible.js
@@ -54,6 +54,56 @@ describe('plausible.es6.js', function () {
             expect(Plausible.defineQueueStub).toHaveBeenCalled();
             expect(Plausible.loadScript).toHaveBeenCalled();
         });
+
+        it('should define the queue stub but not load the script if analytics consent was explicitly declined', function () {
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify({ analytics: false })
+            );
+
+            Plausible.init();
+            expect(Plausible.defineQueueStub).toHaveBeenCalled();
+            expect(Plausible.loadScript).not.toHaveBeenCalled();
+        });
+
+        it('should load the script when analytics consent was granted', function () {
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify({ analytics: true })
+            );
+
+            Plausible.init();
+            expect(Plausible.loadScript).toHaveBeenCalled();
+        });
+    });
+
+    describe('analyticsDenied', function () {
+        it('should return true when GPC is enabled', function () {
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+            expect(Plausible.analyticsDenied()).toBe(true);
+        });
+
+        it('should return true when DNT is enabled', function () {
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+            expect(Plausible.analyticsDenied()).toBe(true);
+        });
+
+        it('should return true when the consent cookie explicitly declines analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify({ analytics: false })
+            );
+            expect(Plausible.analyticsDenied()).toBe(true);
+        });
+
+        it('should return false when the consent cookie grants analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify({ analytics: true })
+            );
+            expect(Plausible.analyticsDenied()).toBe(false);
+        });
+
+        it('should return false when no consent cookie is set (cookieless default)', function () {
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(null);
+            expect(Plausible.analyticsDenied()).toBe(false);
+        });
     });
 
     describe('loadScript', function () {


### PR DESCRIPTION
## One-line summary

Skip loading Plausible analytics when a visitor has opted out.

## Significant changes and points to review

- Adds a `Plausible.analyticsDenied()` helper that centralizes the opt-out checks (GPC, DNT, and an explicit analytics opt-out in the consent cookie).
- `Plausible.init()` now uses that helper instead of the inline GPC/DNT check, so the script is not loaded at all when a visitor has opted out.
- **Point to review:** a missing consent cookie is intentionally *not* treated as an opt-out, so the default loading behavior is unchanged; only an explicit opt-out suppresses loading.
- **Point to review:** gating happens at init/script-load time. An opt-out made *after* the script has already loaded in the same session would need a per-event check to be covered (noted as a follow-up).

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1388

## Testing

- `npm run jasmine` passes (465 specs, 0 failures), stable across multiple random seeds.
- Added unit coverage for `analyticsDenied()` (GPC, DNT, cookie opt-out, cookie opt-in, and no-cookie cases) and for `init()` loading / not loading the script accordingly.
- `npx eslint` clean.
