### PR TITLE
Remove poster + first frame trigger logic

### DIFF
--- a/media/js/cms/pages/flare26-kick-page.es6.js
+++ b/media/js/cms/pages/flare26-kick-page.es6.js
@@ -27,7 +27,6 @@ const setupKickPage = () => {
 
     const video = document.createElement('video');
     video.muted = true;
-    video.poster = '/media/img/logos/firefox/logo-word-hor-white-2026.svg';
 
     const source = document.createElement('source');
     source.src = 'https://assets.mozilla.net/wc/logo-1-alpha.webm';
@@ -50,18 +49,6 @@ const setupKickPage = () => {
         },
         { once: true }
     );
-
-    // Play and pause to trigger the first frame to be loaded
-    const playPromise = video.play();
-    if (playPromise !== undefined) {
-        playPromise
-            .then(() => {
-                video.pause();
-            })
-            .catch(() => {
-                // Ignore `play()` rejections (e.g. `AbortError` when paused before playback begins)
-            });
-    }
 };
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## One-line summary

To solve a noisy `AbortError` in Sentry that’s also hard to recreate, this removes the logic that’s likely the culprit and then relies on the browser showing the first frame of the video without the poster.

## Significant changes and points to review

In Firefox and Chrome (Safari is not applicable), it seems to work fine from my testing locally. From my understanding of the spec, the first frame is expected when the video has data, is paused, and the currentTime is 0 (https://html.spec.whatwg.org/multipage/media.html#dom-video-poster:~:text=else%20the%20first%20frame%20of%20the%20video).

## Issue / Bugzilla link

## Testing

Load the page normally in Firefox or Chrome. Then try it with data throttling set to Good 3G.

Try hovering the video logo once loaded, there should be no shift as the first frame will be used.

Compare this with live.