### PR TITLE
WT-1119: remove /healthz-cdn/ from Springfield

### DIFF
--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -36,57 +36,6 @@ def test_readiness(client):
     )
 
 
-# def test_healthz_cdn(client):
-#     _test(
-#         url="/healthz-cdn/",
-#         client=client,
-#         expected_content="pong",
-#     )
-
-
-# def test_healthz_cdn_fails_when_migrations_pending(client):
-#     from django.db.migrations.executor import MigrationExecutor
-
-#     class FakeMigration:
-#         app_label = "fake_app"
-#         name = "0001_fake"
-
-#     with patch.object(MigrationExecutor, "migration_plan", return_value=[(FakeMigration(), False)]):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="migrations pending",
-#         )
-
-
-# def test_healthz_cdn_fails_when_history_inconsistent(client):
-#     from django.db.migrations.exceptions import InconsistentMigrationHistory
-#     from django.db.migrations.loader import MigrationLoader
-
-#     with patch.object(MigrationLoader, "check_consistent_history", side_effect=InconsistentMigrationHistory("test")):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="migration history inconsistent",
-#         )
-
-
-# def test_healthz_cdn_fails_when_column_missing(client):
-#     from django.db import connection
-
-#     # Return empty column list for all tables — makes every managed model appear
-#     # to have all its columns missing, catching dropped-column schema drift.
-#     with patch.object(connection.introspection, "get_table_description", return_value=[]):
-#         _test(
-#             url="/healthz-cdn/",
-#             client=client,
-#             expected_status=500,
-#             expected_content="schema mismatch",
-#         )
-
-
 def test_healthz_cron(client):
     _test(
         url="/healthz-cron/",

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -3,18 +3,12 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import json
-import logging
 import os.path
 from datetime import datetime
 from os import getenv
 from time import time
 
-from django.apps import apps
 from django.conf import settings
-from django.db import connections
-from django.db.migrations.exceptions import InconsistentMigrationHistory
-from django.db.migrations.executor import MigrationExecutor
-from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
@@ -114,66 +108,6 @@ def get_extra_server_info():
             server_info[f"db_{key}"] = value
 
     return server_info
-
-
-logger = logging.getLogger(__name__)
-
-
-@require_safe
-@never_cache
-def healthz_cdn(request):
-    try:
-        if settings.WATCHMAN_DISABLE_APM:
-            try:
-                from watchman.views import _disable_apm
-
-                _disable_apm()
-            except (ImportError, AttributeError):
-                logger.warning("healthz_cdn: watchman _disable_apm unavailable; continuing without disabling APM")
-
-        connection = connections["default"]
-
-        # Check 1: migration records — catches new code deployed before migrations run,
-        # and applied migrations whose dependencies are missing (InconsistentMigrationHistory).
-        executor = MigrationExecutor(connection)
-        try:
-            executor.loader.check_consistent_history(connection)
-        except InconsistentMigrationHistory as e:
-            logger.warning("healthz_cdn: inconsistent migration history: %s", e)
-            return HttpResponse("migration history inconsistent", content_type="text/plain", status=500)
-        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-        if plan:
-            unapplied = ", ".join(f"{m.app_label}.{m.name}" for m, _backwards in plan)
-            logger.warning("healthz_cdn: unapplied migrations: %s", unapplied)
-            return HttpResponse("migrations pending", content_type="text/plain", status=500)
-
-        # Check 2: schema introspection — catches old code running after a column-dropping
-        # migration. Compares each managed model's expected columns (_meta.local_fields,
-        # which reflects what the running code expects) against the actual DB schema.
-        # This correctly handles Wagtail MTI subclasses, which each have their own table.
-        with connection.cursor() as cursor:
-            for model in apps.get_models():
-                if not model._meta.managed or model._meta.proxy or model._meta.app_label == "wagtailsearch":
-                    continue
-                expected_cols = {f.column for f in model._meta.local_fields}
-                if not expected_cols:
-                    continue
-                actual_cols = {col.name for col in connection.introspection.get_table_description(cursor, model._meta.db_table)}
-                # SQLite's implicit rowid is never listed by PRAGMA table_info() but is
-                # always accessible on every table. Not needed in production (PostgreSQL)
-                # but allows local SQLite testing.
-                if connection.vendor == "sqlite":
-                    actual_cols.add("rowid")
-                missing = expected_cols - actual_cols
-                if missing:
-                    logger.warning("healthz_cdn: missing columns in %s: %s", model._meta.db_table, missing)
-                    return HttpResponse("schema mismatch", content_type="text/plain", status=500)
-
-    except Exception:
-        logger.exception("healthz_cdn: check failed")
-        return HttpResponse("check error", content_type="text/plain", status=500)
-
-    return HttpResponse("pong", content_type="text/plain")
 
 
 @require_safe

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -472,7 +472,6 @@ SUPPORTED_NONLOCALES = [
     "robots.txt",
     ".well-known",
     "healthz",  # Needed for k8s
-    # "healthz-cdn",  # Needed for Fastly CDN health checks
     "readiness",  # Needed for k8s
     "healthz-cron",  # status dash
     "revision.txt",  # from root_files

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -513,7 +513,7 @@ NOINDEX_URLS = [
     r"^thanks/$",
     r"^analytics-tests/",
     r"^readiness/$",
-    r"^healthz(-cron|-cdn)?/$",
+    r"^healthz-cron/$",
     # exclude redirects
     r"^firefox/notes/$",
 ]
@@ -786,7 +786,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = config("SECURE_CONTENT_TYPE_NOSNIFF", default="tru
 SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", default=str(not DISABLE_SSL), parser=bool)
 SECURE_REDIRECT_EXEMPT = [
     r"^readiness/$",
-    r"^healthz(-cron|-cdn)?/$",
+    r"^healthz-cron/$",
 ]
 if config("USE_SECURE_PROXY_HEADER", default=str(SECURE_SSL_REDIRECT), parser=bool):
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/springfield/urls.py
+++ b/springfield/urls.py
@@ -38,7 +38,6 @@ urlpatterns += (
     path("", include("springfield.base.nonlocale_urls")),
     path("", include("springfield.sitemaps.urls")),
     path("healthz/", watchman_views.ping, name="watchman.ping"),
-    # path("healthz-cdn/", base_views.healthz_cdn, name="healthz-cdn"),
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("healthz-cron/", base_views.cron_health_check),
     path("_documents/", include(wagtaildocs_urls)),


### PR DESCRIPTION
## Summary

Removes the disabled `/healthz-cdn/` endpoint and all related scaffolding.

We're moving the failover-on-bad-origin logic to Fastly's VCL (real-time 5xx response handling
plus stale-on-error) rather than trying to express it as an app-side healthcheck — so the surface
area can just go away. The simple `/healthz/` ping (watchman) and the `/healthz-cron/` status
dashboard are unchanged.

## What's removed

- `healthz_cdn` view and its `logger` in `springfield/base/views.py`
- Now-unused imports: `django.apps.apps`, `django.db.connections`,
  `InconsistentMigrationHistory`, `MigrationExecutor`, `HttpResponse`, `logging`
- The commented-out URL pattern in `springfield/urls.py`
- The commented-out `SUPPORTED_NONLOCALES` entry in `springfield/settings/base.py`
- The four commented-out tests in `springfield/base/tests/test_urls.py`

## Context

Two earlier exploratory PRs (#1537 page-render approach, #1538 Redis-cache variant) have been
closed without merging. The takeaway from those iterations was that an active healthcheck either
loads the DB too much or amplifies slow-page conditions, and the cleaner fix is on the Fastly side
— observed-5xx triggered fallback, with `stale_if_error` for cacheable pages. That work will land
separately in `webservices-infra/springfield`, starting with Dev only.

## Test plan

- [x] `uv run pytest springfield/base/` — 333 tests pass
- [x] `uv run ruff check` clean
- [x] No remaining references to `healthz_cdn`, `healthz-cdn`, or `HEALTHZ_CDN` in the codebase