### PR TITLE
WT-1338 fix newsletter checkmark theme issues

### DIFF
--- a/media/css/cms/components/flare26-newsletterform.css
+++ b/media/css/cms/components/flare26-newsletterform.css
@@ -329,6 +329,14 @@
 .fl-newsletterform-success svg {
     display: block;
     margin: 0 auto;
+
+    path {
+        stroke: var(--fl-theme-color-text-inverse);
+    }
+
+    circle {
+        fill: var(--fl-theme-color-text);
+    }
 }
 
 .newsletter-page .fl-newsletterform-cta {

--- a/media/css/cms/flare-newsletterform.css
+++ b/media/css/cms/flare-newsletterform.css
@@ -295,4 +295,12 @@
 .fl-newsletterform-success svg {
     display: block;
     margin: 0 auto;
+
+    path {
+        stroke: var(--fl-theme-color-text-inverse);
+    }
+
+    circle {
+        fill: var(--fl-theme-color-text);
+    }
 }

--- a/springfield/cms/templates/cms/newsletter_enterprise_form.html
+++ b/springfield/cms/templates/cms/newsletter_enterprise_form.html
@@ -106,8 +106,8 @@
        {% if thankyou_head %}aria-label="{{ thankyou_head }}" {% endif %}
        {% if thankyou_content %}aria-description="{{ thankyou_content }}" {% endif %}>
     <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <circle cx="40" cy="40" r="40" fill="white" />
-      <path d="M28 40L36 48L52 32" stroke="black" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
+      <circle cx="40" cy="40" r="40" fill="black" />
+      <path d="M28 40L36 48L52 32" stroke="white" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
     </svg>
   </div>
 

--- a/springfield/cms/templates/cms/newsletter_form.html
+++ b/springfield/cms/templates/cms/newsletter_form.html
@@ -105,8 +105,8 @@
        {% if thankyou_head %}aria-label="{{ thankyou_head }}" {% endif %}
        {% if thankyou_content %}aria-description="{{ thankyou_content }}" {% endif %}>
     <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <circle cx="40" cy="40" r="40" fill="white" />
-      <path d="M28 40L36 48L52 32" stroke="black" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
+      <circle cx="40" cy="40" r="40" fill="black" />
+      <path d="M28 40L36 48L52 32" stroke="white" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
     </svg>
   </div>
 

--- a/springfield/firefox/templates/firefox/testflight/testflight-flare26.html
+++ b/springfield/firefox/templates/firefox/testflight/testflight-flare26.html
@@ -80,8 +80,8 @@
 
           <div id="newsletter-thanks" class="fl-newsletterform-success hidden" data-testid="newsletter-thanks-message">
             <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <circle cx="40" cy="40" r="40" fill="white" />
-              <path d="M28 40L36 48L52 32" stroke="black" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
+              <circle cx="40" cy="40" r="40" fill="black" />
+              <path d="M28 40L36 48L52 32" stroke="white" stroke-width="4" stroke-linecap="butt" stroke-linejoin="miter" />
             </svg>
             <h3>Congrats!</h3>
             <h4>You have been added to the Firefox for iOS testing program.</h4>


### PR DESCRIPTION
## One-line summary

This PR fixes the newsletter checkmark visual issue in light mode.

## Significant changes and points to review

- added CSS rules to change svg color based on theme
- inverted the svg hard-coded color to make it visible even when CSS is not loaded 

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1338

## Testing

http://localhost:8000/en-US/newsletter/

Submit the form with `success@example.com` in both light and dark mode. Review the status