### PR TITLE
Allow experiments in base-flare26

### DIFF
--- a/media/js/firefox/experiment-meets-criteria.es6.js
+++ b/media/js/firefox/experiment-meets-criteria.es6.js
@@ -29,8 +29,8 @@ function meetsExperimentCriteria() {
         // Don't enter into experiment if consent required and not explicitly given by cookie
         return false;
     } else if (
-        (Mozilla.Cookies.hasItem('moz-stub-attribution-code') ||
-            Mozilla.Cookies.hasItem('moz-stub-attribution-sig')) &&
+        (Mozilla.Cookies.hasItem('moz-download-attribution-code') ||
+            Mozilla.Cookies.hasItem('moz-download-attribution-sig')) &&
         !Mozilla.Cookies.hasItem(experimentCookieID)
     ) {
         // Don't enter into experiment if we already have an attribution cookie

--- a/springfield/cms/templates/cms/base-flare26.html
+++ b/springfield/cms/templates/cms/base-flare26.html
@@ -129,6 +129,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
     {# site bundle must load in head before analytics #}
     {{ js_bundle('site') }}
+    {% block experiments %}{% endblock %}
     {% block google_analytics %}
     {% if settings.GTM_CONTAINER_ID %}
     {{ js_bundle('gtm-snippet') }}

--- a/tests/unit/spec/firefox/new/desktop/experiment-meets-criteria.es6.js
+++ b/tests/unit/spec/firefox/new/desktop/experiment-meets-criteria.es6.js
@@ -71,9 +71,9 @@ describe('experiment-meets-criteria.es6.js', function () {
                 .and.returnValue(false)
                 .withArgs('moz-exp-download-privacy')
                 .and.returnValue(false)
-                .withArgs('moz-stub-attribution-code')
+                .withArgs('moz-download-attribution-code')
                 .and.returnValue(true)
-                .withArgs('moz-stub-attribution-sig')
+                .withArgs('moz-download-attribution-sig')
                 .and.returnValue(true);
 
             const result = meetsExperimentCriteria();


### PR DESCRIPTION
## One-line summary

Adds experiment block to base-flare26 template (currently used for some static pages in addition to CMS pages)

Updates `meetsExperimentCriteria` check to use `download-attribution` strings in cookie check (this was specific to `download-privacy` experiment, but might be used in future experiments)

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
In `springfield/firefox/templates/firefox/landing/get-new.html` add this block on L8
```
{% block experiments %}
  {{ js_bundle('experiment-firefox-home') }}
{% endblock %}
```

Not entered into experiment when user has existing download attribution
- go to http://localhost:8000/en-US/ with US geo
- check you have download attribution cookies in dev tools
- go to http://localhost:8000/en-US/landing/get/
- check you do **not** have `moz-exp-` cookie and were not redirected

Entered into experiment with no existing download attribution (must clear cookies first)
- go to http://localhost:8000/en-US/landing/get/
- check you have `moz-exp-` cookie and URL updates to include experiment/variation params