### PR TITLE
Newsletter copy revisions

### DIFF
--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -127,5 +127,4 @@
 -brand-name-chromebook = Chromebook
 
 # Enterprise program name
--brand-name-support-for-organizations = Support for Organizations
--brand-name-firefox-for-organizations-support = Firefox for Organizations Support
+-brand-name-firefox-professional-support = Firefox Professional Support

--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -59,11 +59,12 @@ firefox-enterprise-release-notes = Release Notes
 #   $firefox_all (url) - link to https://www.firefox.com/download/all/
 firefox-enterprise-download-firefox-or-esr = Download { -brand-name-firefox } or { -brand-name-firefox-esr } for <a { $firefox_all }>another language or platform.</a>
 
-firefox-enterprise-support-for-organizations = { -brand-name-support-for-organizations }
+firefox-enterprise-support-for-organizations = { -brand-name-firefox-professional-support }
+
 # Obsolete string (expires: 2026-06-10)
 firefox-enterprise-early-access-is = Early access is now open for our new support program launching in January 2026. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-early-access-is-v2 = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-contact-sales = Contact Sales
-firefox-enterprise-support-for-organizations-documentation = { -brand-name-support-for-organizations } documentation
-firefox-enterprise-support-for-organizations-is = { -brand-name-support-for-organizations } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.
+firefox-enterprise-support-for-organizations-documentation = { -brand-name-firefox-professional-support } documentation
+firefox-enterprise-support-for-organizations-is = { -brand-name-firefox-professional-support } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.
 firefox-enterprise-support-plan = Support Plan

--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -61,7 +61,6 @@ firefox-enterprise-download-firefox-or-esr = Download { -brand-name-firefox } or
 
 firefox-enterprise-support-for-organizations-v2 = { -brand-name-firefox-professional-support }
 
-# Obsolete string (expires: 2026-06-10)
 firefox-enterprise-early-access-is = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-contact-sales = Contact Sales
 firefox-enterprise-support-for-organizations-documentation-v2 = { -brand-name-firefox-professional-support } documentation

--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -59,12 +59,11 @@ firefox-enterprise-release-notes = Release Notes
 #   $firefox_all (url) - link to https://www.firefox.com/download/all/
 firefox-enterprise-download-firefox-or-esr = Download { -brand-name-firefox } or { -brand-name-firefox-esr } for <a { $firefox_all }>another language or platform.</a>
 
-firefox-enterprise-support-for-organizations = { -brand-name-firefox-professional-support }
+firefox-enterprise-support-for-organizations-v2 = { -brand-name-firefox-professional-support }
 
 # Obsolete string (expires: 2026-06-10)
-firefox-enterprise-early-access-is = Early access is now open for our new support program launching in January 2026. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
-firefox-enterprise-early-access-is-v2 = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
+firefox-enterprise-early-access-is = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-contact-sales = Contact Sales
-firefox-enterprise-support-for-organizations-documentation = { -brand-name-firefox-professional-support } documentation
-firefox-enterprise-support-for-organizations-is = { -brand-name-firefox-professional-support } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.
+firefox-enterprise-support-for-organizations-documentation-v2 = { -brand-name-firefox-professional-support } documentation
+firefox-enterprise-support-for-organizations-is-v2 = { -brand-name-firefox-professional-support } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.
 firefox-enterprise-support-plan = Support Plan

--- a/l10n/en/firefox/enterprise.ftl
+++ b/l10n/en/firefox/enterprise.ftl
@@ -61,7 +61,7 @@ firefox-enterprise-download-firefox-or-esr = Download { -brand-name-firefox } or
 
 firefox-enterprise-support-for-organizations-v2 = { -brand-name-firefox-professional-support }
 
-firefox-enterprise-early-access-is = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
+firefox-enterprise-early-access-is-v3 = Early access is now open for our new support program. Built for organizations that use { -brand-name-firefox } to ensure security, resilience, and data sovereignty, it provides private, reliable, and custom support for large-scale deployments.
 firefox-enterprise-contact-sales = Contact Sales
 firefox-enterprise-support-for-organizations-documentation-v2 = { -brand-name-firefox-professional-support } documentation
 firefox-enterprise-support-for-organizations-is-v2 = { -brand-name-firefox-professional-support } is a dedicated offering for teams who need private issue triage and escalation, defined response times, custom development options, and close collaboration with { -brand-name-mozilla }’s engineering and product teams.

--- a/l10n/en/newsletter/newsletters.ftl
+++ b/l10n/en/newsletter/newsletters.ftl
@@ -15,18 +15,15 @@ newsletters-make-the-most = Make the most out of { -brand-name-firefox }
 newsletters-sign-up-to-receive-monthly = Sign up to receive monthly updates from { -brand-name-firefox } and internet trends that shape your life online.
 
 # Enterprise
-
-newsletter-enterprise-title = Subscribe to { -brand-name-mozilla } Enterprise Updates
 newsletter-enterprise-title-v2 = Subscribe for { -brand-name-mozilla } Enterprise Updates
 
 newsletter-enterprise-description-v2 = Stay informed about { -brand-name-firefox-enterprise }, { -brand-name-firefox-professional-support }, as well as relevant webinars, events, and product updates for IT, security, and compliance professionals.
 newsletter-enterprise-description-note = Note: Your subscription is voluntary and can be withdrawn at any time.
 
 # Consent checkbox label in the enterprise newsletter form
-newsletter-enterprise-form-consent-v2 = I would like to receive emails from { -brand-name-mozilla } about Enterprise products, events, product updates, and related IT, security, and compliance topics.
 newsletter-enterprise-form-consent-v3 = By submitting this form, you consent to { -brand-name-mozilla } contacting you about Enterprise products, events, product updates, and related IT, security, and compliance topics.
 
-newsletter-enterprise-form-consent-details-v2 = These emails may include information about { -brand-name-firefox-enterprise }, { -brand-name-firefox-professional-support }, webinars, events, product updates, and feature updates for IT, security, and compliance topics. I can withdraw my consent at any time with effect for the future.
+newsletter-enterprise-form-consent-details-v3 = These emails may include information about { -brand-name-firefox-enterprise }, { -brand-name-firefox-professional-support }, webinars, events, product updates, and feature updates for IT, security, and compliance topics. I can withdraw my consent at any time with effect for the future.
 
 # Privacy notice section below the enterprise newsletter form
 newsletter-enterprise-privacy-statement = { -brand-name-mozilla } will process the information you provide in order to send you the selected email communications and to document your consent. Further information is available in { -brand-name-mozilla }'s privacy notice.

--- a/l10n/en/newsletter/newsletters.ftl
+++ b/l10n/en/newsletter/newsletters.ftl
@@ -17,13 +17,16 @@ newsletters-sign-up-to-receive-monthly = Sign up to receive monthly updates from
 # Enterprise
 
 newsletter-enterprise-title = Subscribe to { -brand-name-mozilla } Enterprise Updates
-newsletter-enterprise-description-v2 = Stay informed about { -brand-name-firefox-enterprise }, { -brand-name-firefox-for-organizations-support }, as well as relevant webinars, events, and product updates for IT, security, and compliance professionals.
+newsletter-enterprise-title-v2 = Subscribe for { -brand-name-mozilla } Enterprise Updates
+
+newsletter-enterprise-description-v2 = Stay informed about { -brand-name-firefox-enterprise }, { -brand-name-firefox-professional-support }, as well as relevant webinars, events, and product updates for IT, security, and compliance professionals.
 newsletter-enterprise-description-note = Note: Your subscription is voluntary and can be withdrawn at any time.
 
 # Consent checkbox label in the enterprise newsletter form
 newsletter-enterprise-form-consent-v2 = I would like to receive emails from { -brand-name-mozilla } about Enterprise products, events, product updates, and related IT, security, and compliance topics.
+newsletter-enterprise-form-consent-v3 = By submitting this form, you consent to { -brand-name-mozilla } contacting you about Enterprise products, events, product updates, and related IT, security, and compliance topics.
 
-newsletter-enterprise-form-consent-details-v2 = These emails may include information about { -brand-name-firefox-enterprise }, { -brand-name-firefox-for-organizations-support }, webinars, events, product updates, and feature updates for IT, security, and compliance topics. I can withdraw my consent at any time with effect for the future.
+newsletter-enterprise-form-consent-details-v2 = These emails may include information about { -brand-name-firefox-enterprise }, { -brand-name-firefox-professional-support }, webinars, events, product updates, and feature updates for IT, security, and compliance topics. I can withdraw my consent at any time with effect for the future.
 
 # Privacy notice section below the enterprise newsletter form
 newsletter-enterprise-privacy-statement = { -brand-name-mozilla } will process the information you provide in order to send you the selected email communications and to document your consent. Further information is available in { -brand-name-mozilla }'s privacy notice.

--- a/springfield/cms/ftl_parser.py
+++ b/springfield/cms/ftl_parser.py
@@ -115,7 +115,7 @@ BRAND_TERMS = {
     "-brand-name-google-play": "Google Play",
     "-brand-name-youtube": "YouTube",
     # Enterprise
-    "-brand-name-support-for-organizations": "Support for Organizations",
+    "-brand-name-firefox-professional-support": "Firefox Professional Support",
 }
 
 

--- a/springfield/cms/templates/cms/newsletter_enterprise_form.html
+++ b/springfield/cms/templates/cms/newsletter_enterprise_form.html
@@ -71,7 +71,7 @@
       <div class="fl-newsletterform-consent">
         <label for="newsletter-privacy" class="fl-body fl-newsletterform-checkbox-label">
           <input type="checkbox" id="newsletter-privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox">
-          <span class="fl-newsletterform-checkbox-text">{{ ftl('newsletter-enterprise-form-consent-v2') }}</span>
+          <span class="fl-newsletterform-checkbox-text">{{ ftl('newsletter-enterprise-form-consent-v3', fallback='newsletter-enterprise-form-consent-v2') }}</span>
         </label>
         <p class="fl-body">{{ ftl('newsletter-enterprise-form-consent-details-v2') }}</p>
         <div class="fl-newsletterform-privacy-notice">

--- a/springfield/cms/templates/cms/newsletter_enterprise_form.html
+++ b/springfield/cms/templates/cms/newsletter_enterprise_form.html
@@ -71,9 +71,9 @@
       <div class="fl-newsletterform-consent">
         <label for="newsletter-privacy" class="fl-body fl-newsletterform-checkbox-label">
           <input type="checkbox" id="newsletter-privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox">
-          <span class="fl-newsletterform-checkbox-text">{{ ftl('newsletter-enterprise-form-consent-v3', fallback='newsletter-enterprise-form-consent-v2') }}</span>
+          <span class="fl-newsletterform-checkbox-text">{{ ftl('newsletter-enterprise-form-consent-v3') }}</span>
         </label>
-        <p class="fl-body">{{ ftl('newsletter-enterprise-form-consent-details-v2') }}</p>
+        <p class="fl-body">{{ ftl('newsletter-enterprise-form-consent-details-v3') }}</p>
         <div class="fl-newsletterform-privacy-notice">
           <p class="fl-body">{{ ftl('newsletter-enterprise-privacy-statement') }}</p>
           <p class="fl-body">

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -65,7 +65,7 @@
         level="h2"
         heading_text="{{ ftl('firefox-enterprise-support-for-organizations-v2') }}"
         heading_size="fl-heading-lg"
-        subheading_text="{{ ftl('firefox-enterprise-early-access-is') }}"
+        subheading_text="{{ ftl('firefox-enterprise-early-access-is-v3') }}"
         subheading_size="fl-subheading-4"
       />
     </content:heading>

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -76,7 +76,6 @@
           label="{{ ftl('firefox-enterprise-contact-sales') }}"
           link="/browsers/enterprise/briefing/"
           theme_class="button-tertiary"
-          external="{{ False }}"
           alignment_class="fl-2026-enterprise-support"
         />
       </div>

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -74,7 +74,7 @@
       <div class="fl-buttons">
         <include:button
           label="{{ ftl('firefox-enterprise-contact-sales') }}"
-          link="https://qsurvey.mozilla.com/s3/firefox-support-plan?src=firefox-enterprise-cta"
+          link="/browsers/enterprise/briefing/"
           theme_class="button-tertiary"
           external="{{ False }}"
           alignment_class="fl-2026-enterprise-support"

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -63,9 +63,9 @@
     <content:heading>
       <include:heading
         level="h2"
-        heading_text="{{ ftl('firefox-enterprise-support-for-organizations') }}"
+        heading_text="{{ ftl('firefox-enterprise-support-for-organizations-v2') }}"
         heading_size="fl-heading-lg"
-        subheading_text="{{ ftl('firefox-enterprise-early-access-is-v2', fallback='firefox-enterprise-early-access-is') }}"
+        subheading_text="{{ ftl('firefox-enterprise-early-access-is') }}"
         subheading_size="fl-subheading-4"
       />
     </content:heading>
@@ -151,11 +151,11 @@
       <content:heading>
         <include:heading
           level="h2"
-          heading_text="{{ ftl('firefox-enterprise-support-for-organizations-documentation') }}"
+          heading_text="{{ ftl('firefox-enterprise-support-for-organizations-documentation-v2') }}"
           heading_size="fl-heading-lg"
           alignment_class="fl-2026-enterprise-documentation"
           superheading_text=""
-          subheading_text="{{ ftl('firefox-enterprise-support-for-organizations-is') }}"
+          subheading_text="{{ ftl('firefox-enterprise-support-for-organizations-is-v2') }}"
           subheading_size="fl-subheading-4"
         />
       </content:heading>

--- a/springfield/newsletter/templates/newsletter/enterprise.html
+++ b/springfield/newsletter/templates/newsletter/enterprise.html
@@ -6,7 +6,7 @@
 
 {% extends "cms/base-flare26.html" %}
 
-{% set page_title_copy = ftl('newsletter-enterprise-title-v2', fallback='newsletter-enterprise-title') %}
+{% set page_title_copy = ftl('newsletter-enterprise-title-v2') %}
 {% set page_desc_copy = ftl('newsletter-enterprise-description-v2') %}
 
 {% block page_title %}{{ page_title_copy }}{% endblock page_title %}

--- a/springfield/newsletter/templates/newsletter/enterprise.html
+++ b/springfield/newsletter/templates/newsletter/enterprise.html
@@ -6,7 +6,7 @@
 
 {% extends "cms/base-flare26.html" %}
 
-{% set page_title_copy = ftl('newsletter-enterprise-title') %}
+{% set page_title_copy = ftl('newsletter-enterprise-title-v2', fallback='newsletter-enterprise-title') %}
 {% set page_desc_copy = ftl('newsletter-enterprise-description-v2') %}
 
 {% block page_title %}{{ page_title_copy }}{% endblock page_title %}


### PR DESCRIPTION
## One-line summary
Lots of minor copy changes: 

* "Firefox Support for Organizations" --> "Firefox Professional Support" throughout. 
* consent checkbox copy revised
* "Subscribe **for** Mozilla Enterprise updates"

<img width="699" height="54" alt="Screenshot 2026-06-26 at 1 56 36 PM" src="https://github.com/user-attachments/assets/1a6405e4-b730-4be3-a52c-97820c0c6a42" />
<img width="665" height="85" alt="Screenshot 2026-06-26 at 1 56 30 PM" src="https://github.com/user-attachments/assets/3dd6f6fd-624b-4b8e-aebf-5224543aa4a7" />
<img width="405" height="146" alt="Screenshot 2026-06-26 at 1 56 21 PM" src="https://github.com/user-attachments/assets/00a0b0fc-1875-4989-95e0-39d05f89b7f9" />
<img width="282" height="77" alt="Screenshot 2026-06-26 at 1 56 19 PM" src="https://github.com/user-attachments/assets/93562b91-ab95-40bd-ba2a-b9c98cc71bbf" />
<img width="802" height="381" alt="Screenshot 2026-06-26 at 1 05 35 PM" src="https://github.com/user-attachments/assets/9f1711c4-adcb-45d5-8e27-dbea75d6f768" />
<img width="1284" height="484" alt="Screenshot 2026-06-26 at 1 59 28 PM" src="https://github.com/user-attachments/assets/dab6a4d8-f139-41d1-8f3a-ba0d224c3394" />
