### PR TITLE
Add v152 translation languages

### DIFF
--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -784,6 +784,7 @@ def firefox_features_translate(request):
     translate_langs = [
         "ar",
         "az",
+        "eu",
         "bg",
         "bn",
         "bs",
@@ -798,6 +799,7 @@ def firefox_features_translate(request):
         "fa",
         "fi",
         "fr",
+        "gl",
         "de",
         "el",
         "gu",


### PR DESCRIPTION
## One-line summary

Adds _eu, gl_ to the list of available languages to the Translations feature.

## Significant changes and points to review

This only affects the items in the JS Intl–based lists on static pages. (CMS–managed locales will need updating the feature content separately.)

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/1190

## Testing

http://localhost:8000/fy-NL/features/translate/