### PR TITLE
Escape CMS values in Firefox Account button markup (WT-1397)

### DIFF
--- a/springfield/firefox/templatetags/misc.py
+++ b/springfield/firefox/templatetags/misc.py
@@ -13,6 +13,8 @@ from django.contrib.staticfiles.finders import find as find_static
 from django.template.defaultfilters import slugify as django_slugify
 from django.template.defaulttags import CsrfTokenNode
 from django.utils.encoding import smart_str
+from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 
 import jinja2
 from django_jinja import library
@@ -610,14 +612,10 @@ def _fxa_product_button(
     include_metrics=True,
     optional_parameters=None,
     optional_attributes=None,
-    inner_html=None,  # override button_text with custom inner HTML
+    inner_html=None,  # override button_text with trusted, component-generated inner HTML
 ):
     href = _fxa_product_url(product_url, entrypoint, optional_parameters)
     css_class = "js-fxa-cta-link"
-    attrs = ""
-
-    if optional_attributes:
-        attrs += " ".join(f'{attr}="{val}"' for attr, val in optional_attributes.items())
 
     if include_metrics:
         css_class += " js-fxa-product-button"
@@ -628,7 +626,23 @@ def _fxa_product_button(
     if class_name:
         css_class += f" {class_name}"
 
-    markup = f'<a href="{href}" data-action="{settings.FXA_ENDPOINT}" class="{css_class}" {attrs}>{inner_html if inner_html else button_text}</a>'
+    # Build the anchor with contextual escaping. `button_text`, the optional
+    # attribute values and the href can all carry CMS- or caller-supplied data
+    # (e.g. a Firefox Account button label that flows into the body, into
+    # data-cta-* attributes and into the entrypoint/utm_campaign of the href),
+    # so every interpolated value must be escaped to prevent stored XSS.
+    # `inner_html` is the explicit opt-in slot for trusted, component-generated
+    # markup (an icon plus an already-escaped label) and is rendered as-is.
+    attrs = format_html_join(" ", '{}="{}"', (optional_attributes or {}).items())
+    body = mark_safe(inner_html) if inner_html else button_text
+    markup = format_html(
+        '<a href="{}" data-action="{}" class="{}" {}>{}</a>',
+        href,
+        settings.FXA_ENDPOINT,
+        css_class,
+        attrs,
+        body,
+    )
 
     return Markup(markup)
 

--- a/springfield/firefox/tests/test_helper_misc.py
+++ b/springfield/firefox/tests/test_helper_misc.py
@@ -897,8 +897,8 @@ class TestRelayFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In to Relay", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://relay.firefox.com/accounts/fxa/login/?process=login&entrypoint=mozilla.org-whatsnew&form_type=button'
-            '&utm_source=mozilla.org-whatsnew&utm_medium=referral&utm_campaign=whatsnew96" data-action="https://accounts.firefox.com/" '
+            '<a href="https://relay.firefox.com/accounts/fxa/login/?process=login&amp;entrypoint=mozilla.org-whatsnew&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-whatsnew&amp;utm_medium=referral&amp;utm_campaign=whatsnew96" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product relay-main-cta-button" '
             'data-cta-text="Sign In to Relay" data-cta-type="fxa-relay" data-cta-position="primary">Sign In to Relay</a>'
         )
@@ -940,8 +940,8 @@ class TestMonitorFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In to Monitor", "data-cta-type": "fxa-monitor", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://monitor.mozilla.org/user/dashboard?entrypoint=mozilla.org-firefox-accounts&form_type=button'
-            '&utm_source=mozilla.org-firefox-accounts&utm_medium=referral&utm_campaign=skyline" '
+            '<a href="https://monitor.mozilla.org/user/dashboard?entrypoint=mozilla.org-firefox-accounts&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-accounts&amp;utm_medium=referral&amp;utm_campaign=skyline" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button '
             'monitor-main-cta-button" data-cta-text="Sign In to Monitor" data-cta-type="fxa-monitor" '
             'data-cta-position="primary">Sign In to Monitor</a>'
@@ -986,8 +986,8 @@ class TestFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign Up", "data-cta-type": "fxa-sync", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
-            '&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            '<a href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-whatsnew73&amp;utm_medium=referral&amp;utm_campaign=whatsnew73" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary">Sign Up</a>'
         )
@@ -1006,8 +1006,8 @@ class TestFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In", "data-cta-type": "fxa-sync", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://accounts.firefox.com/signin?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
-            '&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            '<a href="https://accounts.firefox.com/signin?entrypoint=mozilla.org-firefox-whatsnew73&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-whatsnew73&amp;utm_medium=referral&amp;utm_campaign=whatsnew73" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             'fxa-main-cta-button" data-cta-text="Sign In" data-cta-type="fxa-sync" data-cta-position="primary">Sign In</a>'
         )
@@ -1026,12 +1026,76 @@ class TestFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign Up", "data-cta-type": "fxa-sync", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://accounts.firefox.com/?action=email&entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
-            '&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            '<a href="https://accounts.firefox.com/?action=email&amp;entrypoint=mozilla.org-firefox-whatsnew73&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-whatsnew73&amp;utm_medium=referral&amp;utm_campaign=whatsnew73" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary">Sign Up</a>'
         )
         self.assertEqual(markup, expected)
+
+
+@override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+class TestFxAButtonXSS(TestCase):
+    """Regression tests for stored XSS via CMS-controlled FxA button data.
+
+    A CMS editor can set a Firefox Account button label, and (via the
+    rich-text `<fxa>` tag in `cms_tags.richtext`) the `data-cta-*` attribute
+    values. Every value interpolated into the anchor must be contextually
+    escaped. Only the explicit `inner_html` slot is treated as trusted,
+    component-generated markup.
+    """
+
+    PRODUCT_URL = "https://accounts.firefox.com/signup"
+
+    def test_button_text_label_is_escaped(self):
+        """The button label (CMS-controlled) must not render as live HTML."""
+        markup = misc._fxa_product_button(
+            self.PRODUCT_URL,
+            "www.firefox.com-page",
+            button_text="<img src=x onerror=\"alert('XSS')\">",
+        )
+        assert "<img" not in markup
+        assert "&lt;img src=x" in markup
+
+    def test_optional_attribute_value_is_escaped(self):
+        """Attribute values must not break out of the attribute (e.g. the
+        rich-text `<fxa>` path passes `data-cta-text` here without escaping
+        it)."""
+        markup = misc._fxa_product_button(
+            self.PRODUCT_URL,
+            "www.firefox.com-page",
+            button_text="Sign In",
+            optional_attributes={"data-cta-text": '"><script>alert(1)</script>'},
+        )
+        assert "<script>" not in markup
+        assert "&lt;script&gt;" in markup
+
+    def test_label_in_href_entrypoint_is_escaped(self):
+        """In the default UTM path the label flows into `utm_campaign` and
+        `entrypoint`, and into the `href`, where it must not break out of the
+        `href` attribute value."""
+        entrypoint = "www.firefox.com-" + '"><img src=x onerror=alert(1)>'.lower().replace(" ", "_")
+        markup = misc._fxa_product_button(self.PRODUCT_URL, entrypoint, button_text="ok")
+        assert "<img" not in markup
+        assert '"><img' not in markup
+        assert "&lt;img_src=x" in markup
+
+    def test_trusted_inner_html_is_preserved(self):
+        """`inner_html` is the opt-in trusted slot: even a plain (non-safe)
+        string is rendered as-is. The icon path passes a plain `str` (icon SVG
+        plus an already-escaped label, see `test_blocks.py`), so it must not be
+        escaped. This guards the `mark_safe()` in the sink against an
+        over-escaping "tighten everything" change that would double-escape the
+        icon markup."""
+        markup = misc._fxa_product_button(
+            self.PRODUCT_URL,
+            "www.firefox.com-page",
+            button_text="should-be-ignored",
+            inner_html="<svg class='icon'></svg>&lt;img&gt;",
+        )
+        assert "<svg class='icon'></svg>" in markup  # raw SVG preserved, not escaped
+        assert "&lt;svg" not in markup  # ...confirming it was not run through `escape()`
+        assert "should-be-ignored" not in markup  # `button_text` overridden by `inner_html`
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)


### PR DESCRIPTION
# Summary

`_fxa_product_button` assembled the Firefox Account button anchor by string concatenation and returned it as `Markup`, emitting the CMS button label, the optional attribute values and the label-derived `href` without escaping. Any CMS editor who can edit and publish a page with a Firefox Account Button could store active HTML in the label and trigger stored XSS for every visitor of the public page.

The fix suggested in the report only escaped the button label, which closes the anchor body but leaves two more injection points open: the optional attribute values (reachable through the rich-text `<fxa>` path in `cms_tags.richtext`) and the `href`, into which the label flows via `utm_campaign` and `entrypoint`. Escaping therefore has to happen at the sink so all three are covered at once.

# Fix

Build the anchor with `format_html` and `format_html_join` so all interpolated values are escaped. `inner_html` remains the single trusted slot via `mark_safe`, which is safe because the component template escapes the label before it reaches that slot.

Escaping the `href` renders its `&` separators as `&amp;`, which is valid HTML and decodes identically, so the existing exact-string button tests are updated to match.

# Tests

New `TestFxAButtonXSS` class:

* `test_button_text_label_is_escaped` confirms a label payload renders as inert text in the anchor body.
* `test_optional_attribute_value_is_escaped` confirms an attribute value cannot break out of its attribute.
* `test_label_in_href_entrypoint_is_escaped` confirms a label reaching the `href` cannot break out of the URL.
* `test_trusted_inner_html_is_preserved` confirms the trusted `inner_html` slot is still rendered as-is.

The three escaping tests were confirmed to fail against the unpatched sink, and the `inner_html` test fails if its `mark_safe` is removed.

# Context

* https://mozilla-hub.atlassian.net/browse/WT-1397
* https://bugzilla.mozilla.org/show_bug.cgi?id=2044038