### PR TITLE
(hotfix): Add clean-up migration to drop stale ContentTypes 

### DIFF
--- a/springfield/cms/migrations/0111_remove_stale_contenttypes.py
+++ b/springfield/cms/migrations/0111_remove_stale_contenttypes.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.db import migrations
+
+STALE_MODELS = (
+    "freeformpage",
+    "whatsnewpage",
+    "downloadfirefoxcalltoactionsnippet",
+)
+
+
+def remove_stale_contenttypes(apps, schema_editor):
+    # Migration 0110 dropped FreeFormPage / WhatsNewPage / DownloadFirefoxCallToActionSnippet
+    # but Django doesn't auto-purge the django_content_type rows for deleted models. Anything
+    # that resolves a log entry / permission via ContentType.get_object_for_this_type() (e.g.
+    # the Wagtail admin home recent-edits panel) then crashes because model_class() is None.
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    ContentType.objects.filter(app_label="cms", model__in=STALE_MODELS).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0110_remove_freeformpage_og_image_and_more"),
+        ("contenttypes", "0002_remove_content_type_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_stale_contenttypes, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
…following the deletion of models

`9b63e06a` deleted some 2025-era page models, but didn't also delete the related ContentType which then caused the recently-edited-pages tab to blow up the CMS dashboard.

This changeset fixes that by deleting the now-stale content types
