### PR TITLE
WT-1119: add SyntheticServerErrorMiddleware to force 5xx for cascade testing

### DIFF
--- a/springfield/base/middleware.py
+++ b/springfield/base/middleware.py
@@ -11,6 +11,7 @@ the locale codes.
 
 import base64
 import contextlib
+import hmac
 import inspect
 import logging
 import time
@@ -200,6 +201,54 @@ def simplified_check_for_language():
         yield
     finally:
         trans_real.check_for_language = check_for_language
+
+
+class SyntheticServerErrorMiddleware:
+    """Returns a synthetic 500 when a request carries a matching magic header.
+
+    Purpose is to test failure paths (specifically Fastly's origin failover
+    cascade) by producing a controlled 5xx from Springfield without breaking
+    anything real.
+
+    The middleware is a no-op when the SYNTHETIC_5XX_TOKEN env var is unset
+    (raises MiddlewareNotUsed so Django drops it from the chain). When set,
+    a request carrying the token in the X-Springfield-Cascade-Test header
+    receives HTTP 500 with a synthetic body; other requests pass through.
+
+    Healthcheck paths (/healthz/, /readiness/, /healthz-cron/) are always
+    passed through so Fastly's probe stays green during a cascade test,
+    which is precisely the scenario the cascade is designed to catch
+    (site broken but /healthz/ says 200).
+
+    Token comparison uses constant-time comparison to avoid timing leaks.
+
+    Trigger by curling with:
+
+        curl -H "X-Springfield-Cascade-Test: <token>" https://<host>/some-path
+    """
+
+    HEADER_NAME = "X-Springfield-Cascade-Test"
+    HEALTHCHECK_PATHS = ("/healthz/", "/readiness/", "/healthz-cron/")
+
+    def __init__(self, get_response):
+        if not settings.SYNTHETIC_5XX_TOKEN:
+            raise MiddlewareNotUsed
+        self.get_response = get_response
+        self._token = settings.SYNTHETIC_5XX_TOKEN
+
+    def __call__(self, request):
+        if request.path in self.HEALTHCHECK_PATHS:
+            return self.get_response(request)
+
+        provided = request.headers.get(self.HEADER_NAME, "")
+        if provided and hmac.compare_digest(provided, self._token):
+            return HttpResponse(
+                "synthetic 500 for cascade test",
+                content_type="text/plain",
+                status=500,
+            )
+
+        return self.get_response(request)
 
 
 class BasicAuthMiddleware:

--- a/springfield/base/middleware.py
+++ b/springfield/base/middleware.py
@@ -242,6 +242,11 @@ class SyntheticServerErrorMiddleware:
 
         provided = request.headers.get(self.HEADER_NAME, "")
         if provided and hmac.compare_digest(provided, self._token):
+            # Emit a metric on every successful match so we can alert on unusual
+            # volume - a legitimate test is a handful of hits, a leaked-token
+            # abuser would look very different. Tag with path only (never the
+            # token) so per-URL patterns are queryable without leaking secrets.
+            metrics.incr("synthetic5xx.triggered", tags=[f"path:{request.path}"])
             return HttpResponse(
                 "synthetic 500 for cascade test",
                 content_type="text/plain",

--- a/springfield/base/middleware.py
+++ b/springfield/base/middleware.py
@@ -211,49 +211,98 @@ class SyntheticServerErrorMiddleware:
     anything real.
 
     The middleware is a no-op when the SYNTHETIC_5XX_TOKEN env var is unset
-    (raises MiddlewareNotUsed so Django drops it from the chain). When set,
-    a request carrying the token in the X-Springfield-Cascade-Test header
-    receives HTTP 500 with a synthetic body; other requests pass through.
+    (raises MiddlewareNotUsed so Django drops it from the chain). It also
+    refuses to arm if the configured token is not exactly TOKEN_LENGTH chars
+    (see below for why length is pinned).
+
+    When armed, a request carrying the token in the X-Mozilla-Ops-Canary
+    header receives HTTP 500 with a synthetic body; other requests pass
+    through.
 
     Healthcheck paths (/healthz/, /readiness/, /healthz-cron/) are always
     passed through so Fastly's probe stays green during a cascade test,
     which is precisely the scenario the cascade is designed to catch
     (site broken but /healthz/ says 200).
 
-    Token comparison uses constant-time comparison to avoid timing leaks.
+    Token comparison uses hmac.compare_digest for constant-time content
+    comparison, gated by a strict length check. Python's docs note that
+    compare_digest can leak string lengths via timing when the operands
+    differ in length; by requiring provided == TOKEN_LENGTH before calling
+    compare_digest, we ensure both operands are always the same length when
+    the comparison runs. The pinned length (64 chars = openssl rand -hex 32
+    = 256 bits of entropy) is public info by design, so any timing signal
+    from the length check itself leaks nothing an attacker doesn't already
+    know.
+
+    Two metrics are emitted for observability:
+    - synthetic5xx.triggered (with path tag) on every successful match.
+      Legit tests = a few hits. Leaked-token abuse = many.
+    - synthetic5xx.header_present_no_match on every request that carries
+      the header with a wrong value or wrong length. A spike here is the
+      early-warning signal for token probing before a guesser succeeds.
+
+    The synthetic 500 response carries Cache-Control and Surrogate-Control
+    headers that instruct all downstream caches (Fastly edge, browser,
+    intermediates) to never store the response. This is belt-and-braces
+    against any misconfigured cache policy that might otherwise poison the
+    URL with a 500 that gets served to legitimate users later.
 
     Trigger by curling with:
 
-        curl -H "X-Springfield-Cascade-Test: <token>" https://<host>/some-path
+        curl -H "X-Mozilla-Ops-Canary: <64-char-token>" https://<host>/some-path
     """
 
-    HEADER_NAME = "X-Springfield-Cascade-Test"
+    HEADER_NAME = "X-Mozilla-Ops-Canary"
     HEALTHCHECK_PATHS = ("/healthz/", "/readiness/", "/healthz-cron/")
+    # openssl rand -hex 32 → 64 hex chars, 256 bits of entropy.
+    TOKEN_LENGTH = 64
 
     def __init__(self, get_response):
-        if not settings.SYNTHETIC_5XX_TOKEN:
+        token = settings.SYNTHETIC_5XX_TOKEN
+        if not token:
+            raise MiddlewareNotUsed
+        if len(token) != self.TOKEN_LENGTH:
+            # Fail loud at startup rather than silently accept a weak/misconfigured
+            # token. `openssl rand -hex 32` is the intended generator.
+            logger.warning(
+                "SyntheticServerErrorMiddleware disabled: SYNTHETIC_5XX_TOKEN must be exactly %d chars, got %d",
+                self.TOKEN_LENGTH,
+                len(token),
+            )
             raise MiddlewareNotUsed
         self.get_response = get_response
-        self._token = settings.SYNTHETIC_5XX_TOKEN
+        self._token = token
 
     def __call__(self, request):
         if request.path in self.HEALTHCHECK_PATHS:
             return self.get_response(request)
 
         provided = request.headers.get(self.HEADER_NAME, "")
-        if provided and hmac.compare_digest(provided, self._token):
-            # Emit a metric on every successful match so we can alert on unusual
-            # volume - a legitimate test is a handful of hits, a leaked-token
-            # abuser would look very different. Tag with path only (never the
-            # token) so per-URL patterns are queryable without leaking secrets.
-            metrics.incr("synthetic5xx.triggered", tags=[f"path:{request.path}"])
-            return HttpResponse(
-                "synthetic 500 for cascade test",
-                content_type="text/plain",
-                status=500,
-            )
+        if not provided:
+            return self.get_response(request)
 
-        return self.get_response(request)
+        # Length short-circuit ensures compare_digest is only ever called with
+        # equal-length operands (see docstring). Any header value present but
+        # not matching (wrong length OR wrong value) counts as a probe attempt
+        # so we get observability on token-guessing BEFORE anyone succeeds.
+        if len(provided) != self.TOKEN_LENGTH or not hmac.compare_digest(provided, self._token):
+            metrics.incr("synthetic5xx.header_present_no_match")
+            return self.get_response(request)
+
+        # Successful match.
+        metrics.incr("synthetic5xx.triggered", tags=[f"path:{request.path}"])
+        response = HttpResponse(
+            "synthetic 500 for cascade test",
+            content_type="text/plain",
+            status=500,
+        )
+        # Prevent any middlebox from caching this synthetic 500 and serving it
+        # to legitimate users of the URL later. Fastly's default already avoids
+        # caching 5xx, but Cache-Control + Surrogate-Control together cover
+        # any surrogate/edge policy that might override the default.
+        response["Cache-Control"] = "no-store, private"
+        response["Surrogate-Control"] = "no-store"
+        return response
 
 
 class BasicAuthMiddleware:

--- a/springfield/base/tests/test_middleware.py
+++ b/springfield/base/tests/test_middleware.py
@@ -633,3 +633,32 @@ def test_synthetic_500_middleware_rejects_prefix_of_token(rf):
     response = middleware(request)
     assert response.status_code == 200
     assert response.content == b"real response"
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_emits_metric_on_match(rf):
+    # Every successful token match increments synthetic5xx.triggered so we can
+    # alert on unusual volume (legit tests are a handful of hits; a leaked-token
+    # abuser would look very different). Tagged with path but never the token.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    with MetricsMock() as mm:
+        request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cret")
+        response = middleware(request)
+    assert response.status_code == 500
+    mm.assert_incr_once("synthetic5xx.triggered", tags=["path:/en-US/"])
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_no_metric_on_passthrough(rf):
+    # Non-matching (or no) header must NOT emit the metric.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    with MetricsMock() as mm:
+        request = rf.get("/en-US/")
+        middleware(request)
+        request2 = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="wrong")
+        middleware(request2)
+    mm.assert_not_incr("synthetic5xx.triggered")

--- a/springfield/base/tests/test_middleware.py
+++ b/springfield/base/tests/test_middleware.py
@@ -736,3 +736,64 @@ def test_synthetic_500_middleware_no_metric_on_missing_header(rf):
         middleware(request)
     mm.assert_not_incr("synthetic5xx.triggered")
     mm.assert_not_incr("synthetic5xx.header_present_no_match")
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_fires_before_locale_redirect(rf):
+    # Positioning proof: our middleware sits BEFORE
+    # SpringfieldLangCodeFixupMiddleware in the MIDDLEWARE list, so a matching
+    # request to `/` returns the synthetic 500 rather than the 302 to /en-US/
+    # (or wherever) that LangCodeFixup would normally issue.
+    #
+    # This matters because the whole point of the middleware is to force
+    # user-facing 5xx on Springfield's actual pages. If LangCodeFixup ran
+    # first, `/` (and any other pre-locale path) would 302 before the
+    # synthetic 500 got a chance to fire, and we couldn't test the cascade
+    # on those paths.
+    from springfield.base.middleware import (
+        SpringfieldLangCodeFixupMiddleware,
+        SyntheticServerErrorMiddleware,
+    )
+
+    # Build the chain in the same order as settings.MIDDLEWARE:
+    # SyntheticServerErrorMiddleware wraps SpringfieldLangCodeFixupMiddleware
+    # wraps a passthrough.
+    inner = SpringfieldLangCodeFixupMiddleware(get_response=_passthrough_response)
+    outer = SyntheticServerErrorMiddleware(get_response=inner)
+
+    # `/` with an Accept-Language header WOULD normally trigger LangCodeFixup
+    # to 302 to /en-GB/ (or /en-US/ etc). With our middleware in front and the
+    # canary token present, we should see 500 instead.
+    request = rf.get(
+        "/",
+        HTTP_ACCEPT_LANGUAGE="en-GB,en;q=0.9",
+        HTTP_X_MOZILLA_OPS_CANARY=_VALID_TOKEN,
+    )
+    response = outer(request)
+
+    # 500, not 302: our middleware short-circuited before LangCodeFixup could redirect
+    assert response.status_code == 500
+    assert b"synthetic 500" in response.content
+    assert response["Cache-Control"] == "no-store, private"
+
+
+def test_lang_code_fixup_would_redirect_root_without_our_middleware(rf):
+    # Baseline / control: without our middleware in front, LangCodeFixup
+    # DOES 302-redirect `/` on requests carrying an Accept-Language header.
+    # Together with the test above, this proves that the 500 we get is
+    # coming from our middleware pre-empting the redirect - not from `/`
+    # simply not redirecting in this test setup.
+    from springfield.base.middleware import SpringfieldLangCodeFixupMiddleware
+
+    inner = SpringfieldLangCodeFixupMiddleware(get_response=_passthrough_response)
+
+    request = rf.get(
+        "/",
+        HTTP_ACCEPT_LANGUAGE="en-GB,en;q=0.9",
+    )
+    response = inner.process_request(request)
+
+    # 302 to a locale-prefixed URL
+    assert response is not None
+    assert response.status_code == 302
+    assert response["Location"].startswith("/en-GB")

--- a/springfield/base/tests/test_middleware.py
+++ b/springfield/base/tests/test_middleware.py
@@ -540,3 +540,82 @@ def test_catch_disallowed_redirect_defaults_to_root_and_logs_full_path(rf, caplo
     assert response["location"] == "/"
     assert caplog.records
     assert caplog.records[0].message == f"Caught and silenced DisallowedRedirect for {request.get_full_path()}"
+
+
+# --- SyntheticServerErrorMiddleware ---------------------------------------
+
+
+def _passthrough_response(request):
+    return HttpResponse("real response", status=200)
+
+
+def test_synthetic_500_middleware_no_op_when_token_unset(rf):
+    from django.core.exceptions import MiddlewareNotUsed
+
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    with override_settings(SYNTHETIC_5XX_TOKEN=""):
+        with pytest.raises(MiddlewareNotUsed):
+            SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_fires_on_matching_header(rf):
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cret")
+    response = middleware(request)
+    assert response.status_code == 500
+    assert b"synthetic 500" in response.content
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_passthrough_without_header(rf):
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get("/en-US/")
+    response = middleware(request)
+    assert response.status_code == 200
+    assert response.content == b"real response"
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_passthrough_with_wrong_header(rf):
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="wrong")
+    response = middleware(request)
+    assert response.status_code == 200
+    assert response.content == b"real response"
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+@pytest.mark.parametrize("path", ["/healthz/", "/readiness/", "/healthz-cron/"])
+def test_synthetic_500_middleware_skips_healthcheck_paths(rf, path):
+    # Even with the matching token, healthcheck paths pass through untouched
+    # so Fastly's probe stays green during a cascade test.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get(path, HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cret")
+    response = middleware(request)
+    assert response.status_code == 200
+    assert response.content == b"real response"
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_uses_constant_time_compare(rf):
+    # Sanity check that comparison is via hmac.compare_digest (not ==) to
+    # avoid leaking token characters via response timing. Assertion is
+    # behavioural: mismatched-length tokens still return passthrough,
+    # not some other error.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    # Prefix collides with token but longer; must NOT match
+    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cretlonger")
+    response = middleware(request)
+    assert response.status_code == 200

--- a/springfield/base/tests/test_middleware.py
+++ b/springfield/base/tests/test_middleware.py
@@ -608,14 +608,28 @@ def test_synthetic_500_middleware_skips_healthcheck_paths(rf, path):
 
 @override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
 def test_synthetic_500_middleware_uses_constant_time_compare(rf):
-    # Sanity check that comparison is via hmac.compare_digest (not ==) to
-    # avoid leaking token characters via response timing. Assertion is
-    # behavioural: mismatched-length tokens still return passthrough,
-    # not some other error.
+    # Verify that hmac.compare_digest is actually used for token comparison,
+    # not a plain == comparison. Timing-safe compare avoids leaking token
+    # characters via response timing.
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
-    # Prefix collides with token but longer; must NOT match
-    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cretlonger")
+    with mock.patch("springfield.base.middleware.hmac.compare_digest", return_value=True) as m:
+        request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="any-value")
+        response = middleware(request)
+    m.assert_called_once_with("any-value", "s3cret")
+    # And the response is the synthetic 500 because we forced the compare to True
+    assert response.status_code == 500
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_rejects_prefix_of_token(rf):
+    # A header value that is a strict prefix of the token must not match,
+    # regardless of what comparison function is used underneath.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3c")
     response = middleware(request)
     assert response.status_code == 200
+    assert response.content == b"real response"

--- a/springfield/base/tests/test_middleware.py
+++ b/springfield/base/tests/test_middleware.py
@@ -544,6 +544,10 @@ def test_catch_disallowed_redirect_defaults_to_root_and_logs_full_path(rf, caplo
 
 # --- SyntheticServerErrorMiddleware ---------------------------------------
 
+# A valid 64-char token for use in tests. Value itself is not sensitive; it's
+# just something the length check will accept.
+_VALID_TOKEN = "a" * 64
+
 
 def _passthrough_response(request):
     return HttpResponse("real response", status=200)
@@ -559,18 +563,55 @@ def test_synthetic_500_middleware_no_op_when_token_unset(rf):
             SyntheticServerErrorMiddleware(get_response=_passthrough_response)
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+def test_synthetic_500_middleware_refuses_short_configured_token(rf):
+    # If the configured token isn't exactly 64 chars, the middleware refuses to
+    # arm itself. Prevents accidental weak-token config from silently working.
+    from django.core.exceptions import MiddlewareNotUsed
+
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    with override_settings(SYNTHETIC_5XX_TOKEN="short"):
+        with pytest.raises(MiddlewareNotUsed):
+            SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+
+
+def test_synthetic_500_middleware_refuses_long_configured_token(rf):
+    from django.core.exceptions import MiddlewareNotUsed
+
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    with override_settings(SYNTHETIC_5XX_TOKEN="a" * 65):
+        with pytest.raises(MiddlewareNotUsed):
+            SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
 def test_synthetic_500_middleware_fires_on_matching_header(rf):
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
-    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cret")
+    request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY=_VALID_TOKEN)
     response = middleware(request)
     assert response.status_code == 500
     assert b"synthetic 500" in response.content
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_synthetic_response_is_not_cacheable(rf):
+    # Cache-Control and Surrogate-Control headers instruct all downstream
+    # caches to never store the response, so a synthetic 500 can't poison the
+    # URL for legitimate users later.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY=_VALID_TOKEN)
+    response = middleware(request)
+    assert response.status_code == 500
+    assert response["Cache-Control"] == "no-store, private"
+    assert response["Surrogate-Control"] == "no-store"
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
 def test_synthetic_500_middleware_passthrough_without_header(rf):
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
@@ -581,18 +622,32 @@ def test_synthetic_500_middleware_passthrough_without_header(rf):
     assert response.content == b"real response"
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
-def test_synthetic_500_middleware_passthrough_with_wrong_header(rf):
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_passthrough_with_wrong_value_header(rf):
+    # Wrong value, correct length - passes through, no 500.
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
-    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="wrong")
+    request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY="b" * 64)
     response = middleware(request)
     assert response.status_code == 200
     assert response.content == b"real response"
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_passthrough_with_wrong_length_header(rf):
+    # Wrong length - shortcircuits before compare_digest is called and
+    # passes through.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY="short")
+    response = middleware(request)
+    assert response.status_code == 200
+    assert response.content == b"real response"
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
 @pytest.mark.parametrize("path", ["/healthz/", "/readiness/", "/healthz-cron/"])
 def test_synthetic_500_middleware_skips_healthcheck_paths(rf, path):
     # Even with the matching token, healthcheck paths pass through untouched
@@ -600,13 +655,13 @@ def test_synthetic_500_middleware_skips_healthcheck_paths(rf, path):
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
-    request = rf.get(path, HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cret")
+    request = rf.get(path, HTTP_X_MOZILLA_OPS_CANARY=_VALID_TOKEN)
     response = middleware(request)
     assert response.status_code == 200
     assert response.content == b"real response"
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
 def test_synthetic_500_middleware_uses_constant_time_compare(rf):
     # Verify that hmac.compare_digest is actually used for token comparison,
     # not a plain == comparison. Timing-safe compare avoids leaking token
@@ -614,28 +669,17 @@ def test_synthetic_500_middleware_uses_constant_time_compare(rf):
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    # Use a 64-char header so we pass the length gate and reach compare_digest.
+    provided = "c" * 64
     with mock.patch("springfield.base.middleware.hmac.compare_digest", return_value=True) as m:
-        request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="any-value")
+        request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY=provided)
         response = middleware(request)
-    m.assert_called_once_with("any-value", "s3cret")
-    # And the response is the synthetic 500 because we forced the compare to True
+    m.assert_called_once_with(provided, _VALID_TOKEN)
+    # Response is the synthetic 500 because we forced the compare to True.
     assert response.status_code == 500
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
-def test_synthetic_500_middleware_rejects_prefix_of_token(rf):
-    # A header value that is a strict prefix of the token must not match,
-    # regardless of what comparison function is used underneath.
-    from springfield.base.middleware import SyntheticServerErrorMiddleware
-
-    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
-    request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3c")
-    response = middleware(request)
-    assert response.status_code == 200
-    assert response.content == b"real response"
-
-
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
 def test_synthetic_500_middleware_emits_metric_on_match(rf):
     # Every successful token match increments synthetic5xx.triggered so we can
     # alert on unusual volume (legit tests are a handful of hits; a leaked-token
@@ -644,21 +688,51 @@ def test_synthetic_500_middleware_emits_metric_on_match(rf):
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
     with MetricsMock() as mm:
-        request = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="s3cret")
+        request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY=_VALID_TOKEN)
         response = middleware(request)
     assert response.status_code == 500
     mm.assert_incr_once("synthetic5xx.triggered", tags=["path:/en-US/"])
 
 
-@override_settings(SYNTHETIC_5XX_TOKEN="s3cret")
-def test_synthetic_500_middleware_no_metric_on_passthrough(rf):
-    # Non-matching (or no) header must NOT emit the metric.
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_emits_probe_metric_on_wrong_value(rf):
+    # Header present but wrong value = suspicious. Increments
+    # synthetic5xx.header_present_no_match so we get visibility on probing
+    # BEFORE anyone succeeds guessing the token.
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    with MetricsMock() as mm:
+        request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY="b" * 64)
+        response = middleware(request)
+    assert response.status_code == 200
+    mm.assert_incr_once("synthetic5xx.header_present_no_match")
+    mm.assert_not_incr("synthetic5xx.triggered")
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_emits_probe_metric_on_wrong_length(rf):
+    # Same probe metric fires when length is wrong (e.g. attacker sending a
+    # prefix or guessing at a different length).
+    from springfield.base.middleware import SyntheticServerErrorMiddleware
+
+    middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
+    with MetricsMock() as mm:
+        request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY="short")
+        response = middleware(request)
+    assert response.status_code == 200
+    mm.assert_incr_once("synthetic5xx.header_present_no_match")
+    mm.assert_not_incr("synthetic5xx.triggered")
+
+
+@override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
+def test_synthetic_500_middleware_no_metric_on_missing_header(rf):
+    # No header at all = normal traffic, no metrics.
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
     with MetricsMock() as mm:
         request = rf.get("/en-US/")
         middleware(request)
-        request2 = rf.get("/en-US/", HTTP_X_SPRINGFIELD_CASCADE_TEST="wrong")
-        middleware(request2)
     mm.assert_not_incr("synthetic5xx.triggered")
+    mm.assert_not_incr("synthetic5xx.header_present_no_match")

--- a/springfield/base/tests/test_sentry.py
+++ b/springfield/base/tests/test_sentry.py
@@ -24,7 +24,7 @@ def test_pre_sentry_sanitisation__before_send_setup():
     assert SENSITIVE_FIELDS_TO_MASK_ENTIRELY == [
         "email",
         # "token",  # token is on the default blocklist, which we also use
-        "X-Springfield-Cascade-Test",
+        "X-Mozilla-Ops-Canary",
     ]
 
 

--- a/springfield/base/tests/test_sentry.py
+++ b/springfield/base/tests/test_sentry.py
@@ -24,6 +24,7 @@ def test_pre_sentry_sanitisation__before_send_setup():
     assert SENSITIVE_FIELDS_TO_MASK_ENTIRELY == [
         "email",
         # "token",  # token is on the default blocklist, which we also use
+        "X-Springfield-Cascade-Test",
     ]
 
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -683,6 +683,14 @@ ENABLE_HOSTNAME_MIDDLEWARE = config("ENABLE_HOSTNAME_MIDDLEWARE", default=str(bo
 BASIC_AUTH_CREDS = config("BASIC_AUTH_CREDS", default="")
 ENABLE_METRICS_VIEW_TIMING_MIDDLEWARE = config("ENABLE_METRICS_VIEW_TIMING_MIDDLEWARE", default="false", parser=bool)
 
+# Optional token that arms SyntheticServerErrorMiddleware. When set (via a k8s
+# Secret in webservices-infra), requests carrying the same token in the
+# X-Springfield-Cascade-Test header receive HTTP 500. Used to force user-facing
+# 5xx for testing Fastly's failover cascade without breaking the /healthz/
+# probe. When unset (the default in every environment) the middleware is a
+# no-op and this setting has no effect.
+SYNTHETIC_5XX_TOKEN = config("SYNTHETIC_5XX_TOKEN", default="")
+
 MIDDLEWARE = [
     # IMPORTANT: this may be extended later in this file or via settings/__init__.py
     "django.middleware.security.SecurityMiddleware",
@@ -691,6 +699,7 @@ MIDDLEWARE = [
     "django.middleware.http.ConditionalGetMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "springfield.base.middleware.BasicAuthMiddleware",
+    "springfield.base.middleware.SyntheticServerErrorMiddleware",
     "springfield.base.middleware.CatchDisallowedRedirect",
     "springfield.redirects.middleware.RedirectsMiddleware",  # must come before SpringfieldLocaleMiddleware
     "springfield.base.middleware.SpringfieldLangCodeFixupMiddleware",  # must come after RedirectsMiddleware

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1091,9 +1091,9 @@ SENTRY_DSN = config("SENTRY_DSN", default="")
 SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
     "email",
     # "token",  # token is on the default blocklist, which we also use via `with_default_keys`
-    # X-Springfield-Cascade-Test carries the SYNTHETIC_5XX_TOKEN value on cascade-test
+    # X-Mozilla-Ops-Canary carries the SYNTHETIC_5XX_TOKEN value on cascade-test
     # requests; keep it out of Sentry events so the token cannot leak via error reports.
-    "X-Springfield-Cascade-Test",
+    "X-Mozilla-Ops-Canary",
 ]
 SENTRY_IGNORE_ERRORS = (
     BrokenPipeError,

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1091,6 +1091,9 @@ SENTRY_DSN = config("SENTRY_DSN", default="")
 SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
     "email",
     # "token",  # token is on the default blocklist, which we also use via `with_default_keys`
+    # X-Springfield-Cascade-Test carries the SYNTHETIC_5XX_TOKEN value on cascade-test
+    # requests; keep it out of Sentry events so the token cannot leak via error reports.
+    "X-Springfield-Cascade-Test",
 ]
 SENTRY_IGNORE_ERRORS = (
     BrokenPipeError,


### PR DESCRIPTION
## Summary

This changeset adds a token-gated Django middleware that returns HTTP 500 when a request carries a matching
`X-Springfield-Cascade-Test` header. The purpose is to force user-facing 5xx from Springfield in a
controlled way, so we can test Fastly's [origin failover cascade](https://github.com/mozilla/webservices-infra/pull/11575) without breaking anything real.

## Why we need this

If we scale down the cluster to 0 to simulate GKE dying, then Fastly's redirector logic sends traffic to the failover static site, but that doesn't use the cascade/fallback logic that we want to add. 

The "cascade" behaviour (details below) is triggered by 500s in pages even when `/healthz/` (which is pretty naive) confirm the application is technically available.

In Dev it doesn't really make a difference, but in Stage and Prod we want to be able to run a failover cascade from the US cluster to the EU cluster and _then_ to the static site in the worst case. This new middleware lets us test that in by simulating 500s from pages which are not the `/healthz/` or `/readiness/` pages.


## What it does

- **When `SYNTHETIC_5XX_TOKEN` env var is unset**: middleware raises `MiddlewareNotUsed` at construction so Django drops it from the chain entirely. Zero cost, zero risk. This is the default in every environment.
- **When `SYNTHETIC_5XX_TOKEN` is set** (via a k8s Secret, only for environments where cascade testing is desired): a request carrying the same token value in the `X-Mozilla-Ops-Canary` header returns HTTP 500 with a synthetic body. Other requests pass through.
- **Healthcheck paths (`/healthz/`, `/readiness/`, `/healthz-cron/`) are always passed through** even with the matching token. This is deliberate and load-bearing: we need to force user-facing 5xx WHILE keeping `/healthz/` green, so that Fastly's probe stays healthy and only the restart-based cascade can rescue the request. Otherwise the probe would trip and director-fallback would kick in, obscuring what we're trying to test.
- **Token comparison uses `hmac.compare_digest`** for constant-time comparison, so nothing about the token can be inferred from response timing.

## Test plan

- [x] New unit tests in `test_middleware.py` covering: no-op when unset, fires on matching header,
      passthrough without header, passthrough with wrong header, skips each of the three healthcheck
      paths, constant-time compare prefix-resistance
- [x] `uv run pytest springfield/base/tests/test_middleware.py` (62 tests pass)
- [x] `ruff check` clean on changed files
- [ ] After Secret is set in Dev, run the actual cascade test via curl and confirm `restarts=1, backend=F_springfield_backup, response_status=200` in BQ
