### PR TITLE
Add v148 translation languages

### DIFF
--- a/springfield/firefox/templates/firefox/features/translate.html
+++ b/springfield/firefox/templates/firefox/features/translate.html
@@ -25,8 +25,9 @@
 <ul class="c-lang-list c-translate-lang-list mzp-u-list-styled">
 {%- set display = 'English' if LANG.startswith('en-') else 'native' -%}
 {%- for lang in translate_langs -%}
-  {# Remove regional variants for the listing #}
-  {%- set name = (lang_names[lang][display] if lang_names[lang] else lang).split(' (')[0] %}
+  {# Remove regional variants save for zh #}
+  {%- set full_name = lang_names[lang][display] if lang_names[lang] else lang %}
+  {%- set name = full_name if lang in ['zh-CN', 'zh-TW'] else full_name.split(' (')[0] %}
   <li data-lang="{{ lang }}"{% if display == 'native' %} lang="{{ lang }}"{% endif %}>{{ name }}</li>
 {%- endfor %}
 </ul>

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -753,6 +753,7 @@ def firefox_features_translate(request):
         "bs",
         "ca",
         "zh-CN",
+        "zh-TW",
         "hr",
         "cs",
         "da",


### PR DESCRIPTION
## One-line summary

Backfills missing languages in the Translations feature list of non–CMS content. Additional _vi_ direction was already covered, and now with (regional) variants, scripts and subtags called out based on CLDR this also adds _zh-TW_ explicitly.

## Significant changes and points to review

Comparing both CMS and nonCMS lists with the model data to check for accuracy showed a few gaps. The v148 languages at the time were handled differently, and were also announced in a different section, so were not added right away, but now that extra entry can be rendered I'm adding it here. (This only affects the items in the JS Intl–based lists on static pages.)

CMS–managed locales have a different few languages missing, see the linked ticket.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/1190

## Testing

http://localhost:8000/fy-NL/features/translate/