### PR TITLE
WT-1119: drop Cache-Control override from synthetic 500 response

### DIFF
--- a/springfield/base/middleware.py
+++ b/springfield/base/middleware.py
@@ -241,11 +241,13 @@ class SyntheticServerErrorMiddleware:
       the header with a wrong value or wrong length. A spike here is the
       early-warning signal for token probing before a guesser succeeds.
 
-    The synthetic 500 response carries Cache-Control and Surrogate-Control
-    headers that instruct all downstream caches (Fastly edge, browser,
-    intermediates) to never store the response. This is belt-and-braces
-    against any misconfigured cache policy that might otherwise poison the
-    URL with a 500 that gets served to legitimate users later.
+    The synthetic 500 response is a plain text body with no Cache-Control or
+    Surrogate-Control override. Setting `Cache-Control: no-store` (which was
+    tempting as belt-and-braces against caching a 500) empirically caused
+    Fastly to enter pass state BEFORE our failover cascade in vcl_fetch got
+    a look, suppressing the restart. Fastly's default behaviour already
+    avoids caching 5xx, so the belt-and-braces was low-value and worth
+    dropping for the cascade to fire correctly.
 
     Trigger by curling with:
 
@@ -291,18 +293,19 @@ class SyntheticServerErrorMiddleware:
 
         # Successful match.
         metrics.incr("synthetic5xx.triggered", tags=[f"path:{request.path}"])
-        response = HttpResponse(
+        # Note: we deliberately do NOT set Cache-Control: no-store or
+        # Surrogate-Control here, even as belt-and-braces against a synthetic
+        # 500 getting cached. Empirically, Fastly reacts to those headers by
+        # switching the response into pass state BEFORE our cascade block in
+        # vcl_fetch gets a look, which suppresses the failover restart we
+        # want to trigger. Fastly's default behaviour already avoids caching
+        # 5xx responses, so the belt-and-braces was low-value; the cascade
+        # firing correctly is not. See PR #1567 discussion (2026-07-02).
+        return HttpResponse(
             "synthetic 500 for cascade test",
             content_type="text/plain",
             status=500,
         )
-        # Prevent any middlebox from caching this synthetic 500 and serving it
-        # to legitimate users of the URL later. Fastly's default already avoids
-        # caching 5xx, but Cache-Control + Surrogate-Control together cover
-        # any surrogate/edge policy that might override the default.
-        response["Cache-Control"] = "no-store, private"
-        response["Surrogate-Control"] = "no-store"
-        return response
 
 
 class BasicAuthMiddleware:

--- a/springfield/base/tests/test_middleware.py
+++ b/springfield/base/tests/test_middleware.py
@@ -597,18 +597,20 @@ def test_synthetic_500_middleware_fires_on_matching_header(rf):
 
 
 @override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
-def test_synthetic_500_middleware_synthetic_response_is_not_cacheable(rf):
-    # Cache-Control and Surrogate-Control headers instruct all downstream
-    # caches to never store the response, so a synthetic 500 can't poison the
-    # URL for legitimate users later.
+def test_synthetic_500_middleware_synthetic_response_has_no_cache_override(rf):
+    # We deliberately do NOT set Cache-Control: no-store or Surrogate-Control on
+    # the synthetic response, even as belt-and-braces against caching a 500.
+    # In Dev testing, those headers caused Fastly to enter pass state before
+    # our failover cascade in vcl_fetch got a look, suppressing the restart.
+    # Fastly's default behaviour already avoids caching 5xx.
     from springfield.base.middleware import SyntheticServerErrorMiddleware
 
     middleware = SyntheticServerErrorMiddleware(get_response=_passthrough_response)
     request = rf.get("/en-US/", HTTP_X_MOZILLA_OPS_CANARY=_VALID_TOKEN)
     response = middleware(request)
     assert response.status_code == 500
-    assert response["Cache-Control"] == "no-store, private"
-    assert response["Surrogate-Control"] == "no-store"
+    assert "Cache-Control" not in response
+    assert "Surrogate-Control" not in response
 
 
 @override_settings(SYNTHETIC_5XX_TOKEN=_VALID_TOKEN)
@@ -774,7 +776,6 @@ def test_synthetic_500_middleware_fires_before_locale_redirect(rf):
     # 500, not 302: our middleware short-circuited before LangCodeFixup could redirect
     assert response.status_code == 500
     assert b"synthetic 500" in response.content
-    assert response["Cache-Control"] == "no-store, private"
 
 
 def test_lang_code_fixup_would_redirect_root_without_our_middleware(rf):


### PR DESCRIPTION
Setting `Cache-Control: no-store, private` (and `Surrogate-Control: no-store`) on the
synthetic 500 caused Fastly to switch the response into pass state before the failover
cascade in `vcl_fetch` could fire. BQ evidence: `restarts=0, response_state=PASS` on test
requests.

Drops both headers. Fastly's default is to not cache 5xx anyway, so the belt-and-braces was
low-value; the cascade firing correctly is not.

Test and docstring updated accordingly.