### PR TITLE
Illustration card video play button always on bottom right

### DIFF
--- a/media/css/cms/components/flare-media.css
+++ b/media/css/cms/components/flare-media.css
@@ -91,12 +91,22 @@
     z-index: 1;
 }
 
+/* Center on non-animation videos */
 .fl-video:not(.fl-animation, .fl-video-is-animation) .fl-video-play-icon {
     block-size: 48px;
     inline-size: 48px;
     inset-block-start: 50%;
     inset-inline-start: 50%;
     transform: translate(-50%, -50%);
+}
+
+/* illustration cards always bottom-right */
+.fl-illustration-card .fl-video .fl-video-play-icon {
+    block-size: 36px;
+    inline-size: 36px;
+    inset-block-start: auto;
+    inset-inline-start: auto;
+    transform: none;
 }
 
 .fl-video-play-icon svg {


### PR DESCRIPTION
## One-line summary

This is a quick fix, but it illustrates an awkward situation where the difference between the "animation" and "video" components are beginning to get muddy. This change makes it so the play button is always on the bottom right corner in either component when used in vertical illustration cards. 

[Slack context](https://mozilla.slack.com/archives/C019N6J8FGA/p1782404411799349)

Before: 
<img width="666" height="455" alt="Screenshot 2026-07-02 at 9 08 19 AM" src="https://github.com/user-attachments/assets/5bb4f5f0-fe4c-499e-8c42-0f9fec884274" />

After: 
<img width="695" height="510" alt="Screenshot 2026-07-02 at 9 14 23 AM" src="https://github.com/user-attachments/assets/781b2a8a-7799-4db2-963e-599d539e94a3" />

To test: build a card list, then add illustration cards. In one card, place a video, and in the other, place an animation, and set "show pause button" to visible. You should see that both play/pause buttons look identical. 