### PR TITLE
Fix BreadcrumbList to exclude non-routable ancestors

### DIFF
--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -10,7 +10,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 
 from wagtail.admin.panels import FieldPanel
-from wagtail.models import Locale, Page as WagtailBasePage
+from wagtail.models import Locale, Page as WagtailBasePage, Site
 from wagtail_localize.fields import SynchronizedField
 
 from lib import l10n_utils
@@ -205,3 +205,26 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
     def noindex(self):
         """By default, don't add the robots meta tag to CMS pages, but allow child classes to override this if needed."""
         return False
+
+    def get_breadcrumb_ancestors(self):
+        """Live, publicly-visible ancestors of this page for a BreadcrumbList.
+
+        Restricts the ancestor chain to pages within the current Site's
+        routable subtree by matching `url_path` prefixes against the cached
+        `Site.get_site_root_paths()`. Pages above the routable subtree — the
+        Wagtail system root (depth 1) and per-locale root pages (depth 2 in
+        production, see migration 0060_create_alias_locale_records) — have
+        `url_path`s outside every SiteRootPath prefix and are excluded.
+
+        Applies `.public()` so ancestors with a `PageViewRestriction`
+        (password-required, group-restricted, login-required) never leak
+        into public JSON-LD.
+
+        Filters on `url_path` rather than calling `get_site()` / iterating
+        `full_url` on each ancestor — both would fire extra queries per
+        page render. Don't refactor to `full_url is not None` in Python.
+        """
+        for site_root_path in Site.get_site_root_paths():
+            if self.url_path.startswith(site_root_path.root_path):
+                return self.get_ancestors().live().public().filter(url_path__startswith=site_root_path.root_path)
+        return WagtailBasePage.objects.none()

--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -226,5 +226,5 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
         """
         for site_root_path in Site.get_site_root_paths():
             if self.url_path.startswith(site_root_path.root_path):
-                return self.get_ancestors().live().public().filter(url_path__startswith=site_root_path.root_path)
+                return self.get_ancestors().live().public().filter(url_path__startswith=site_root_path.root_path).order_by("path")
         return WagtailBasePage.objects.none()

--- a/springfield/cms/templates/cms/base-flare.html
+++ b/springfield/cms/templates/cms/base-flare.html
@@ -83,7 +83,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
     {% block structured_data %}
       {% if page is defined %}
-        {% set breadcrumb_ancestors = page.get_ancestors().live().filter(depth__gt=1) %}
+        {% set breadcrumb_ancestors = page.get_breadcrumb_ancestors() %}
         {% if breadcrumb_ancestors %}
         <script type="application/ld+json">
         {

--- a/springfield/cms/tests/conftest.py
+++ b/springfield/cms/tests/conftest.py
@@ -363,3 +363,52 @@ def site_with_en_de_fr_it_homepages_and_some_translations(site_with_en_de_fr_it_
     it_translation = fr_page.copy_for_translation(it_locale)
     it_translation.title = "Italian Translation"
     it_translation.save_revision().publish()
+
+
+@pytest.fixture
+def prod_shape_site():
+    """Site tree mirroring production's 3-level shape (see migration 0060).
+
+    - depth 1: Wagtail system root
+    - depth 2: 'Welcome to your new Wagtail site!' — the seeded default page,
+      demoted so it is NOT Site.root_page (mirrors production's per-locale
+      roots that sit above Site.root_page and have full_url=None)
+    - depth 3: Site.root_page — the localized homepage
+    - depth 4+: content pages
+
+    Use this to exercise regressions that only reproduce when a non-routable
+    ancestor sits above Site.root_page. The `tiny_localized_site` fixture
+    has Site.root_page at depth 2 and cannot catch such regressions.
+    """
+    default_seed_page = Page.objects.get(depth=2, slug="home")
+
+    homepage = SimpleRichTextPageFactory(
+        title="Firefox Home",
+        slug="firefox-home",
+        parent=default_seed_page,
+        live=True,
+    )
+
+    site = Site.objects.get(is_default_site=True)
+    site.root_page = homepage
+    site.save()
+
+    features = SimpleRichTextPageFactory(
+        title="Features",
+        slug="features",
+        parent=homepage,
+        live=True,
+    )
+    article = SimpleRichTextPageFactory(
+        title="Private Browsing",
+        slug="private-browsing",
+        parent=features,
+        live=True,
+    )
+
+    return {
+        "default_seed": default_seed_page,
+        "homepage": homepage,
+        "features": features,
+        "article": article,
+    }

--- a/springfield/cms/tests/test_blog_pages.py
+++ b/springfield/cms/tests/test_blog_pages.py
@@ -764,10 +764,15 @@ def test_blog_article_related_articles_display_image(privacy_articles, rf):
 
 
 def test_blog_index_no_n_plus_one_queries(blog_setup, rf, django_assert_max_num_queries):
-    """Blog index page should fetch all related data in bulk, not per article."""
+    """Blog index page should fetch all related data in bulk, not per article.
+
+    The ceiling includes one query from AbstractSpringfieldCMSPage.get_breadcrumb_ancestors
+    calling `.public()`, which does a PageViewRestriction lookup per render — required to
+    keep view-restricted ancestors out of the BreadcrumbList JSON-LD.
+    """
     index_page, _ = blog_setup
     request = rf.get(index_page.get_full_url())
-    with django_assert_max_num_queries(17):
+    with django_assert_max_num_queries(18):
         index_page.serve(request)
 
 
@@ -776,5 +781,5 @@ def test_blog_all_no_n_plus_one_queries(blog_setup, rf, django_assert_max_num_qu
     index_page, _ = blog_setup
     url = index_page.full_url + index_page.reverse_subpage("all_route")
     request = rf.get(url)
-    with django_assert_max_num_queries(20):
+    with django_assert_max_num_queries(21):
         index_page.all_route(request)

--- a/springfield/cms/tests/test_structured_data.py
+++ b/springfield/cms/tests/test_structured_data.py
@@ -17,6 +17,7 @@ from django.conf import settings
 
 import pytest
 from bs4 import BeautifulSoup
+from wagtail.models import Page
 
 from springfield.cms.fixtures.homepage_fixtures import get_home_test_page
 
@@ -143,22 +144,107 @@ def test_homepage_software_application_has_dynamic_version(index_page, rf):
 
 
 # ---------------------------------------------------------------------------
-# BreadcrumbList on nested CMS pages
+# BreadcrumbList — get_breadcrumb_ancestors() helper on AbstractSpringfieldCMSPage
 #
-# BreadcrumbList rendering lives in the `{% block structured_data %}` default
-# in `cms/base-flare.html`. It fires for any CMS page whose template extends
-# base-flare.html and which has ancestors above the Wagtail root.
-#
-# The straightforward `tiny_localized_site` fixture (used in
-# test_locale_fallback_rendering.py) creates `SimpleRichTextPage` instances
-# which extend `base-protocol.html` — a legacy base that does NOT have the
-# structured_data block. Adding live-render coverage for BreadcrumbList would
-# require building a nested fixture with a page type that extends
-# base-flare.html (e.g. ArticleDetailPage), which is more setup than this
-# behavior warrants.
-#
-# Manual verification path: visit any nested CMS page in dev and view source —
-# the JSON-LD BreadcrumbList block appears in <head> with itemListElement
-# entries for each ancestor and the current page (last item has `name` but no
-# `item` URL, per schema.org convention).
+# Full template-render coverage is skipped: the fixture pages extend
+# base-protocol.html (no structured_data block). The helper is what actually
+# determines whether the emitted BreadcrumbList is correct, so we cover it
+# directly.
 # ---------------------------------------------------------------------------
+
+
+def test_get_breadcrumb_ancestors_starts_at_site_root(tiny_localized_site):
+    """The ancestor list must start at Site.root_page, never above it.
+
+    Regression guard for the "Welcome to your new Wagtail site!" leak: in
+    production the Wagtail tree root and per-locale roots sit above
+    Site.root_page, and their titles must not appear in the BreadcrumbList.
+    """
+    home = Page.objects.get(locale__language_code="en-US", slug="home")
+    test_page = home.get_children().get(slug="test-page")
+    child_page = test_page.get_children().get(slug="child-page")
+
+    ancestors = list(child_page.specific.get_breadcrumb_ancestors())
+
+    assert ancestors == [home, test_page]
+
+
+def test_get_breadcrumb_ancestors_excludes_wagtail_system_root(tiny_localized_site):
+    """The depth-1 Wagtail system root must never appear in the breadcrumb."""
+    home = Page.objects.get(locale__language_code="en-US", slug="home")
+    test_page = home.get_children().get(slug="test-page")
+
+    wagtail_root = Page.objects.get(depth=1)
+
+    for page in test_page.specific.get_breadcrumb_ancestors():
+        assert page != wagtail_root
+        assert page.depth > 1
+
+
+def test_get_breadcrumb_ancestors_all_items_have_full_url(tiny_localized_site):
+    """Every ancestor returned must be routable (full_url is not None).
+
+    This is the invariant that a valid Google BreadcrumbList requires: every
+    non-final `item` must be a resolvable URL.
+    """
+    home = Page.objects.get(locale__language_code="en-US", slug="home")
+    child_page = home.get_children().get(slug="test-page").get_children().get(slug="child-page")
+
+    for page in child_page.specific.get_breadcrumb_ancestors():
+        assert page.full_url is not None, f"Ancestor {page!r} has full_url=None — would emit invalid BreadcrumbList"
+
+
+def test_get_breadcrumb_ancestors_only_returns_live_pages(tiny_localized_site):
+    """Unpublished ancestors must be excluded."""
+    home = Page.objects.get(locale__language_code="en-US", slug="home")
+    test_page = home.get_children().get(slug="test-page")
+    child_page = test_page.get_children().get(slug="child-page")
+
+    test_page.unpublish()
+
+    ancestors = list(child_page.specific.get_breadcrumb_ancestors())
+    assert test_page not in ancestors
+
+
+def test_get_breadcrumb_ancestors_excludes_ancestor_above_site_root_page(prod_shape_site):
+    """Regression guard for the production bug this method was written to fix.
+
+    Uses a fixture that mirrors production's 3-level tree, where a non-routable
+    page ('Welcome to your new Wagtail site!') sits at depth 2 above
+    Site.root_page at depth 3. A regression to depth-based filtering
+    (`filter(depth__gt=1)`) would leak that page's title into the breadcrumb;
+    this test would catch it. The other tests in this file use `tiny_localized_site`
+    where Site.root_page is at depth 2, so they cannot reproduce this scenario.
+    """
+    article = prod_shape_site["article"]
+    default_seed = prod_shape_site["default_seed"]
+    homepage = prod_shape_site["homepage"]
+    features = prod_shape_site["features"]
+
+    ancestors = list(article.specific.get_breadcrumb_ancestors())
+
+    ancestor_pks = [a.pk for a in ancestors]
+    assert default_seed.pk not in ancestor_pks
+    assert all(a.title != "Welcome to your new Wagtail site!" for a in ancestors)
+    assert ancestor_pks == [homepage.pk, features.pk]
+
+
+def test_get_breadcrumb_ancestors_excludes_view_restricted_ancestors(prod_shape_site):
+    """Access-restricted ancestors must not leak into public JSON-LD.
+
+    A password-protected or group-restricted ancestor would otherwise expose
+    its title and URL to Google when a public descendant is crawled.
+    """
+    from wagtail.models import PageViewRestriction
+
+    features = prod_shape_site["features"]
+    article = prod_shape_site["article"]
+
+    PageViewRestriction.objects.create(
+        page=features,
+        restriction_type=PageViewRestriction.PASSWORD,
+        password="secret",
+    )
+
+    ancestors = list(article.specific.get_breadcrumb_ancestors())
+    assert features.pk not in [a.pk for a in ancestors]

--- a/springfield/cms/tests/test_structured_data.py
+++ b/springfield/cms/tests/test_structured_data.py
@@ -17,7 +17,7 @@ from django.conf import settings
 
 import pytest
 from bs4 import BeautifulSoup
-from wagtail.models import Page
+from wagtail.models import Page, PageViewRestriction
 
 from springfield.cms.fixtures.homepage_fixtures import get_home_test_page
 
@@ -235,8 +235,6 @@ def test_get_breadcrumb_ancestors_excludes_view_restricted_ancestors(prod_shape_
     A password-protected or group-restricted ancestor would otherwise expose
     its title and URL to Google when a public descendant is crawled.
     """
-    from wagtail.models import PageViewRestriction
-
     features = prod_shape_site["features"]
     article = prod_shape_site["article"]
 
@@ -248,3 +246,23 @@ def test_get_breadcrumb_ancestors_excludes_view_restricted_ancestors(prod_shape_
 
     ancestors = list(article.specific.get_breadcrumb_ancestors())
     assert features.pk not in [a.pk for a in ancestors]
+
+
+def test_get_breadcrumb_ancestors_query_count(prod_shape_site, django_assert_max_num_queries):
+    """Tripwire for the docstring's `Don't refactor to full_url is not None` warning.
+
+    In steady state, the helper should fire exactly 2 queries: one for `.public()`'s
+    PageViewRestriction lookup and one for the ancestor QuerySet. Site.get_site_root_paths
+    is cached — in production requests it's always warm; here we pre-call it to isolate
+    the steady-state cost from the one-time cache warmup.
+
+    If a future refactor swaps the url_path prefix filter for per-ancestor Python
+    attribute access (`[a for a in ... if a.full_url]`), this ceiling will trip.
+    """
+    from wagtail.models import Site
+
+    Site.get_site_root_paths()  # warm the cache the way production requests do
+
+    article = prod_shape_site["article"]
+    with django_assert_max_num_queries(2):
+        list(article.specific.get_breadcrumb_ancestors())


### PR DESCRIPTION
## What changed

Fixes the `BreadcrumbList` JSON-LD emitted on CMS pages. Previously position 1 was `{"name": "Welcome to your new Wagtail site!", "item": null}` — a Wagtail default title leaking on every CMS page (invalid schema per Google's spec, since only the last position can omit `item`).

Root cause: template filtered ancestors by `depth__gt=1`, keeping the depth-2 non-routable per-locale root pages that sit above `Site.root_page` in production (see migration 0060).

- New `AbstractSpringfieldCMSPage.get_breadcrumb_ancestors()` — filters by `url_path` prefix against the cached `Site.get_site_root_paths()`, so only ancestors inside the routable subtree are returned.
- Also chains `.public()` to keep view-restricted ancestor titles/URLs out of public JSON-LD.
- Template updated to call the helper.
- New `prod_shape_site` fixture that mirrors production's 3-level tree, plus 6 new tests covering the helper (including one that would catch a regression to `depth__gt=1`, and one that would catch dropping `.public()`).

## Things to note

- **Cost:** +1 DB query per CMS page render (`.public()` does a `PageViewRestriction` lookup). Bumped `test_blog_index_no_n_plus_one_queries` (17→18) and `test_blog_all_no_n_plus_one_queries` (20→21) with an explanatory comment.
- **Homepage behavior change:** rendering `Site.root_page` itself now emits no `BreadcrumbList` at all (its own url_path is not a prefix of any ancestor's). Before, it emitted a broken 2-item list with `"Welcome..."` at position 1. Confirm SEO is fine with a home page having no BreadcrumbList — I think it's the right call.
- **Data-side cleanup (not in this PR):** the depth-2 per-locale root pages still have the default `"Welcome to your new Wagtail site!"` title in Wagtail. Not user-visible after this fix, but I'll rename them manually in prod for admin readability.
- **Preview mode caveat:** `.live()` filters draft ancestors, so previews under an unpublished parent show a truncated breadcrumb. Considered out of scope — preview honestly reflecting "what would ship if only this page were published" is arguably correct.

## How to test

```bash
pytest springfield/cms/tests/test_structured_data.py springfield/cms/tests/test_blog_pages.py -v