### PR TITLE
Fix Compare page integration tests

### DIFF
--- a/tests/playwright/specs/compare/compare-article-download.spec.js
+++ b/tests/playwright/specs/compare/compare-article-download.spec.js
@@ -21,11 +21,9 @@ test.describe(
         });
 
         test('Download button is displayed', async ({ page, browserName }) => {
-            const downloadButtonPrimary = page
-                .locator('.c-compare-footer')
-                .getByRole('link', {
-                    name: 'Download Firefox'
-                });
+            const downloadButtonPrimary = page.locator(
+                '.fl-pre-footer-cta-button'
+            );
 
             if (browserName === 'firefox') {
                 await expect(downloadButtonPrimary).not.toBeVisible();


### PR DESCRIPTION
## One-line summary

Fix the download button selector for Compare pages in Playwright tests now that they're served from the CMS.

## Significant changes and points to review

- Change the Playwright test selector to target the Pre Footer CTA snippet download button used in CMS pages

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1413

## Testing

Run integration tests with a fresh prod DB