### PR TITLE
Fix arg order in release-notes redirect tests

### DIFF
--- a/springfield/releasenotes/tests/test_views.py
+++ b/springfield/releasenotes/tests/test_views.py
@@ -171,7 +171,7 @@ def test_releases_index__product_other_than_firefox(render_mock, rf):
     ],
 )
 @patch("springfield.releasenotes.views.latest_release")
-def test_latest_redirects_preserve_query_params(view_func, url_method, latest_release_mock, rf):
+def test_latest_redirects_preserve_query_params(latest_release_mock, view_func, url_method, rf):
     mock_release = latest_release_mock.return_value
     mock_release.get_sysreq_url.return_value = "/firefox/ios/152.0/system-requirements/"
     mock_release.get_absolute_url.return_value = "/en-US/firefox/ios/152.0/releasenotes/"
@@ -192,7 +192,7 @@ def test_latest_redirects_preserve_query_params(view_func, url_method, latest_re
     ],
 )
 @patch("springfield.releasenotes.views.latest_release")
-def test_latest_redirects_without_query_params(view_func, url_method, latest_release_mock, rf):
+def test_latest_redirects_without_query_params(latest_release_mock, view_func, url_method, rf):
     mock_release = latest_release_mock.return_value
     mock_release.get_sysreq_url.return_value = "/firefox/ios/152.0/system-requirements/"
     mock_release.get_absolute_url.return_value = "/en-US/firefox/ios/152.0/releasenotes/"


### PR DESCRIPTION
The previous commit added two parametrized redirect tests that broke CI at collection time with "function uses no argument 'view_func'".

The cause is argument ordering. When a test combines `@patch` with `@pytest.mark.parametrize`, `mock.patch` injects its mock as the first positional argument, so the patched mock has to be the first parameter in the function signature. The new tests put `latest_release_mock` after `view_func` and `url_method`, so pytest stripped `view_func` as if it were the mock and then could not match the parametrized name.

This moves `latest_release_mock` to the front of the signature in `test_latest_redirects_preserve_query_params` and `test_latest_redirects_without_query_params`. No production code changes, the view logic from the previous commit is unchanged.

All 31 tests in `springfield/releasenotes/tests/test_views.py` pass.

Follow-up of issue #1520 and PR #1521.