### PR TITLE
Remove decorational video animations from tab order

### DIFF
--- a/springfield/cms/templates/components/animation.html
+++ b/springfield/cms/templates/components/animation.html
@@ -11,6 +11,8 @@
   <video
     autoplay muted loop
     poster="{{ poster }}"
+    {# Firefox does not support playsinline, so we need to manually remove it from the tab order #}
+    tabindex="-1"
     playsinline
     preload="metadata"
   >


### PR DESCRIPTION
## One-line summary

The `playsinline` attribute for the `<video>` element is not supported in Firefox, which in other browsers removes the video element from the tab order, so we need to manually remove it from the tab order with `tabindex=-1`.

## Significant changes and points to review

Here’s what it looks like **before** when the element has been focused with the keyboard:

<img width="1237" height="1024" alt="The Firefox 152 What’s New page featuring Kit balancing a soccer ball. There’s a purple focus ring around the video animation that intersects with the headline text." src="https://github.com/user-attachments/assets/aee06d21-d97b-4481-9566-d41f46e1982e" />

- This video element has `autoplay`, `muted`, `loop`, and has no `controls` attribute, so in Firefox this seems safe. My only concern might be users with a “always show video controls” extension installed.
- This is most prominent on the `/en-US/whatsnew/152/` page where there’s a video animation of Kit balancing a soccer ball.

## Issue / Bugzilla link

N/A

## Testing

Check that decorational videos that use this template are not focusable.