### PR TITLE
Ignore noise for media play/pause race

### DIFF
--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -61,7 +61,22 @@ const SentryConsent = {
                 globalHandlersIntegration(),
                 httpContextIntegration(),
                 eventFiltersIntegration(options)
-            ]
+            ],
+            beforeSend(event) {
+                const values =
+                    (event.exception && event.exception.values) || [];
+                const mediaAbortedPattern =
+                    /fetching process for the media resource was aborted/i;
+                if (
+                    values.some((text) =>
+                        mediaAbortedPattern.test(text.value || '')
+                    )
+                ) {
+                    return null;
+                }
+
+                return event;
+            }
         });
 
         getCurrentScope().setClient(client);

--- a/media/js/cms/pages/flare-kick-page.es6.js
+++ b/media/js/cms/pages/flare-kick-page.es6.js
@@ -46,7 +46,11 @@ const setupKickPage = () => {
         'canplaythrough',
         () => {
             video.addEventListener('mouseover', () => {
-                video.play();
+                video.play().catch((error) => {
+                    // Pause interrupted, ignore
+                    if (error && error.name === 'AbortError') return;
+                    throw error;
+                });
             });
             video.addEventListener('mouseout', () => {
                 video.pause();


### PR DESCRIPTION
## One-line summary

This both guards the `.play()` call when the logo is hovered on the kick page and as a last resort filters out a substring of the noisy error using `beforeSend()` which from what I understand is a bit lower level than using the `eventFiltersIntegration`.

## Significant changes and points to review

- **Filter media resource aborted error with `beforeSend`**
- **Guard logo hover play call and ignore when aborted by pause**

## Issue / Bugzilla link

Prior art: 😅

#1527 
#1534
#1540
#1544

## Testing

Check there are no errors in dev… but this seems to be something we can only reliably reproduce in production.