### PR TITLE
WT-1277 kit page light theme regression fix

### DIFF
--- a/media/css/firefox/landing/kit.scss
+++ b/media/css/firefox/landing/kit.scss
@@ -36,6 +36,7 @@ main {
     --purple-light-purple: #F1E7F8; // Figma Soft Purple
     --figma-link-purple: #6132BC;
     --figma-black-4: #15141A;
+    background: var(--fl-theme-background);
     display: grid;
     row-gap: 16px;
     padding: 16px 16px 0;


### PR DESCRIPTION
## One-line summary

This PR fixes kit page light theme background regression.

## Significant changes and points to review

- kit page with light mode 

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1277

## Testing

http://localhost:8000/en-US/kit/ with both light and dark mode