### PR TITLE
WT-1420: Add compare pages script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tests/unit/coverage
 tests/unit/dist/
 tests/playwright/test-results/
 tests/playwright/test-results-a11y/
+tests/playwright/.auth/
 Thumbs.db
 tmp/*
 venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ services:
       - ./l10n/:/app/l10n:delegated
 
   playwright-visual-regression:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.1-noble
     network_mode: host
     working_dir: /app/tests/playwright
     volumes:
@@ -147,7 +147,7 @@ services:
     command: sh -c "npm install && npx playwright test --config playwright.visual-regression.config.js"
 
   playwright-visual-regression-ui:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.1-noble
     network_mode: host
     working_dir: /app/tests/playwright
     volumes:
@@ -158,7 +158,7 @@ services:
     command: sh -c "npm install && npx playwright test --config playwright.visual-regression.config.js --ui --ui-host=0.0.0.0 --ui-port=8085"
 
   playwright-update-snapshots:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.1-noble
     network_mode: host
     working_dir: /app/tests/playwright
     volumes:

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -79,3 +79,37 @@ npm run local:update-screenshots
 ```
 
 The visual regression config (`playwright.visual-regression.config.js`) extends the base config but disables parallelism and restricts runs to Chromium.
+
+### Live page comparison tests
+
+Takes full-page screenshots of the same pages on two different hosts and fails if any pair differs. Useful for verifying a local or staging environment matches the live site before a deploy.
+
+The tests run on Chromium only. Both screenshots are saved to `test-results/compare-live/` for inspection, and a pixel diff image is generated there on failure. No baseline files are committed to the repo — the live site screenshot is always captured fresh as the reference.
+
+```sh
+# Compare localhost:8000 against www.firefox.com (defaults)
+npm run compare-live-pages
+
+# Compare a staging host against the live site
+HOST_A=https://staging.example.com npm run compare-live-pages
+
+# Open the interactive Playwright UI
+npm run compare-live-pages:ui
+```
+
+Override either host via environment variables:
+
+| Variable | Default |
+|---|---|
+| `HOST_A` | `http://localhost:8000` |
+| `HOST_B` | `https://www.firefox.com` |
+
+#### Authentication
+
+If the target host sits behind a login page (e.g. Google SSO), log in once to save a session:
+
+```sh
+npm run compare-live-pages:login
+```
+
+This opens a browser window. Navigate to the login page, complete sign-in, then close the browser. The session cookies are saved to `.auth/compare-live-auth.json` (gitignored) and loaded automatically on subsequent runs. They persist until you log in again.

--- a/tests/playwright/compare-live/compare-live-pages.spec.js
+++ b/tests/playwright/compare-live/compare-live-pages.spec.js
@@ -23,7 +23,11 @@ const PAGES = [
     { name: 'article-hub', path: '/en-US/features/' },
     { name: 'article-detail', path: '/features/password-manager/' },
     { name: 'enterprise-landing', path: '/en-US/browsers/enterprise/' },
-    { name: 'mobile-landing', path: '/en-US/mobile/' }
+    { name: 'mobile-landing', path: '/en-US/mobile/' },
+    { name: 'user-privacy', path: '/en-US/user-privacy/' },
+    { name: 'newsletter', path: '/en-US/newsletter/' },
+    { name: 'release-notes', path: '/en-US/firefox/notes/' },
+    { name: 'download-all', path: '/en-US/download/all/' }
 ];
 
 const VIEWPORT = { width: 1280, height: 720 };

--- a/tests/playwright/compare-live/compare-live-pages.spec.js
+++ b/tests/playwright/compare-live/compare-live-pages.spec.js
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const BASE_URL_A = process.env.HOST_A || 'http://localhost:8000';
+const BASE_URL_B = process.env.HOST_B || 'https://www.firefox.com';
+
+const PAGES = [
+    { name: 'home', path: '/' },
+    { name: 'download-windows', path: '/en-US/download/windows/' },
+    { name: 'thanks', path: '/en-US/thanks/' },
+    { name: 'whatsnew', path: '/en-US/whatsnew/' },
+    { name: 'roadmap', path: '/en-US/whatsnext/' },
+    { name: 'article-index', path: '/en-US/features/all/' },
+    { name: 'article-hub', path: '/en-US/features/' },
+    { name: 'article-detail', path: '/features/password-manager/' },
+    { name: 'enterprise-landing', path: '/en-US/browsers/enterprise/' },
+    { name: 'mobile-landing', path: '/en-US/mobile/' }
+];
+
+const VIEWPORT = { width: 1280, height: 720 };
+const SCREENSHOT_OPTIONS = { fullPage: true, animations: 'disabled' };
+const AUTH_FILE = path.join(__dirname, '../../.auth/compare-live-auth.json');
+const storageState = fs.existsSync(AUTH_FILE) ? AUTH_FILE : undefined;
+
+for (const { name, path: pagePath } of PAGES) {
+    test(name, async ({ browser }, testInfo) => {
+        const contextB = await browser.newContext({
+            viewport: VIEWPORT,
+            storageState
+        });
+        const pageB = await contextB.newPage();
+        await pageB.goto(BASE_URL_B + pagePath);
+        const refScreenshot = await pageB.screenshot(SCREENSHOT_OPTIONS);
+        await contextB.close();
+
+        // Write live screenshot as comparison baseline and as a viewable artifact
+        const snapshotPath = testInfo.snapshotPath(`${name}.png`);
+        fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+        fs.writeFileSync(snapshotPath, refScreenshot);
+        fs.writeFileSync(
+            testInfo.outputPath(`${name}-live.png`),
+            refScreenshot
+        );
+
+        const contextA = await browser.newContext({
+            viewport: VIEWPORT,
+            storageState
+        });
+        const pageA = await contextA.newPage();
+        await pageA.goto(BASE_URL_A + pagePath);
+        const localScreenshot = await pageA.screenshot(SCREENSHOT_OPTIONS);
+        fs.writeFileSync(
+            testInfo.outputPath(`${name}-local.png`),
+            localScreenshot
+        );
+        await contextA.close();
+
+        expect(localScreenshot).toMatchSnapshot(`${name}.png`);
+    });
+}

--- a/tests/playwright/compare-live/compare-live-pages.spec.js
+++ b/tests/playwright/compare-live/compare-live-pages.spec.js
@@ -28,7 +28,7 @@ const PAGES = [
 
 const VIEWPORT = { width: 1280, height: 720 };
 const SCREENSHOT_OPTIONS = { fullPage: true, animations: 'disabled' };
-const AUTH_FILE = path.join(__dirname, '../../.auth/compare-live-auth.json');
+const AUTH_FILE = path.join(__dirname, '../.auth/compare-live-auth.json');
 const storageState = fs.existsSync(AUTH_FILE) ? AUTH_FILE : undefined;
 
 for (const { name, path: pagePath } of PAGES) {

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -27,6 +27,9 @@
     "a11y-tests": "npx playwright test --grep @a11y --project=chromium",
     "local:visual-regression-tests": "npx playwright test --config playwright.visual-regression.config.js --grep @visual-regression",
     "local:visual-regression-tests:ui": "npx playwright test --config playwright.visual-regression.config.js --grep @visual-regression --ui",
-    "local:update-snapshots": "npm run local:visual-regression-tests -- --update-snapshots"
+    "local:update-snapshots": "npm run local:visual-regression-tests -- --update-snapshots",
+    "compare-live-pages": "npx playwright test --config playwright.compare-live.config.js",
+    "compare-live-pages:ui": "npx playwright test --config playwright.compare-live.config.js --ui",
+    "compare-live-pages:login": "npx playwright open --save-storage=.auth/compare-live-auth.json"
   }
 }

--- a/tests/playwright/playwright.compare-live.config.js
+++ b/tests/playwright/playwright.compare-live.config.js
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { defineConfig } = require('@playwright/test');
+const visualRegressionConfig = require('./playwright.visual-regression.config');
+
+module.exports = defineConfig({
+    ...visualRegressionConfig,
+    testDir: './compare-live',
+    snapshotDir: './test-results/compare-live-snapshots',
+    outputDir: './test-results/compare-live',
+    grep: undefined,
+    globalSetup: undefined
+});


### PR DESCRIPTION
## One-line summary

This PR adds a playwright script to compare critical pages between environments. It's not meant to be used for testing, but to manually smoke test big changes, like data migrations

## Significant changes and points to review

I also updates the playwright docker image version, which has not been updated at the latest playwright package bump.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1420

## Testing

Go to the tests/playwright folder and run `npm run compare-live-pages` (or, `compare-live-pages:ui`, for a visual comparison). Also, verify that the other tests don't run these by accident (integration, accessibility, and visual regression), and that passing `HOST_A` and/or `HOST_B` env vars change the points of comparison.

Look at the playwright README file for more info.