### PR TITLE
Add light/dark developer feature icons

### DIFF
--- a/media/img/firefox/developer/feature-console-dark.svg
+++ b/media/img/firefox/developer/feature-console-dark.svg
@@ -1,0 +1,21 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<mask id="path-2-inside-1_113358_141854" fill="white">
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V108C133 112.418 129.418 116 125 116H35C30.5817 116 27 112.418 27 108V45Z"/>
+</mask>
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V108C133 112.418 129.418 116 125 116H35C30.5817 116 27 112.418 27 108V45Z" stroke="#C7A8FF" stroke-width="4" mask="url(#path-2-inside-1_113358_141854)"/>
+<path d="M41 73.5H75" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M41 82H91" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M85 73.5H119" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M40 94L46.9333 99.2C47.4667 99.6 47.4667 100.4 46.9333 100.8L40 106" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<path d="M51 106H62" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<path d="M101 82H115" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<mask id="path-9-inside-2_113358_141854" fill="white">
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V65H27V45Z"/>
+</mask>
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V65H27V45Z" fill="#C7A8FF"/>
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V65H27V45Z" stroke="#C7A8FF" stroke-width="4" mask="url(#path-9-inside-2_113358_141854)"/>
+<circle cx="53" cy="54" r="2" fill="#210340"/>
+<circle cx="45" cy="54" r="2" fill="#210340"/>
+<circle cx="37" cy="54" r="2" fill="#210340"/>
+</svg>

--- a/media/img/firefox/developer/feature-console-light.svg
+++ b/media/img/firefox/developer/feature-console-light.svg
@@ -1,0 +1,21 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<mask id="path-2-inside-1_113358_141839" fill="white">
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V108C133 112.418 129.418 116 125 116H35C30.5817 116 27 112.418 27 108V45Z"/>
+</mask>
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V108C133 112.418 129.418 116 125 116H35C30.5817 116 27 112.418 27 108V45Z" stroke="#7543E3" stroke-width="4" mask="url(#path-2-inside-1_113358_141839)"/>
+<path d="M41 73.5H75" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M41 82H91" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M85 73.5H119" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M40 94L46.9333 99.2C47.4667 99.6 47.4667 100.4 46.9333 100.8L40 106" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M51 106H62" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M101 82H115" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<mask id="path-9-inside-2_113358_141839" fill="white">
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V65H27V45Z"/>
+</mask>
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V65H27V45Z" fill="#7543E3"/>
+<path d="M27 45C27 44.4477 27.4477 44 28 44H132C132.552 44 133 44.4477 133 45V65H27V45Z" stroke="#7543E3" stroke-width="4" mask="url(#path-9-inside-2_113358_141839)"/>
+<circle cx="53" cy="54" r="2" fill="white"/>
+<circle cx="45" cy="54" r="2" fill="white"/>
+<circle cx="37" cy="54" r="2" fill="white"/>
+</svg>

--- a/media/img/firefox/developer/feature-debugger-dark.svg
+++ b/media/img/firefox/developer/feature-debugger-dark.svg
@@ -1,0 +1,14 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<path d="M26 80.5H36" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M26 97H134" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M26 109H57" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M65.5 109H89.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<path d="M113.5 80.5H123.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M79.5 80.5H89.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M99.5 80.5H109.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M65.5 80.5H75.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M63.5 51H78.5V69M71 61.5L78.5 69L86 61.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M28.5 67.9097L39.1066 57.3031L51.8345 70.031M41.2279 70.031H51.8345V59.4244" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M112.5 74.5L112.5 59.5L130.5 59.5M123 67L130.5 59.5L123 52" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-debugger-light.svg
+++ b/media/img/firefox/developer/feature-debugger-light.svg
@@ -1,0 +1,14 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<path d="M26 80.5H36" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M26 97H134" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M26 109H57" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M65.5 109H89.5" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M113.5 80.5H123.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M79.5 80.5H89.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M99.5 80.5H109.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M65.5 80.5H75.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M63.5 51H78.5V69M71 61.5L78.5 69L86 61.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M28.5 67.9097L39.1066 57.3031L51.8345 70.031M41.2279 70.031H51.8345V59.4244" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M112.5 74.5L112.5 59.5L130.5 59.5M123 67L130.5 59.5L123 52" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-inspector-dark.svg
+++ b/media/img/firefox/developer/feature-inspector-dark.svg
@@ -1,0 +1,12 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<path d="M42 44V106" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M112.5 44V106" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M25 54H129" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M25 95.5H129" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M50 66C50 63.7909 51.7909 62 54 62H100C102.209 62 104 63.7909 104 66V84C104 86.2091 102.209 88 100 88H54C51.7909 88 50 86.2091 50 84V66Z" fill="#9468FF"/>
+<path d="M77 78C77 76.8954 77.8954 76 79 76H127C131.418 76 135 79.5817 135 84V108C135 112.418 131.418 116 127 116H85C80.5817 116 77 112.418 77 108V78Z" fill="#F1E7F8"/>
+<path d="M88 88H124" stroke="#210340" stroke-width="2" stroke-linecap="round"/>
+<path d="M88 96H124" stroke="#210340" stroke-width="2" stroke-linecap="round"/>
+<path d="M88 104H124" stroke="#210340" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-inspector-light.svg
+++ b/media/img/firefox/developer/feature-inspector-light.svg
@@ -1,0 +1,12 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<path d="M42 44V106" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M112.5 44V106" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M25 54H129" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M25 95.5H129" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M50 66C50 63.7909 51.7909 62 54 62H100C102.209 62 104 63.7909 104 66V84C104 86.2091 102.209 88 100 88H54C51.7909 88 50 86.2091 50 84V66Z" fill="#9468FF"/>
+<path d="M77 78C77 76.8954 77.8954 76 79 76H127C131.418 76 135 79.5817 135 84V108C135 112.418 131.418 116 127 116H85C80.5817 116 77 112.418 77 108V78Z" fill="#3A0F6E"/>
+<path d="M88 88H124" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M88 96H124" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M88 104H124" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-memory-dark.svg
+++ b/media/img/firefox/developer/feature-memory-dark.svg
@@ -1,0 +1,21 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<path d="M124 29H36C33.7909 29 32 30.7909 32 33V58.5C32 60.7091 33.8446 62.4315 35.9204 63.1873C40.1962 64.7442 43.2421 68.774 43.2421 73.5C43.2421 78.226 40.1962 82.2558 35.9204 83.8127C33.8446 84.5685 32 86.2909 32 88.5V127C32 129.209 33.7909 131 36 131H124C126.209 131 128 129.209 128 127V88.5C128 86.2909 126.155 84.5685 124.08 83.8127C119.804 82.2558 116.758 78.226 116.758 73.5C116.758 68.774 119.804 64.7442 124.08 63.1873C126.155 62.4315 128 60.7091 128 58.5V33C128 30.7909 126.209 29 124 29Z" stroke="#AE89FF" stroke-width="2"/>
+<path d="M56 113.5V121.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M72 113.5V121.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M88 113.5V121.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M104 113.5V121.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M80 54V46" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M92 54V46" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68 54V46" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M80 101V93" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M92 101V93" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68 101V93" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 73L110 73" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 85L110 85" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 61L110 61" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50 73L58 73" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50 85L58 85" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50 61L58 61" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="58" y="54" width="44" height="39" rx="4" fill="#6132BC" stroke="#F1E7F8" stroke-width="2"/>
+</svg>

--- a/media/img/firefox/developer/feature-memory-light.svg
+++ b/media/img/firefox/developer/feature-memory-light.svg
@@ -1,0 +1,21 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<path d="M124 29H36C33.7909 29 32 30.7909 32 33V58.5C32 60.7091 33.8446 62.4315 35.9204 63.1873C40.1962 64.7442 43.2421 68.774 43.2421 73.5C43.2421 78.226 40.1962 82.2558 35.9204 83.8127C33.8446 84.5685 32 86.2909 32 88.5V127C32 129.209 33.7909 131 36 131H124C126.209 131 128 129.209 128 127V88.5C128 86.2909 126.155 84.5685 124.08 83.8127C119.804 82.2558 116.758 78.226 116.758 73.5C116.758 68.774 119.804 64.7442 124.08 63.1873C126.155 62.4315 128 60.7091 128 58.5V33C128 30.7909 126.209 29 124 29Z" stroke="#7543E3" stroke-width="2"/>
+<path d="M56 113.5V121.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M72 113.5V121.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M88 113.5V121.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M104 113.5V121.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M80 54V46" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M92 54V46" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68 54V46" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M80 101V93" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M92 101V93" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68 101V93" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 73L110 73" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 85L110 85" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 61L110 61" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50 73L58 73" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50 85L58 85" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50 61L58 61" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="58" y="54" width="44" height="39" rx="4" fill="white" stroke="#3A0F6E" stroke-width="2"/>
+</svg>

--- a/media/img/firefox/developer/feature-network-dark.svg
+++ b/media/img/firefox/developer/feature-network-dark.svg
@@ -1,0 +1,12 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<path d="M27 82H71.5" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M84 82H110" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M64 94L132 94" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M27 61L132 61" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M100 106L132 106" stroke="#9468FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M121 54V68.5" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M93 54V68.5" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M65 54V68.5" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M37 54V68.5" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-network-light.svg
+++ b/media/img/firefox/developer/feature-network-light.svg
@@ -1,0 +1,12 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<path d="M27 82H71.5" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M84 82H110" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M64 94L132 94" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M27 61L132 61" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M100 106L132 106" stroke="#AE89FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M121 54V68.5" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M93 54V68.5" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M65 54V68.5" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M37 54V68.5" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-performance-dark.svg
+++ b/media/img/firefox/developer/feature-performance-dark.svg
@@ -1,0 +1,24 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<mask id="path-2-inside-1_113360_142289" fill="white">
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V100C122 104.418 118.418 108 114 108H35C30.5817 108 27 104.418 27 100V49Z"/>
+</mask>
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V100C122 104.418 118.418 108 114 108H35C30.5817 108 27 104.418 27 100V49Z" stroke="#7543E3" stroke-width="4" mask="url(#path-2-inside-1_113360_142289)"/>
+<path d="M41 77H75" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M41 85H58" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M41 93H69" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<mask id="path-6-inside-2_113360_142289" fill="white">
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V65.5H27V49Z"/>
+</mask>
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V65.5H27V49Z" fill="#7543E3"/>
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V65.5H27V49Z" stroke="#7543E3" stroke-width="4" mask="url(#path-6-inside-2_113360_142289)"/>
+<circle cx="53" cy="56" r="2" fill="white"/>
+<circle cx="45" cy="56" r="2" fill="white"/>
+<circle cx="37" cy="56" r="2" fill="white"/>
+<path d="M105 71C90.0883 71 78 83.0883 78 98C78 103.126 79.4283 107.918 81.9086 112H128.091C130.572 107.918 132 103.126 132 98C132 83.0883 119.912 71 105 71Z" fill="#3A0F6E" stroke="#F1E7F8" stroke-width="2"/>
+<circle cx="105" cy="98" r="7" stroke="#F1E7F8" stroke-width="2"/>
+<path d="M105 80V86" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M87 98L93 98" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M91 85L95.2426 89.2426" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M105 98L118 85" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-performance-light.svg
+++ b/media/img/firefox/developer/feature-performance-light.svg
@@ -1,0 +1,24 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<mask id="path-2-inside-1_113360_142277" fill="white">
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V100C122 104.418 118.418 108 114 108H35C30.5817 108 27 104.418 27 100V49Z"/>
+</mask>
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V100C122 104.418 118.418 108 114 108H35C30.5817 108 27 104.418 27 100V49Z" stroke="#7543E3" stroke-width="4" mask="url(#path-2-inside-1_113360_142277)"/>
+<path d="M41 77H75" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M41 85H58" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M41 93H69" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<mask id="path-6-inside-2_113360_142277" fill="white">
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V65.5H27V49Z"/>
+</mask>
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V65.5H27V49Z" fill="#7543E3"/>
+<path d="M27 49C27 48.4477 27.4477 48 28 48H121C121.552 48 122 48.4477 122 49V65.5H27V49Z" stroke="#7543E3" stroke-width="4" mask="url(#path-6-inside-2_113360_142277)"/>
+<circle cx="53" cy="56" r="2" fill="white"/>
+<circle cx="45" cy="56" r="2" fill="white"/>
+<circle cx="37" cy="56" r="2" fill="white"/>
+<path d="M105 71C90.0883 71 78 83.0883 78 98C78 103.126 79.4283 107.918 81.9086 112H128.091C130.572 107.918 132 103.126 132 98C132 83.0883 119.912 71 105 71Z" fill="#F1E7F8" stroke="#3A0F6E" stroke-width="2"/>
+<circle cx="105" cy="98" r="7" stroke="#3A0F6E" stroke-width="2"/>
+<path d="M105 80V86" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M87 98L93 98" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M91 85L95.2426 89.2426" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M105 98L118 85" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-responsive-design-mode-dark.svg
+++ b/media/img/firefox/developer/feature-responsive-design-mode-dark.svg
@@ -1,0 +1,29 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<mask id="path-2-inside-1_113360_142137" fill="white">
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V104C127 108.418 123.418 112 119 112H29C24.5817 112 21 108.418 21 104V41Z"/>
+</mask>
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V104C127 108.418 123.418 112 119 112H29C24.5817 112 21 108.418 21 104V41Z" stroke="#7543E3" stroke-width="4" mask="url(#path-2-inside-1_113360_142137)"/>
+<path d="M35 69.5H69" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M35 78H85" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M35 86H98" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M79 69.5H113" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M95 78H109" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<mask id="path-8-inside-2_113360_142137" fill="white">
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V61H21V41Z"/>
+</mask>
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V61H21V41Z" fill="#7543E3"/>
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V61H21V41Z" stroke="#7543E3" stroke-width="4" mask="url(#path-8-inside-2_113360_142137)"/>
+<circle cx="47" cy="50" r="2" fill="white"/>
+<circle cx="39" cy="50" r="2" fill="white"/>
+<circle cx="31" cy="50" r="2" fill="white"/>
+<path d="M102 53C102 51.8954 102.895 51 104 51H136C137.105 51 138 51.8954 138 53V102H102V53Z" fill="#9468FF"/>
+<path d="M102 53C102 51.8954 102.895 51 104 51H136C137.105 51 138 51.8954 138 53V102H102V53Z" stroke="#6132BC" stroke-width="2"/>
+<path d="M108 62H118" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M108 72H125" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M108 82H132" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M124 62L132 62" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 102H138V117C138 118.105 137.105 119 136 119H104C102.895 119 102 118.105 102 117V102Z" fill="#7543E3"/>
+<path d="M102 102H138V117C138 118.105 137.105 119 136 119H104C102.895 119 102 118.105 102 117V102Z" stroke="#6132BC" stroke-width="2"/>
+<circle cx="120" cy="110" r="4" fill="#6132BC" stroke="#3A0F6E" stroke-width="2"/>
+</svg>

--- a/media/img/firefox/developer/feature-responsive-design-mode-light.svg
+++ b/media/img/firefox/developer/feature-responsive-design-mode-light.svg
@@ -1,0 +1,29 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<mask id="path-2-inside-1_113360_142124" fill="white">
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V104C127 108.418 123.418 112 119 112H29C24.5817 112 21 108.418 21 104V41Z"/>
+</mask>
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V104C127 108.418 123.418 112 119 112H29C24.5817 112 21 108.418 21 104V41Z" stroke="#7543E3" stroke-width="4" mask="url(#path-2-inside-1_113360_142124)"/>
+<path d="M35 69.5H69" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M35 78H85" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M35 86H98" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M79 69.5H113" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M95 78H109" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<mask id="path-8-inside-2_113360_142124" fill="white">
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V61H21V41Z"/>
+</mask>
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V61H21V41Z" fill="#7543E3"/>
+<path d="M21 41C21 40.4477 21.4477 40 22 40H126C126.552 40 127 40.4477 127 41V61H21V41Z" stroke="#7543E3" stroke-width="4" mask="url(#path-8-inside-2_113360_142124)"/>
+<circle cx="47" cy="50" r="2" fill="white"/>
+<circle cx="39" cy="50" r="2" fill="white"/>
+<circle cx="31" cy="50" r="2" fill="white"/>
+<path d="M102 53C102 51.8954 102.895 51 104 51H136C137.105 51 138 51.8954 138 53V102H102V53Z" fill="#E4D7FC"/>
+<path d="M102 53C102 51.8954 102.895 51 104 51H136C137.105 51 138 51.8954 138 53V102H102V53Z" stroke="#6132BC" stroke-width="2"/>
+<path d="M108 62H118" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M108 72H125" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M108 82H132" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M124 62L132 62" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M102 102H138V117C138 118.105 137.105 119 136 119H104C102.895 119 102 118.105 102 117V102Z" fill="#7543E3"/>
+<path d="M102 102H138V117C138 118.105 137.105 119 136 119H104C102.895 119 102 118.105 102 117V102Z" stroke="#6132BC" stroke-width="2"/>
+<circle cx="120" cy="110" r="4" fill="white" stroke="#3A0F6E" stroke-width="2"/>
+</svg>

--- a/media/img/firefox/developer/feature-storage-panel-dark.svg
+++ b/media/img/firefox/developer/feature-storage-panel-dark.svg
@@ -1,0 +1,16 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<path d="M116 60L116 68" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M116 92L116 100" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M44 92L44 100" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M44 60L44 68" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round"/>
+<rect x="30" y="36" width="100" height="24" rx="2" fill="#6132BC"/>
+<rect x="30" y="36" width="100" height="24" rx="2" stroke="#F1E7F8" stroke-width="2"/>
+<circle cx="44" cy="48" r="5" fill="#9468FF" stroke="#F1E7F8" stroke-width="2"/>
+<rect x="30" y="68" width="100" height="24" rx="2" fill="#6132BC"/>
+<rect x="30" y="68" width="100" height="24" rx="2" stroke="#F1E7F8" stroke-width="2"/>
+<circle cx="44" cy="80" r="5" fill="#9468FF" stroke="#F1E7F8" stroke-width="2"/>
+<rect x="30" y="100" width="100" height="24" rx="2" fill="#6132BC"/>
+<rect x="30" y="100" width="100" height="24" rx="2" stroke="#F1E7F8" stroke-width="2"/>
+<circle cx="44" cy="112" r="5" fill="#9468FF" stroke="#F1E7F8" stroke-width="2"/>
+</svg>

--- a/media/img/firefox/developer/feature-storage-panel-light.svg
+++ b/media/img/firefox/developer/feature-storage-panel-light.svg
@@ -1,0 +1,16 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<path d="M116 60L116 68" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M116 92L116 100" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M44 92L44 100" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M44 60L44 68" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<rect x="30" y="36" width="100" height="24" rx="2" fill="#E4D7FC"/>
+<rect x="30" y="36" width="100" height="24" rx="2" stroke="#3A0F6E" stroke-width="2"/>
+<circle cx="44" cy="48" r="5" fill="#C7A8FF" stroke="#7543E3" stroke-width="2"/>
+<rect x="30" y="68" width="100" height="24" rx="2" fill="#E4D7FC"/>
+<rect x="30" y="68" width="100" height="24" rx="2" stroke="#3A0F6E" stroke-width="2"/>
+<circle cx="44" cy="80" r="5" fill="#C7A8FF" stroke="#7543E3" stroke-width="2"/>
+<rect x="30" y="100" width="100" height="24" rx="2" fill="#E4D7FC"/>
+<rect x="30" y="100" width="100" height="24" rx="2" stroke="#3A0F6E" stroke-width="2"/>
+<circle cx="44" cy="112" r="5" fill="#C7A8FF" stroke="#7543E3" stroke-width="2"/>
+</svg>

--- a/media/img/firefox/developer/feature-style-editor-dark.svg
+++ b/media/img/firefox/developer/feature-style-editor-dark.svg
@@ -1,0 +1,8 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+  <rect x="26" y="51" width="82" height="82" stroke="#DEC9FF" stroke-width="2"/>
+  <rect x="47" y="72" width="40" height="40" fill="#9468FF" stroke="#DEC9FF" stroke-width="2"/>
+  <path d="M102.328 41.5771L119.299 58.5477L86.3223 91.5241L65.5586 95.3173L69.3517 74.5535L102.328 41.5771Z" fill="#9468FF" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M124.246 28.1424C125.808 26.5803 128.341 26.5803 129.903 28.1424L132.024 30.2637C133.977 32.2163 133.977 35.3822 132.024 37.3348L115.053 54.3053L106.568 45.8201L124.246 28.1424Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M95.2578 34.5063L126.371 65.619" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-style-editor-light.svg
+++ b/media/img/firefox/developer/feature-style-editor-light.svg
@@ -1,0 +1,8 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+  <rect x="26" y="51" width="82" height="82" stroke="#7543E3" stroke-width="2"/>
+  <rect x="47" y="72" width="40" height="40" fill="#C7A8FF" stroke="#7543E3" stroke-width="2"/>
+  <path d="M102.326 41.5771L119.297 58.5477L86.3203 91.5241L65.5566 95.3173L69.3498 74.5535L102.326 41.5771Z" fill="#C7A8FF" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M124.246 28.1424C125.808 26.5803 128.341 26.5803 129.903 28.1424L132.024 30.2637C133.977 32.2163 133.977 35.3822 132.024 37.3348L115.053 54.3053L106.568 45.8201L124.246 28.1424Z" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M95.2559 34.5063L126.369 65.619" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-visual-editing-dark.svg
+++ b/media/img/firefox/developer/feature-visual-editing-dark.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#3A0F6E"/>
+<path d="M34 98.5L125.5 60" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M124.5 35C100.199 35 80.5 54.2518 80.5 78C80.5 103.405 59.9051 124 34.5 124" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M125 28V42" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M34 117V131" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M106.5 112C106.5 116.971 110.529 121 115.5 121C120.471 121 124.5 116.971 124.5 112C124.5 107.029 120.471 103 115.5 103C110.529 103 106.5 107.029 106.5 112ZM106.5 112H78" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+<path d="M52 47C52 42.0294 47.9706 38 43 38C38.0294 38 34 42.0294 34 47C34 51.9706 38.0294 56 43 56C47.9706 56 52 51.9706 52 47ZM52 47L80.5 47" stroke="#F1E7F8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/developer/feature-visual-editing-light.svg
+++ b/media/img/firefox/developer/feature-visual-editing-light.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 40C0 17.9086 17.9086 0 40 0H120C142.091 0 160 17.9086 160 40V120C160 142.091 142.091 160 120 160H40C17.9086 160 0 142.091 0 120V40Z" fill="#F1E7F8"/>
+<path d="M34 98.5L125.5 60" stroke="#C7A8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M124.5 35C100.199 35 80.5 54.2518 80.5 78C80.5 103.405 59.9051 124 34.5 124" stroke="#7543E3" stroke-width="2" stroke-linecap="round"/>
+<path d="M125 28V42" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M34 117V131" stroke="#7543E3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M106.5 112C106.5 116.971 110.529 121 115.5 121C120.471 121 124.5 116.971 124.5 112C124.5 107.029 120.471 103 115.5 103C110.529 103 106.5 107.029 106.5 112ZM106.5 112H78" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+<path d="M52 47C52 42.0294 47.9706 38 43 38C38.0294 38 34 42.0294 34 47C34 51.9706 38.0294 56 43 56C47.9706 56 52 51.9706 52 47ZM52 47L80.5 47" stroke="#3A0F6E" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/springfield/firefox/templates/firefox/developer/index-flare.html
+++ b/springfield/firefox/templates/firefox/developer/index-flare.html
@@ -153,9 +153,18 @@
         />
 
         <include:cards-list cards_per_row="3" container_width="wide">
+          <style>
+            @scope {
+              .fl-illustration-card.fl-illustration-sticker-card .fl-card-media { padding: 0; }
+              .fl-illustration-card.fl-illustration-sticker-card .fl-card-media picture { margin-block-end: 0; }
+            }
+          </style>
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-inspector.svg') }}" width="202" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-inspector-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-inspector-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-inspector') }}</h3>
@@ -172,7 +181,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-console.svg') }}" width="182" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-console-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-console-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-console') }}</h3>
@@ -189,7 +201,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-debugger.svg') }}" width="202" height="110" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-debugger-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-debugger-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-debugger') }}</h3>
@@ -206,7 +221,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-network.svg') }}" width="232" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-network-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-network-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-network') }}</h3>
@@ -223,7 +241,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-storage.svg') }}" width="134" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-storage-panel-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-storage-panel-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-storage-panel') }}</h3>
@@ -240,7 +261,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-responsive-mode.svg') }}" width="194" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-responsive-design-mode-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-responsive-design-mode-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-responsive-design-mode') }}</h3>
@@ -257,7 +281,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-visual-editing.svg') }}" width="112" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-visual-editing-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-visual-editing-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-visual-editing') }}</h3>
@@ -274,7 +301,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-performance.svg') }}" width="202" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-performance-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-performance-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-performance') }}</h3>
@@ -291,7 +321,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-memory.svg') }}" width="116" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-memory-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-memory-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-memory') }}</h3>
@@ -308,7 +341,10 @@
 
           <include:illustration-card variant="sticker" expand_link>
             <content:media>
-              <img src="{{ static('img/firefox/developer/feature-style-editor.svg') }}" width="116" height="124" loading="lazy" alt="" />
+              <picture>
+                <source srcset="{{ static('img/firefox/developer/feature-style-editor-dark.svg') }}" media="(prefers-color-scheme: dark)">
+                <img src="{{ static('img/firefox/developer/feature-style-editor-light.svg') }}" width="124" height="124" loading="lazy" alt="">
+              </picture>
             </content:media>
             <content:heading>
               <h3>{{ ftl('firefox-developer-style-editor') }}</h3>


### PR DESCRIPTION
*Work in progress…*

- [ ] Determine where the CSS should live
  - The sticker variant of the card presumes that the icons are just the graphic not a background. The background is slightly different as well. I’m removing it with some scoped styles, but will need to find a better solution.
- [ ] Remove old assets

## One-line summary

Adds light and dark mode variants of the feature icons on the Developer Edition page (i.e. `/channel/desktop/developer/`).

## Significant changes and points to review

- This uses `<picture>` with the dark mode sources applied with a `prefers-color-scheme` condition in the `media` attribute.
- I considered trying to use a single SVG for each icon, then use CSS + design tokens to apply the styles based on light or dark colour preferences. That seemed like it would be too troublesome between browser support (e.g. Safari doesn’t work well with `color-scheme`) and limited capabilities when using different embedding methods (e.g. `<img>` can’t use custom props from the document; `<use>` doesn’t allow `<mask>`). I imagine there’s a way to just use `@media`, but I don’t think it really improves things.

## Issue / Bugzilla link

- https://mozilla-hub.atlassian.net/browse/WT-770

## Testing

Go to <http://localhost:8000/channel/desktop/developer/> and test the page in the OS light mode and dark mode (or a simulated version of that).