### PR TITLE
Remove `ENABLE_CMS_REFRESH_REDIRECTS` flag

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -4,7 +4,6 @@ ALLOWED_HOSTS=*
 SWITCH_NEWSLETTER_MAINTENANCE_MODE=False
 CSP_DEFAULT_SRC=*.springfield.moz.works
 WAGTAIL_ENABLE_ADMIN=True
-ENABLE_CMS_REFRESH_REDIRECTS=True
 
 # By default, local dev builds store CMS-uploaded media on the local system. If
 # you need to enable cloud storage for CMS media (likely only needed to debug or

--- a/springfield/cms/tests/test_download_url_cms_preference.py
+++ b/springfield/cms/tests/test_download_url_cms_preference.py
@@ -3,40 +3,19 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """
-Tests for the ENABLE_CMS_REFRESH_REDIRECTS URL patterns.
+Tests for the download platform URL patterns.
 
 These patterns (in springfield/firefox/urls.py) wrap download platform views
 with prefer_cms so that a published CMS DownloadPage takes precedence over
 the legacy Django/template view for the same URL.
 """
 
-import importlib
-
-from django.test import override_settings
-from django.urls import clear_url_caches
-
 import pytest
 
-import springfield.firefox.urls as firefox_urls_module
-import springfield.urls as root_urls_module
 from springfield.cms.models import SimpleRichTextPage
 from springfield.cms.tests.factories import DownloadIndexPageFactory, DownloadPageFactory
 
 pytestmark = [pytest.mark.django_db]
-
-
-@pytest.fixture
-def cms_refresh_redirects_enabled():
-    """Enable ENABLE_CMS_REFRESH_REDIRECTS and reload the URL conf to pick up the new patterns."""
-    with override_settings(ENABLE_CMS_REFRESH_REDIRECTS=True):
-        importlib.reload(firefox_urls_module)
-        importlib.reload(root_urls_module)
-        clear_url_caches()
-        yield
-    # Restore original URL patterns (setting is False again outside override_settings)
-    importlib.reload(firefox_urls_module)
-    importlib.reload(root_urls_module)
-    clear_url_caches()
 
 
 @pytest.fixture
@@ -64,7 +43,7 @@ PLATFORM_PARAMS = pytest.mark.parametrize(
 
 
 @PLATFORM_PARAMS
-def test_cms_content_served_when_download_page_exists(platform, url_path, slug, cms_refresh_redirects_enabled, download_index_page, client):
+def test_cms_content_served_when_download_page_exists(platform, url_path, slug, download_index_page, client):
     """When a live CMS DownloadPage exists for the requested locale, it is served
     instead of the legacy Django view."""
     download_page = DownloadPageFactory(
@@ -82,7 +61,7 @@ def test_cms_content_served_when_download_page_exists(platform, url_path, slug, 
 
 
 @PLATFORM_PARAMS
-def test_django_view_served_when_no_cms_page_for_locale(platform, url_path, slug, cms_refresh_redirects_enabled, download_index_page, client):
+def test_django_view_served_when_no_cms_page_for_locale(platform, url_path, slug, download_index_page, client):
     """When no CMS DownloadPage exists for the requested locale, the legacy
     Django view/template is served as a fallback."""
     # Create an en-US DownloadPage but no French translation

--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -118,19 +118,17 @@ redirectpatterns = (
     redirect(r"^mobile/get-app/?$", "/mobile/", permanent=False),
 )
 
-permanent = settings.PERMANENT_CMS_REFRESH_REDIRECTS
 refresh_redirects = (
-    redirect(r"^browsers/desktop/windows/$", "/download/windows/", permanent=permanent),
-    redirect(r"^browsers/desktop/mac/$", "/download/mac/", permanent=permanent),
-    redirect(r"^browsers/desktop/linux/$", "/download/linux/", permanent=permanent),
-    redirect(r"^browsers/mobile/android/$", "/download/android/", permanent=permanent),
-    redirect(r"^browsers/mobile/ios/$", "/download/ios/", permanent=permanent),
-    redirect(r"^browsers/desktop/chromebook/$", "/download/chromebook/", permanent=permanent),
-    redirect(r"^browsers/unsupported-systems/$", "/download/unsupported-systems/", permanent=permanent),
-    redirect(r"^browsers/mobile/$", "/mobile/", permanent=permanent),
-    redirect(r"^browsers/mobile/focus/$", "/mobile/focus/", permanent=permanent),
-    redirect(r"^browsers/mobile/get-app/$", "/mobile/", permanent=permanent),
+    redirect(r"^browsers/desktop/windows/$", "/download/windows/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/desktop/mac/$", "/download/mac/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/desktop/linux/$", "/download/linux/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/mobile/android/$", "/download/android/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/mobile/ios/$", "/download/ios/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/desktop/chromebook/$", "/download/chromebook/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/unsupported-systems/$", "/download/unsupported-systems/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/mobile/$", "/mobile/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/mobile/focus/$", "/mobile/focus/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/mobile/get-app/$", "/mobile/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
 )
 
-if settings.ENABLE_CMS_REFRESH_REDIRECTS:
-    redirectpatterns = redirectpatterns + refresh_redirects
+redirectpatterns = redirectpatterns + refresh_redirects

--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -155,17 +155,6 @@ def test_refresh_redirect_locale_handling(locale, permanent):
     assert resp["location"] == f"/{locale}/download/windows/"
 
 
-def test_refresh_redirects_not_in_redirectpatterns_when_disabled():
-    with override_settings(ENABLE_CMS_REFRESH_REDIRECTS=False, PERMANENT_CMS_REFRESH_REDIRECTS=False):
-        importlib.reload(redirects_module)
-        rf = RequestFactory()
-        middleware = RedirectsMiddleware(get_response=HttpResponse, resolver=get_resolver(redirects_module.redirectpatterns))
-        resp = middleware.process_request(rf.get("/browsers/desktop/windows/"))
-    assert resp is None
-    # Reload to restore original state
-    importlib.reload(redirects_module)
-
-
 @pytest.mark.parametrize(
     "source, dest",
     (

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -56,12 +56,9 @@ DEBUG = config("DEBUG", parser=bool, default="false")
 # Enable legacy CSS mode for Flare (links only CSS for legacy browsers)
 FLARECSS_LEGACY_MODE = config("FLARECSS_LEGACY_MODE", parser=bool, default="false")
 
-# CMS refresh redirect controls (toggled by infra during URL/content migrations).
-# ENABLE_CMS_REFRESH_REDIRECTS turns the redirects on; defaults to false so new behavior
-# is opt-in and can be rolled out gradually. PERMANENT_CMS_REFRESH_REDIRECTS switches
-# the redirects from temporary (302) to permanent (301); defaults to false so we can
-# verify the rollout and later make redirects permanent or remove them as part of cleanup.
-ENABLE_CMS_REFRESH_REDIRECTS = config("ENABLE_CMS_REFRESH_REDIRECTS", default="false", parser=bool)
+# PERMANENT_CMS_REFRESH_REDIRECTS switches the CMS-refresh redirects from temporary (302)
+# to permanent (301); defaults to true. The redirects themselves are now always
+# on. TODO: remove this setting once the redirects are confirmed permanent (follow-up).
 PERMANENT_CMS_REFRESH_REDIRECTS = config("PERMANENT_CMS_REFRESH_REDIRECTS", default="true", parser=bool)
 
 db_connection_max_age_secs = config("DB_CONN_MAX_AGE", default="0", parser=int)

--- a/tests/redirects/test_redirects.py
+++ b/tests/redirects/test_redirects.py
@@ -7,7 +7,6 @@
 import importlib
 from operator import itemgetter
 
-from django.test import override_settings
 from django.urls import clear_url_caches
 
 import pytest
@@ -28,15 +27,14 @@ from .map_locales import URLS as LOCALE_URLS
 @pytest.mark.parametrize("url", REDIRECT_URLS, ids=itemgetter("url"))
 def test_redirect_url(url, base_url):
     original_patterns = list(redirects_util.redirectpatterns)
-    with override_settings(ENABLE_CMS_REFRESH_REDIRECTS=True):
-        importlib.reload(firefox_redirects_module)
-        importlib.reload(firefox_urls_module)
-        importlib.reload(root_urls_module)
-        redirects_util.redirectpatterns.clear()
-        redirects_util.register(firefox_redirects_module.redirectpatterns)
-        clear_url_caches()
-        url["base_url"] = base_url
-        assert_valid_url(**url)
+    importlib.reload(firefox_redirects_module)
+    importlib.reload(firefox_urls_module)
+    importlib.reload(root_urls_module)
+    redirects_util.redirectpatterns.clear()
+    redirects_util.register(firefox_redirects_module.redirectpatterns)
+    clear_url_caches()
+    url["base_url"] = base_url
+    assert_valid_url(**url)
 
     redirects_util.redirectpatterns.clear()
     redirects_util.redirectpatterns.extend(original_patterns)


### PR DESCRIPTION
# Summary

Follow-up to the review and merge of #1546. `True` is the only behavior we want for `ENABLE_CMS_REFRESH_REDIRECTS`, so this removes the flag entirely rather than leaving `urls.py` unconditional while `redirects.py` stays gated behind it.

# Changes

See [Steve's comment on #1546](https://github.com/mozmeao/springfield/pull/1546#issuecomment-4810121207).

# Testing

* `ruff check` passes on the changed files
* redirect and CMS suites pass