### PR TITLE
Adding easter egg logo

### DIFF
--- a/media/js/cms/components/flare-animations.es6.js
+++ b/media/js/cms/components/flare-animations.es6.js
@@ -99,7 +99,10 @@ function initAnimationPauseButtons() {
 
         button.addEventListener('click', function () {
             if (video.paused) {
-                video.play().catch();
+                video.play().catch((error) => {
+                    if (error && error.name === 'AbortError') return;
+                    throw error;
+                });
                 button.setAttribute('aria-label', button.dataset.labelPause);
                 button.classList.remove('is-paused');
                 pauseIcon.hidden = false;

--- a/media/js/cms/components/flare-sliding-carousel.es6.js
+++ b/media/js/cms/components/flare-sliding-carousel.es6.js
@@ -83,7 +83,12 @@ class SlidingCarousel {
     }
 
     playVideo(videoEl) {
-        videoEl.play();
+        // play() rejects with AbortError when a slide change pauses the video
+        // before the play promise resolves; that's expected here.
+        videoEl.play().catch((error) => {
+            if (error && error.name === 'AbortError') return;
+            throw error;
+        });
         videoEl.autoplay = true;
 
         const btn = this.getAnimationButton(videoEl);

--- a/media/js/cms/components/flare-video.es6.js
+++ b/media/js/cms/components/flare-video.es6.js
@@ -26,18 +26,24 @@ function honorReducedMotionForAutoplay() {
     if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
     document.querySelectorAll('video[autoplay]').forEach(function (video) {
-        // Pause immediately — more reliable than removing the autoplay attribute,
-        // which browsers may have already acted on before JS runs.
-        video.pause();
+        video.autoplay = false;
 
-        // Guard against the browser restarting playback (e.g. after seek).
-        video.addEventListener(
-            'play',
-            function () {
-                video.pause();
-            },
-            { once: true }
-        );
+        // If the browser-initiated autoplay is still pending, calling pause()
+        // synchronously rejects that play() promise with AbortError, which
+        // surfaces as an unhandled rejection. Wait for the 'play' event —
+        // that's when the pending promise has resolved and pausing is safe.
+        // (Listener also guards against restart after seek.)
+        if (video.paused) {
+            video.addEventListener(
+                'play',
+                function () {
+                    video.pause();
+                },
+                { once: true }
+            );
+        } else {
+            video.pause();
+        }
 
         // Update the paired pause/play button if one exists.
         const container = video.closest('.fl-video');

--- a/media/js/cms/easter-egg-logo.es6.js
+++ b/media/js/cms/easter-egg-logo.es6.js
@@ -1,0 +1,110 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+  Loaded site-wide behind the `easter-egg-logo` waffle switch. Swaps the
+  Firefox header logo for a WebM that plays on hover. To retire or change
+  the easter egg, edit this file (and the matching CSS) or flip the switch off.
+*/
+
+function isAlphaWebmUnsupported() {
+    const ua = navigator.userAgent;
+    if (/iPad|iPhone|iPod/.test(ua)) return true;
+    if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return true;
+    return /^((?!chrome|android|crios|fxios).)*safari/i.test(ua);
+}
+
+const setupEasterEggLogo = () => {
+    // The kick/sidekick pages have their own scoped script; let it own the logo there.
+    if (document.body.classList.contains('flare26-kick-page')) return;
+    // Enterprise pages use a wider (200x40) wordmark; our sizing tweaks don't fit.
+    if (document.body.classList.contains('fl-theme-enterprise')) return;
+    if (isAlphaWebmUnsupported()) return;
+    if (
+        window.matchMedia &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    )
+        return;
+
+    const logoLink = document.querySelector('.fl-logo-fx');
+
+    if (!logoLink) return;
+    if (logoLink.querySelector('.fl-video')) return;
+
+    const existingLogo = logoLink.querySelector('img');
+    if (existingLogo) existingLogo.remove();
+
+    // Hide the wordmark that .fl-logo-fx paints as a background.
+    logoLink.style.backgroundImage = 'none';
+    // Widen the logo container so the WebM's flame lands at the same visual
+    // size as the SVG wordmark, and shift it back so the layout doesn't move.
+    logoLink.style.setProperty('inline-size', '130px');
+    logoLink.style.setProperty('block-size', '55px');
+    logoLink.style.setProperty('margin-inline-start', '-5px');
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'fl-video';
+    wrapper.style.setProperty('max-block-size', '56px');
+
+    const video = document.createElement('video');
+    video.muted = true;
+
+    const source = document.createElement('source');
+    source.src = 'https://assets.mozilla.net/wc/logo-1-alpha.webm';
+    source.type = 'video/webm';
+
+    video.appendChild(source);
+    wrapper.appendChild(video);
+    logoLink.appendChild(wrapper);
+
+    const HOVER_INTENT_MS = 1000;
+    const COOLDOWN_MS = 10000;
+
+    let hoverTimer = null;
+    let isPlaying = false;
+    let cooldownUntil = 0;
+
+    video.addEventListener(
+        'canplaythrough',
+        () => {
+            video.addEventListener('mouseover', () => {
+                if (isPlaying || hoverTimer) return;
+                if (Date.now() < cooldownUntil) return;
+
+                hoverTimer = setTimeout(() => {
+                    hoverTimer = null;
+                    isPlaying = true;
+                    video.play().catch((error) => {
+                        if (error && error.name === 'AbortError') return;
+                        throw error;
+                    });
+                }, HOVER_INTENT_MS);
+            });
+
+            video.addEventListener('mouseout', () => {
+                // Cancel a pending start if the user leaves before hover-intent fires.
+                // Do NOT stop an in-progress animation — let it play through.
+                if (hoverTimer) {
+                    clearTimeout(hoverTimer);
+                    hoverTimer = null;
+                }
+            });
+
+            video.addEventListener('ended', () => {
+                isPlaying = false;
+                cooldownUntil = Date.now() + COOLDOWN_MS;
+                video.currentTime = 0;
+            });
+        },
+        { once: true }
+    );
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupEasterEggLogo);
+} else {
+    setupEasterEggLogo();
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -783,6 +783,12 @@
     },
     {
       "files": [
+        "js/cms/easter-egg-logo.es6.js"
+      ],
+      "name": "easter-egg-logo"
+    },
+    {
+      "files": [
         "js/firefox/landing/init.es6.js"
       ],
       "name": "firefox_landing"

--- a/springfield/cms/templates/cms/base-flare.html
+++ b/springfield/cms/templates/cms/base-flare.html
@@ -252,6 +252,9 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     {{ js_bundle('ui-tour-buttons') }}
     {{ js_bundle('flare-navigation') }}
     {{ js_bundle('flare-lang-switcher') }}
+    {% if switch('easter-egg-logo') %}
+    {{ js_bundle('easter-egg-logo') }}
+    {% endif %}
     {% endblock %}
 
     {% block consent_banner_js %}


### PR DESCRIPTION
## Summary
Bring the `/landing/kick` logo easter egg (animated Firefox WebM on hover) to the whole flare-themed side of firefox.com, behind a waffle switch so we can flip it on/off without a deploy. The `/landing/kick` and `/landing/sidekick` pages keep their own scoped implementation untouched.

Hover behaviour: 1s hover-intent before the animation starts, plays through to completion regardless of mouseout, then a ~10s cooldown before it can trigger again.

## Files affected
- `media/js/cms/easter-egg-logo.es6.js` — new. Self-contained: logo swap, hover-intent, cooldown, and all safety gates (kick/sidekick, enterprise theme, Safari/WebM alpha, `prefers-reduced-motion`).
- `media/static-bundles.json` — registers the `easter-egg-logo` JS bundle.
- `springfield/cms/templates/cms/base-flare.html` — includes the bundle in `site_js` behind `switch('easter-egg-logo')`. This template is the only load point; older non-CMS pages (extending `base-protocol.html`) and enterprise-themed pages are unaffected.

## Waffle switch to create
- **Name:** `EASTER_EGG_LOGO`
- **Where:** Django admin → Waffle → Switches → *Add switch* on each environment (stage, prod).
- **Default:** create as **off**, flip on when you want it live. In local dev the switch defaults to **on** if it doesn't exist (existing `switch()` helper behaviour).
- **To retire or swap in a future easter egg:** edit the WebM URL and any sizing tweaks in `easter-egg-logo.es6.js`. Flip the switch off to disable entirely.

## Expected behavior

**Accessibility — `prefers-reduced-motion`**
When the user has requested reduced motion at the OS level (macOS System Settings → Accessibility → Display → Reduce motion; Windows Settings → Accessibility → Visual effects → Animation effects off), the swap is skipped entirely. The user sees the normal static SVG wordmark and no video ever loads or plays. This applies regardless of whether the switch is on.

**Safari and WebM alpha**
Safari (all versions), iOS Safari, and touch-enabled Macs are all detected via UA and touch-point sniffing, and the swap is skipped. Reason: Safari's support for WebM with an alpha channel is unreliable — historically it either failed to decode or rendered the transparent regions as a black background. On those browsers users see the normal static SVG wordmark; no video element is ever inserted.

**Other early-bail conditions**
- Kick/sidekick pages (`body.flare26-kick-page`) — their scoped implementation owns the logo.
- Enterprise-themed pages (`body.fl-theme-enterprise`) — their wider 200x40 wordmark doesn't fit our sizing tweaks.

In all early-bail cases the normal SVG wordmark stays in place; nothing regresses.

## Test plan
- [ ] Create switch `EASTER_EGG_LOGO`, enable it — hover the logo on `/en-US/`, `/firefox/new/`, or any other flare page. Video plays after 1s hover, completes fully, cooldown gates the next trigger.
- [ ] Disable the switch — normal SVG wordmark restored across the site.
- [ ] `/landing/kick` and `/landing/sidekick` still show their existing (immediate hover-play) easter egg regardless of switch state.
- [ ] Enterprise-themed CMS pages (`fl-theme-enterprise` body class) do not swap the logo.
- [ ] Safari (desktop + iOS + touch-Mac) shows the static SVG wordmark — no video attempted (check Network tab: no `.webm` request).
- [ ] With OS-level `prefers-reduced-motion: reduce`, static SVG is shown, no swap (check Elements panel: original `<img>` still in place).
- [ ] Non-CMS pages extending `base-protocol.html` (older channel/marketing pages) do not load the bundle at all — confirm in DevTools Network tab.