### PR TITLE
WT-1438 Add enterprise download component

### DIFF
--- a/media/js/firefox/enterprise/landing.es6.js
+++ b/media/js/firefox/enterprise/landing.es6.js
@@ -7,4 +7,18 @@
 import MzpDetails from '@mozilla-protocol/core/protocol/js/details';
 
 window.MzpDetails = MzpDetails;
-window.MzpDetails.init('.mzp-c-menu-list-title');
+
+function initMenuLists() {
+    window.MzpDetails.init('.mzp-c-menu-list-title');
+}
+
+// This bundle can be loaded before the "lib" bundle that defines
+// window.MzpSupports/MzpUtils (e.g. when rendered from a CMS block, whose
+// position in the page is not guaranteed to be after "lib"). Deferring to
+// DOMContentLoaded ensures all other page scripts have already run,
+// regardless of where this script tag is placed.
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMenuLists);
+} else {
+    initMenuLists();
+}

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -3254,6 +3254,19 @@ class DownloadSupportBlock(blocks.StaticBlock):
         label = "Download Support Message"
 
 
+class EnterpriseDownloadBlock(blocks.StaticBlock):
+    """Static placeholder block for the Firefox Enterprise download section.
+
+    No editable fields by design: it renders the existing enterprise
+    download markup/FTL strings as-is while the Enterprise page's
+    redesign is in progress.
+    """
+
+    class Meta:
+        template = "cms/blocks/enterprise-download.html"
+        label = "Enterprise Download"
+
+
 # Contact Page Form Field Blocks
 
 

--- a/springfield/cms/fixtures/enterprise_download_fixtures.py
+++ b/springfield/cms/fixtures/enterprise_download_fixtures.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from springfield.cms.fixtures.base_fixtures import get_flare_blocks_docs_page, get_or_create_page
+from springfield.cms.models import FreeFormPage2026
+
+
+def get_enterprise_download() -> dict:
+    return {
+        "type": "enterprise_download",
+        "value": None,
+        "id": "ed000001-0000-0000-0000-000000000001",
+    }
+
+
+def get_enterprise_download_test_page() -> FreeFormPage2026:
+    index_page = get_flare_blocks_docs_page()
+
+    page = get_or_create_page(
+        FreeFormPage2026,
+        slug="test-enterprise-download-page",
+        parent=index_page,
+        defaults={
+            "title": "Enterprise Download",
+        },
+    )
+
+    page.upper_content = [get_enterprise_download()]
+    page.content = [get_enterprise_download()]
+    page.save_revision().publish()
+    return page

--- a/springfield/cms/fixtures/registry.py
+++ b/springfield/cms/fixtures/registry.py
@@ -25,6 +25,7 @@ from springfield.cms.fixtures.carousel_fixtures import get_carousel_test_page
 from springfield.cms.fixtures.conditional_display_fixtures import get_conditional_display_test_page
 from springfield.cms.fixtures.contact_page_fixtures import get_contact_test_page
 from springfield.cms.fixtures.download_page_fixtures import get_download_pages
+from springfield.cms.fixtures.enterprise_download_fixtures import get_enterprise_download_test_page
 from springfield.cms.fixtures.featured_image_section_fixtures import get_featured_image_section_test_page
 from springfield.cms.fixtures.freeformpage import (
     get_freeform_page_test_page,
@@ -92,6 +93,7 @@ PAGE_FIXTURES = [
     get_media_content_test_page,
     get_topic_list_test_page,
     get_download_pages,
+    get_enterprise_download_test_page,
     get_thanks_page,
     get_contact_test_page,
     get_article_index_test_page,

--- a/springfield/cms/models/locale.py
+++ b/springfield/cms/models/locale.py
@@ -24,6 +24,7 @@ class SpringfieldLocale(WagtailLocale):
 
     class Meta:
         proxy = True
+        app_label = "cms"
 
     @classmethod
     def get_active(cls):

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -56,6 +56,7 @@ from springfield.cms.blocks import (
     CountrySelectFieldBlock,
     DownloadSupportBlock,
     EmailFieldBlock,
+    EnterpriseDownloadBlock,
     FeaturedImageSectionBlock,
     HeadingBlock,
     HiddenFieldBlock,
@@ -967,6 +968,7 @@ def _get_freeform_page_blocks(allow_uitour=True, allow_kit_intro=False):
         ("topic_list", TopicListBlock(allow_uitour=allow_uitour, group="Main")),
         ("line_cards", LineCardsBlock(allow_uitour=allow_uitour, template="cms/blocks/sections/line-cards-section.html", group="Main")),
         ("button_row", ButtonRowBlock(allow_uitour=allow_uitour, group="Main")),
+        ("enterprise_download", EnterpriseDownloadBlock(group="Main")),
         ("kit_banner", KitBannerBlock(allow_uitour=allow_uitour, group="Banners")),
         (
             "banner_snippet",

--- a/springfield/cms/templates/cms/blocks/enterprise-download.html
+++ b/springfield/cms/templates/cms/blocks/enterprise-download.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<include:enterprise-download />

--- a/springfield/cms/templates/components/enterprise-download.html
+++ b/springfield/cms/templates/components/enterprise-download.html
@@ -1,0 +1,142 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% set params = '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=enterprise' %}
+{% set win_download_lang = LANG %}
+{% set mac_download_lang = "ja-JP-mac" if LANG == "ja" else LANG %}
+
+{#
+ This markup is reused as-is from the legacy (non-Flare) enterprise page, so
+ it needs its supporting CSS bundles here: callers other than
+ firefox/enterprise/index.html (e.g. CMS page templates) won't have already
+ loaded them via a page_css block. Duplicate <link> tags when a caller does
+ already load them are harmless. Remove once this gets a proper Flare redesign.
+#}
+{{ css_bundle('protocol-split') }}
+{{ css_bundle('protocol-picto') }}
+{{ css_bundle('firefox-enterprise') }}
+{{ css_bundle('flare-enterprise') }}
+
+<section id="download" class="fl-section fl-section-download">
+  <h2 class="fl-heading">{{ ftl('firefox-enterprise-enterprise-downloads') }}</h2>
+
+  <div class="enterprise-download-lists">
+
+    <section class="enterprise-download-block platform-win64">
+      <h3 class="enterprise-download-title">{{ ftl('firefox-enterprise-windows') }}</h3>
+
+      <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win64-download-list">
+        <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-win64-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
+        <ul class="mzp-c-menu-list-list download-platform-list">
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64" data-cta-text="Win64 - Download - Firefox" data-testid="firefox-enterprise-win64-menu-link">
+              {{ ftl('firefox-enterprise-firefox-latest') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64-msi" data-cta-text="Win64 - Download - Firefox MSI" data-testid="firefox-enterprise-win64-msi-menu-link">
+              {{ ftl('firefox-enterprise-firefox-latest-msi') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64" data-cta-text="Win64 - Download - Firefox ESR" data-testid="firefox-enterprise-win64-esr-menu-link">
+              {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ win_download_lang }}" data-download-version="win64-msi" data-cta-text="Win64 - Download - Firefox ESR MSI" data-testid="firefox-enterprise-win64-esr-msi-menu-link">
+              {{ ftl('firefox-enterprise-firefox-esr-msi') }}
+            </a>
+          </li>
+        </ul>
+      </div>
+
+    </section>
+
+    <section class="enterprise-download-block platform-mac">
+      <h3 class="enterprise-download-title">{{ ftl('firefox-enterprise-macos') }}</h3>
+
+      <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="mac-download-list">
+        <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-mac-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
+        <ul class="mzp-c-menu-list-list download-platform-list">
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx" data-cta-text="MacOS - Download - Firefox" data-testid="firefox-enterprise-mac-menu-link">
+              {{ ftl('firefox-enterprise-firefox-latest') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-pkg-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx-pkg" data-cta-text="MacOS - Download - Firefox PKG" data-testid="firefox-enterprise-mac-pkg-menu-link">
+              {{ ftl('firefox-enterprise-firefox-latest-pkg') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx" data-cta-text="MacOS - Download - Firefox ESR" data-testid="firefox-enterprise-mac-esr-menu-link">
+              {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx&lang={{ mac_download_lang }}" data-download-version="osx-pkg" data-cta-text="MacOS - Download - Firefox ESR PKG" data-testid="firefox-enterprise-mac-esr-pkg-menu-link">
+              {{ ftl('firefox-enterprise-firefox-esr-pkg') }}
+            </a>
+          </li>
+        </ul>
+      </div>
+
+    </section>
+
+    <section class="enterprise-download-block platform-linux">
+      <h3 class="enterprise-download-title">{{ ftl('firefox-enterprise-linux') }}</h3>
+
+      <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="linux-download-list">
+        <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-linux-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
+        <ul class="mzp-c-menu-list-list download-platform-list">
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" data-download-version="linux64" data-cta-text="Linux64 - Download - Firefox" data-testid="firefox-enterprise-linux-menu-link">
+              {{ ftl('firefox-enterprise-firefox-latest-64-bit') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64-aarch64&lang={{ LANG }}" data-download-version="linux64-aarch64" data-cta-text="Linux64 ARM64 - Download - Firefox" data-testid="firefox-enterprise-linux-arm64-menu-link">
+              {{ ftl('firefox-enterprise-firefox-latest-arm64') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64&lang={{ LANG }}" data-download-version="linux64" data-cta-text="Linux64 - Download - Firefox ESR" data-testid="firefox-enterprise-linux-esr-menu-link">
+              {{ ftl('firefox-enterprise-firefox-esr-64-bit') }}
+            </a>
+          </li>
+          <li class="mzp-c-menu-list-item">
+            <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64-aarch64&lang={{ LANG }}" data-download-version="linux64-aarch64" data-cta-text="Linux64 ARM64 - Download - Firefox ESR" data-testid="firefox-enterprise-linux-esr-arm64-menu-link">
+              {{ ftl('firefox-enterprise-firefox-esr-arm64') }}
+            </a>
+          </li>
+        </ul>
+      </div>
+
+    </section>
+  </div>
+
+  <div class="enterprise-download-support enterprise-download-resources">
+    <h3 class="enterprise-download-subtitle">{{ ftl('firefox-enterprise-resources') }}</h3>
+    <ul class="mzp-u-list-styled">
+      <li><a href="https://firefox-admin-docs.mozilla.org/">{{ ftl('firefox-enterprise-documentation') }}</a></li>
+      <li><a href="https://github.com/mozilla/policy-templates/releases">{{ ftl('firefox-enterprise-policy-templates') }}</a></li>
+      <li><a href="https://support.mozilla.org/products/firefox-enterprise/whats-new-firefox-enterprise/{{ params }}">{{ ftl('firefox-enterprise-release-notes-v2', fallback='firefox-enterprise-release-notes') }}</a></li>
+    </ul>
+  </div>
+
+  <p class="fl-body text-center fl-body-md">
+    {{ ftl('firefox-enterprise-download-firefox-or-esr', firefox_all = 'href="' ~ firefox_url('desktop', 'all', 'esr') ~ '"') }}
+  </p>
+</section>
+
+{#
+ This JS turns the "Select your download" menu-list headings into the
+ expandable download-button widget (MzpDetails). Same as the CSS bundles
+ above, callers other than firefox/enterprise/index.html won't already have
+ loaded it via a page_css/js block.
+#}
+{{ js_bundle('firefox-enterprise') }}

--- a/springfield/cms/templates/pattern-library/components/flare/enterprise-download/enterprise-download.html
+++ b/springfield/cms/templates/pattern-library/components/flare/enterprise-download/enterprise-download.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div data-testid="enterprise-download">
+  <include:enterprise-download />
+</div>

--- a/springfield/cms/templates/pattern-library/components/flare/enterprise-download/enterprise-download.yaml
+++ b/springfield/cms/templates/pattern-library/components/flare/enterprise-download/enterprise-download.yaml
@@ -1,0 +1,2 @@
+name: "Enterprise Download"
+context: {}

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -68,6 +68,7 @@ from springfield.cms.fixtures.cards_fixtures import (
     get_sticker_cards_test_page,
 )
 from springfield.cms.fixtures.carousel_fixtures import get_carousel_test_page, get_carousel_variants
+from springfield.cms.fixtures.enterprise_download_fixtures import get_enterprise_download_test_page
 from springfield.cms.fixtures.featured_image_section_fixtures import (
     get_featured_image_section_test_page,
     get_featured_image_section_variants,
@@ -2130,6 +2131,48 @@ def test_mobile_store_qr_code_block(index_page, placeholder_images, rf):
     lower_mobile_image_div = lower_qr_section.find("div", class_="fl-mobile-store-mobile-image")
     assert lower_mobile_image_div, "Mobile image div should be present"
     assert lower_mobile_image_div.find("img"), "Mobile image should render an img element"
+
+
+def test_enterprise_download_block(index_page, rf):
+    page = get_enterprise_download_test_page()
+
+    request = rf.get(page.get_full_url())
+    response = page.serve(request)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    upper = soup.find("div", class_="fl-split-page-upper")
+    lower = soup.find("div", class_="fl-split-page-lower")
+    assert upper, "Upper section should exist when upper_content has blocks"
+    assert lower, "Lower section should exist when content has blocks"
+
+    for region in (upper, lower):
+        download_section = region.find("section", id="download")
+        assert download_section, "Enterprise download section should render"
+        assert "Enterprise downloads" in download_section.get_text()
+
+        platform_blocks = download_section.find_all("section", class_="enterprise-download-block")
+        platform_classes = [cls for block in platform_blocks for cls in block["class"]]
+        assert "platform-win64" in platform_classes
+        assert "platform-mac" in platform_classes
+        assert "platform-linux" in platform_classes
+
+        win64_links = download_section.find("div", id="win64-download-list").find_all("a", class_="download-link")
+        assert any(link["href"].startswith("https://download.mozilla.org/?product=firefox-latest-ssl&os=win64") for link in win64_links)
+
+        mac_links = download_section.find("div", id="mac-download-list").find_all("a", class_="download-link")
+        assert any(link["href"].startswith("https://download.mozilla.org/?product=firefox-latest-ssl&os=osx") for link in mac_links)
+
+        linux_links = download_section.find("div", id="linux-download-list").find_all("a", class_="download-link")
+        assert any(link["href"].startswith("https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64") for link in linux_links)
+
+        resources = download_section.find("div", class_="enterprise-download-resources")
+        assert resources, "Resources block should render"
+        assert resources.find("a", href="https://firefox-admin-docs.mozilla.org/")
+        assert resources.find("a", href="https://github.com/mozilla/policy-templates/releases")
+
+        assert download_section.find("p", class_="fl-body"), "ESR download language paragraph should render"
 
 
 def test_freeform_page_split_layout(index_page, rf):

--- a/springfield/firefox/templates/firefox/enterprise/index.html
+++ b/springfield/firefox/templates/firefox/enterprise/index.html
@@ -172,7 +172,7 @@
         </div>
       </content:content>
     </include:banner>
-<div class="mzp-l-content">
+  <div class="mzp-l-content">
     <section id="download" class="fl-section fl-section-download">
       <h2 class="fl-heading">{{ ftl('firefox-enterprise-enterprise-downloads') }}</h2>
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -312,6 +312,7 @@ FLUENT_DEFAULT_FILES = [
     "ui",
     "mozilla-account-promo",
     "components",
+    "firefox/enterprise",
 ]
 
 FLUENT_DEFAULT_PERCENT_REQUIRED = config("FLUENT_DEFAULT_PERCENT_REQUIRED", default="80", parser=int)


### PR DESCRIPTION
## One-line summary

Create a component for the download section on the Enterprise Firefox page so the page can be migrated to the Wagtail CMS in the future,

## Significant changes and points to review

The component is a verbatim copy of the existing HTML and template language constructs. 

1. The existing page includes the template extracted for the component and should display identically to the previous version.
2. media/js/firefox/enterprise/landing.es6.js was updated to ensure the menus were initialized correctly. Since this file is 'global' the change should be reviewed carefully.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1438

## Testing

The download component currently exists in isolation. However it can be added to a "Free Form 2026 Page" to confirm it renders identically to the section at the bottom of the https://www.firefox.com/en-US/browsers/enterprise/

It's also worth noting that during development the download section was replaced by the component and a visual regression test generated to confirm the component rendered identically to the static content it replaced. These are available as a patch, if required.