### PR TITLE
WT-1212: redirect /school/ to /en-US/landing/school/

### DIFF
--- a/springfield/base/nonlocale_urls.py
+++ b/springfield/base/nonlocale_urls.py
@@ -15,6 +15,7 @@ sync with the urlpatterns below
 """
 
 from django.urls import path
+from django.views.generic.base import RedirectView
 
 from springfield.base import views
 
@@ -23,4 +24,9 @@ urlpatterns = (
     path(".well-known/security.txt", views.SecurityDotTxt.as_view(), name="security.txt"),
     path(".well-known/gpc.json", views.GpcDotJson.as_view(), name="gpc.json"),
     path("locales/", views.locales, name="base.locales"),
+    path(
+        "school/",
+        RedirectView.as_view(url="/en-US/landing/school/", permanent=False, query_string=True),
+        name="school.redirect",
+    ),
 )

--- a/springfield/base/tests/test_i18n.py
+++ b/springfield/base/tests/test_i18n.py
@@ -79,6 +79,8 @@ def test_normalize_language(lang_code, expected):
         ("healthz-cron", False),
         ("revision.txt", False),
         ("locales", False),
+        ("school", False),
+        ("/school/", False),
         ("/all-urls-global.xml", False),
         ("/all-urls.xml", False),
         # Some example paths that do need them

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -43,3 +43,19 @@ def test_healthz_cron(client):
         expected_content="Time Since Last Cron Task Runs",
         expected_status=500,  # because an unsynced DB returns a 500, but with the correct HTML
     )
+
+
+@pytest.mark.parametrize(
+    "accept_language",
+    ("en-US", "de", "fr", "es-MX", "ja"),
+)
+def test_school_redirects_to_en_us_landing_regardless_of_accept_language(client, accept_language):
+    resp = client.get("/school/", headers={"accept-language": accept_language})
+    assert resp.status_code == 302
+    assert resp["Location"] == "/en-US/landing/school/"
+
+
+def test_school_redirect_preserves_query_string(client):
+    resp = client.get("/school/?utm_source=test&utm_campaign=school")
+    assert resp.status_code == 302
+    assert resp["Location"] == "/en-US/landing/school/?utm_source=test&utm_campaign=school"

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -476,6 +476,7 @@ SUPPORTED_NONLOCALES = [
     "csrf_403",
     "pattern-library",
     "_documents",
+    "school",  # short vanity URL that always redirects to /en-US/landing/school/
 ]
 
 # Paths that can exist either with or without a locale code in the URL.


### PR DESCRIPTION
This changeset adds an opinonated redirect from  `/school/` to `/en-US/landing/school/` regardless of browser locale prefs. It's for a campaign that will only be run in the US.

## Summary

- Adds `school` to `SUPPORTED_NONLOCALES` so `SpringfieldLangCodeFixupMiddleware` does not prepend an Accept-Language-derived locale before the URL resolver runs.
- Wires a 302 `RedirectView` in `nonlocale_urls.py` so `/school/` always redirects to `/en-US/landing/school/` (query string preserved).

The redirect target `/en-US/landing/school/` is a CMS page

## Test plan

- [X] `pytest springfield/base/tests/test_i18n.py::test_path_needs_lang_code springfield/base/tests/test_urls.py`
- [X] Hit `/school/` with `Accept-Language: de` and confirm 302 -> `/en-US/landing/school/`
- [X] Hit `/school/?utm_source=x` and confirm the query string is preserved