### PR TITLE
Rename AWS_DB_JSON_DATA_FILE env var to GCS_DB_JSON_DATA_FILE

### DIFF
--- a/bin/db_utils.py
+++ b/bin/db_utils.py
@@ -11,7 +11,7 @@ from subprocess import CalledProcessError, check_output
 
 JSON_DATA_FILE_NAME = "springfield_db_info.json"
 DATA_PATH = getenv("DATA_PATH", "data")
-JSON_DATA_FILE = getenv("AWS_DB_JSON_DATA_FILE", f"{DATA_PATH}/{JSON_DATA_FILE_NAME}")
+JSON_DATA_FILE = getenv("GCS_DB_JSON_DATA_FILE", f"{DATA_PATH}/{JSON_DATA_FILE_NAME}")
 DB_FILE = f"{DATA_PATH}/springfield.db"
 CACHE = {}
 BLOCKSIZE = 65536

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -62,7 +62,7 @@ if SQLITE_DB_IN_USE and not LOCAL_DB_UPDATE:
         ("download_database", 600),
     )
 
-DB_INFO_FILE = getenv("AWS_DB_JSON_DATA_FILE", f"{settings.DATA_PATH}/springfield_db_info.json")
+DB_INFO_FILE = getenv("GCS_DB_JSON_DATA_FILE", f"{settings.DATA_PATH}/springfield_db_info.json")
 GIT_SHA = getenv("GIT_SHA")
 BUCKET_NAME = config("GCS_DB_BUCKET", default="springfield-db-dev")
 GCS_BASE_URL = f"https://storage.googleapis.com/{BUCKET_NAME}"

--- a/springfield/base/views.py
+++ b/springfield/base/views.py
@@ -55,7 +55,7 @@ HEALTH_FILES = [
     ("update_locales", 600),
 ]
 
-# Only check download_database health for SQLite deployments that download from S3
+# Only check download_database health for SQLite deployments that download from GCS
 if SQLITE_DB_IN_USE and not LOCAL_DB_UPDATE:
     HEALTH_FILES.insert(
         0,


### PR DESCRIPTION
## Summary

- Follow-up to #1603 (S3 → GCS migration): the env var name still referenced AWS. Rename to `GCS_DB_JSON_DATA_FILE` to match the actual storage backend.
- Only two references in the repo: `bin/db_utils.py` and `springfield/base/views.py`.

## Test plan

- [x] Confirm any deployment configs / secrets referencing `AWS_DB_JSON_DATA_FILE` are updated to `GCS_DB_JSON_DATA_FILE` before/with this rollout (the fallback default keeps local dev working without the env var set).