### PR TITLE
Add Mastodon verification link to head

### DIFF
--- a/springfield/base/templates/base-protocol.html
+++ b/springfield/base/templates/base-protocol.html
@@ -52,6 +52,7 @@
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="{% block page_ios_icon %}{{ static('img/favicons/firefox/browser/apple-touch-icon.png') }}{% endblock %}">
     <link rel="icon" type="image/png" sizes="196x196" href="{% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}">
     <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}">
+    <link rel="me" href="https://mastodon.social/@FirefoxOfficial">
     {% block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
     {% endblock shared_meta %}
 

--- a/springfield/cms/templates/cms/base-flare.html
+++ b/springfield/cms/templates/cms/base-flare.html
@@ -77,6 +77,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="{% block page_ios_icon %}{{ static('img/favicons/firefox/browser/apple-touch-icon.png') }}{% endblock %}">
     <link rel="icon" type="image/png" sizes="196x196" href="{% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}">
     <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}">
+    <link rel="me" href="https://mastodon.social/@FirefoxOfficial">
     {% block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
     {% endblock shared_meta %}
 


### PR DESCRIPTION
## One-line summary
Adds a Mastodon verification link to the header.

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1459

## Testing
- [ ] Checkout this PR
- [ ] Open the site
- [ ] Open the developer tools inspector and search for "Mastodon"
- [ ] Verify the <link rel="me" href="https://mastodon.social/@FirefoxOfficial"> tag exists

See the image in the attached work item and this thread https://github.com/mastodon/mastodon/issues/10345

Link tags are acceptable here and a body is not required. As far as I can tell you supply a base URL to Mastodon and it checks that URL for this verification. In our case that's of course www.firefox.com