### PR TITLE
WT-1212: swap /school/ redirect to redirect() helper pattern

### DIFF
--- a/springfield/base/nonlocale_urls.py
+++ b/springfield/base/nonlocale_urls.py
@@ -15,7 +15,6 @@ sync with the urlpatterns below
 """
 
 from django.urls import path
-from django.views.generic.base import RedirectView
 
 from springfield.base import views
 
@@ -24,9 +23,4 @@ urlpatterns = (
     path(".well-known/security.txt", views.SecurityDotTxt.as_view(), name="security.txt"),
     path(".well-known/gpc.json", views.GpcDotJson.as_view(), name="gpc.json"),
     path("locales/", views.locales, name="base.locales"),
-    path(
-        "school/",
-        RedirectView.as_view(url="/en-US/landing/school/", permanent=False, query_string=True),
-        name="school.redirect",
-    ),
 )

--- a/springfield/base/tests/test_urls.py
+++ b/springfield/base/tests/test_urls.py
@@ -43,19 +43,3 @@ def test_healthz_cron(client):
         expected_content="Time Since Last Cron Task Runs",
         expected_status=500,  # because an unsynced DB returns a 500, but with the correct HTML
     )
-
-
-@pytest.mark.parametrize(
-    "accept_language",
-    ("en-US", "de", "fr", "es-MX", "ja"),
-)
-def test_school_redirects_to_en_us_landing_regardless_of_accept_language(client, accept_language):
-    resp = client.get("/school/", headers={"accept-language": accept_language})
-    assert resp.status_code == 302
-    assert resp["Location"] == "/en-US/landing/school/"
-
-
-def test_school_redirect_preserves_query_string(client):
-    resp = client.get("/school/?utm_source=test&utm_campaign=school")
-    assert resp.status_code == 302
-    assert resp["Location"] == "/en-US/landing/school/?utm_source=test&utm_campaign=school"

--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -116,6 +116,10 @@ redirectpatterns = (
         merge_query=False,
     ),
     redirect(r"^mobile/get-app/?$", "/mobile/", permanent=False),
+    # WT-1212: /school/ vanity URL always lands on the en-US page.
+    # `school` is in SUPPORTED_NONLOCALES so LangCodeFixupMiddleware won't
+    # prepend a locale before this pattern fires.
+    redirect(r"^school/?$", "/en-US/landing/school/", locale_prefix=False, permanent=False),
 )
 
 refresh_redirects = (

--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -170,6 +170,30 @@ def test_ai_redirect_to_smart_window_waitlist(client, source, dest):
     assert resp.headers["Location"] == dest
 
 
+@pytest.mark.parametrize(
+    "accept_language",
+    ("en-US", "de", "fr", "es-MX", "ja"),
+)
+@pytest.mark.parametrize(
+    "source",
+    ("/school/", "/school"),
+)
+def test_school_redirect_always_lands_on_en_us(client, source, accept_language):
+    resp = client.get(source, headers={"accept-language": accept_language}, follow=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/en-US/landing/school/"
+
+
+@pytest.mark.parametrize(
+    "source",
+    ("/school/?utm_source=test&utm_campaign=school", "/school?utm_source=test&utm_campaign=school"),
+)
+def test_school_redirect_preserves_query_string(client, source):
+    resp = client.get(source, follow=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/en-US/landing/school/?utm_source=test&utm_campaign=school"
+
+
 # -- Offsite redirect / locale / query string isolation tests --
 
 EXPECTED_REDIRECT_QS = "?redirect_source=test"


### PR DESCRIPTION
## Summary

Follow-up to #1611. Swaps the bespoke `RedirectView` for a `redirect()` helper entry in `firefox/redirects.py`, matching the pattern used for other vanity redirects. Also broadens coverage to `/school` (no trailing slash).

`school` remains in `SUPPORTED_NONLOCALES` from #1611 so `SpringfieldLangCodeFixupMiddleware` still won't prepend an Accept-Language-derived locale.

## Test plan

- [x] `pytest springfield/base/tests/test_i18n.py::test_path_needs_lang_code springfield/firefox/tests/test_redirects.py`
- [x] Hit `/school/` and `/school` with various `Accept-Language` headers, confirm 302 -> `/en-US/landing/school/`
- [x] Hit `/school/?utm_source=x` and `/school?utm_source=x`, confirm query string is preserved