### PR TITLE
Remove `PERMANENT_CMS_REFRESH_REDIRECTS`, redirects always permanent

### DIFF
--- a/springfield/firefox/redirects.py
+++ b/springfield/firefox/redirects.py
@@ -4,8 +4,6 @@
 
 import re
 
-from django.conf import settings
-
 from springfield.redirects.util import mobile_app_redirector, no_redirect, platform_redirector, redirect
 
 # matches only ASCII letters (ignoring case), numbers, dashes, periods, and underscores.
@@ -123,16 +121,16 @@ redirectpatterns = (
 )
 
 refresh_redirects = (
-    redirect(r"^browsers/desktop/windows/$", "/download/windows/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/desktop/mac/$", "/download/mac/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/desktop/linux/$", "/download/linux/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/mobile/android/$", "/download/android/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/mobile/ios/$", "/download/ios/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/desktop/chromebook/$", "/download/chromebook/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/unsupported-systems/$", "/download/unsupported-systems/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/mobile/$", "/mobile/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/mobile/focus/$", "/mobile/focus/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
-    redirect(r"^browsers/mobile/get-app/$", "/mobile/", permanent=settings.PERMANENT_CMS_REFRESH_REDIRECTS),
+    redirect(r"^browsers/desktop/windows/$", "/download/windows/", permanent=True),
+    redirect(r"^browsers/desktop/mac/$", "/download/mac/", permanent=True),
+    redirect(r"^browsers/desktop/linux/$", "/download/linux/", permanent=True),
+    redirect(r"^browsers/mobile/android/$", "/download/android/", permanent=True),
+    redirect(r"^browsers/mobile/ios/$", "/download/ios/", permanent=True),
+    redirect(r"^browsers/desktop/chromebook/$", "/download/chromebook/", permanent=True),
+    redirect(r"^browsers/unsupported-systems/$", "/download/unsupported-systems/", permanent=True),
+    redirect(r"^browsers/mobile/$", "/mobile/", permanent=True),
+    redirect(r"^browsers/mobile/focus/$", "/mobile/focus/", permanent=True),
+    redirect(r"^browsers/mobile/get-app/$", "/mobile/", permanent=True),
 )
 
 redirectpatterns = redirectpatterns + refresh_redirects

--- a/springfield/firefox/tests/test_redirects.py
+++ b/springfield/firefox/tests/test_redirects.py
@@ -2,12 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import importlib
 from functools import partial
 from unittest.mock import patch
 
 from django.http.response import HttpResponse
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 
 import pytest
 
@@ -94,12 +93,10 @@ def test_mobile_app():
 
 
 def _get_refresh_middleware():
-    """Reload the redirects module and return middleware built from its refresh_redirects."""
-    importlib.reload(redirects_module)
+    """Return middleware built from the redirects module's refresh_redirects."""
     return RedirectsMiddleware(get_response=HttpResponse, resolver=get_resolver(redirects_module.refresh_redirects))
 
 
-@pytest.mark.parametrize("permanent", (True, False), ids=("301", "302"))
 @pytest.mark.parametrize(
     "source, destination",
     (
@@ -115,16 +112,14 @@ def _get_refresh_middleware():
         ("/browsers/unsupported-systems/", "/download/unsupported-systems/"),
     ),
 )
-def test_refresh_redirect_destinations(source, destination, permanent):
+def test_refresh_redirect_destinations(source, destination):
     rf = RequestFactory()
-    with override_settings(PERMANENT_CMS_REFRESH_REDIRECTS=permanent):
-        middleware = _get_refresh_middleware()
-        resp = middleware.process_request(rf.get(source))
-    assert resp.status_code == (301 if permanent else 302)
+    middleware = _get_refresh_middleware()
+    resp = middleware.process_request(rf.get(source))
+    assert resp.status_code == 301
     assert resp["location"] == destination
 
 
-@pytest.mark.parametrize("permanent", (True, False), ids=("301", "302"))
 @pytest.mark.parametrize(
     "source, destination",
     (
@@ -132,26 +127,23 @@ def test_refresh_redirect_destinations(source, destination, permanent):
         ("/browsers/desktop/mac/?utm_source=foo&utm_medium=bar", "/download/mac/?utm_source=foo&utm_medium=bar"),
     ),
 )
-def test_refresh_redirect_preserves_query_strings(source, destination, permanent):
+def test_refresh_redirect_preserves_query_strings(source, destination):
     rf = RequestFactory()
-    with override_settings(PERMANENT_CMS_REFRESH_REDIRECTS=permanent):
-        middleware = _get_refresh_middleware()
-        resp = middleware.process_request(rf.get(source))
-    assert resp.status_code == (301 if permanent else 302)
+    middleware = _get_refresh_middleware()
+    resp = middleware.process_request(rf.get(source))
+    assert resp.status_code == 301
     assert resp["location"] == destination
 
 
-@pytest.mark.parametrize("permanent", (True, False), ids=("301", "302"))
 @pytest.mark.parametrize(
     "locale",
     ("en-US", "de", "fr"),
 )
-def test_refresh_redirect_locale_handling(locale, permanent):
+def test_refresh_redirect_locale_handling(locale):
     rf = RequestFactory()
-    with override_settings(PERMANENT_CMS_REFRESH_REDIRECTS=permanent):
-        middleware = _get_refresh_middleware()
-        resp = middleware.process_request(rf.get(f"/{locale}/browsers/desktop/windows/"))
-    assert resp.status_code == (301 if permanent else 302)
+    middleware = _get_refresh_middleware()
+    resp = middleware.process_request(rf.get(f"/{locale}/browsers/desktop/windows/"))
+    assert resp.status_code == 301
     assert resp["location"] == f"/{locale}/download/windows/"
 
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -56,11 +56,6 @@ DEBUG = config("DEBUG", parser=bool, default="false")
 # Enable legacy CSS mode for Flare (links only CSS for legacy browsers)
 FLARECSS_LEGACY_MODE = config("FLARECSS_LEGACY_MODE", parser=bool, default="false")
 
-# PERMANENT_CMS_REFRESH_REDIRECTS switches the CMS-refresh redirects from temporary (302)
-# to permanent (301); defaults to true. The redirects themselves are now always
-# on. TODO: remove this setting once the redirects are confirmed permanent (follow-up).
-PERMANENT_CMS_REFRESH_REDIRECTS = config("PERMANENT_CMS_REFRESH_REDIRECTS", default="true", parser=bool)
-
 db_connection_max_age_secs = config("DB_CONN_MAX_AGE", default="0", parser=int)
 db_conn_health_checks = config("DB_CONN_HEALTH_CHECKS", default="false", parser=bool)
 db_default_url = config(

--- a/tests/redirects/map_all_redirects.py
+++ b/tests/redirects/map_all_redirects.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.conf import settings
-
 from .base import flatten, url_test
 
 UA_ANDROID = {"User-Agent": "Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) Gecko/51.0 Firefox/51.0"}
@@ -15,12 +13,10 @@ URLS = flatten(
         url_test("/os/", "https://support.mozilla.org/products/firefox-os?redirect_source=firefox-com", status_code=301),
         url_test("/desktop/", "/browsers/desktop/", status_code=302),
         url_test("/android/", "/download/android/", status_code=302),
-        url_test("/browsers/mobile/", "/mobile/", status_code=301 if settings.PERMANENT_CMS_REFRESH_REDIRECTS else 302),
-        url_test("/browsers/mobile/focus/", "/mobile/focus/", status_code=301 if settings.PERMANENT_CMS_REFRESH_REDIRECTS else 302),
-        url_test("/browsers/mobile/get-app/", "/mobile/", status_code=301 if settings.PERMANENT_CMS_REFRESH_REDIRECTS else 302),
-        url_test(
-            "/browsers/unsupported-systems/", "/download/unsupported-systems/", status_code=301 if settings.PERMANENT_CMS_REFRESH_REDIRECTS else 302
-        ),
+        url_test("/browsers/mobile/", "/mobile/", status_code=301),
+        url_test("/browsers/mobile/focus/", "/mobile/focus/", status_code=301),
+        url_test("/browsers/mobile/get-app/", "/mobile/", status_code=301),
+        url_test("/browsers/unsupported-systems/", "/download/unsupported-systems/", status_code=301),
         url_test("/developer/", "/channel/desktop/developer/", status_code=302),
         url_test("/10/", "/features/", status_code=301),
         url_test("/independent/", "/features/", status_code=301),

--- a/tests/redirects/test_redirects.py
+++ b/tests/redirects/test_redirects.py
@@ -4,17 +4,9 @@
 
 """Test redirects from all apps."""
 
-import importlib
 from operator import itemgetter
 
-from django.urls import clear_url_caches
-
 import pytest
-
-import springfield.firefox.redirects as firefox_redirects_module
-import springfield.firefox.urls as firefox_urls_module
-import springfield.urls as root_urls_module
-from springfield.redirects import util as redirects_util
 
 from .base import assert_valid_url
 from .map_all_redirects import URLS as REDIRECT_URLS
@@ -26,22 +18,8 @@ from .map_locales import URLS as LOCALE_URLS
 @pytest.mark.django_db
 @pytest.mark.parametrize("url", REDIRECT_URLS, ids=itemgetter("url"))
 def test_redirect_url(url, base_url):
-    original_patterns = list(redirects_util.redirectpatterns)
-    importlib.reload(firefox_redirects_module)
-    importlib.reload(firefox_urls_module)
-    importlib.reload(root_urls_module)
-    redirects_util.redirectpatterns.clear()
-    redirects_util.register(firefox_redirects_module.redirectpatterns)
-    clear_url_caches()
     url["base_url"] = base_url
     assert_valid_url(**url)
-
-    redirects_util.redirectpatterns.clear()
-    redirects_util.redirectpatterns.extend(original_patterns)
-    importlib.reload(firefox_redirects_module)
-    importlib.reload(firefox_urls_module)
-    importlib.reload(root_urls_module)
-    clear_url_caches()
 
 
 @pytest.mark.headless


### PR DESCRIPTION
# Summary

`PERMANENT_CMS_REFRESH_REDIRECTS` was a rollout toggle that switched the CMS-refresh redirects between temporary (302) and permanent (301). 301 is the behavior we're keeping, so the flag is gone and these redirects are now unconditionally permanent.

# Changes

* Remove the `PERMANENT_CMS_REFRESH_REDIRECTS` setting and inline `permanent=True` on the refresh redirects.
* Update the unit tests to assert `301` directly, dropping the `permanent` parametrization and `override_settings`.
* Drop the URL-module reload machinery from `test_redirect_url`. It only existed to rebuild patterns for the two-state setup, and with a single state the redirects are already correct at startup.

# Testing

* `pytest springfield/firefox/tests/test_redirects.py tests/redirects/` passes. The headless tests run against an in-process `live_server`.

# Companion changes

The `PERMANENT_CMS_REFRESH_REDIRECTS` env var is now ignored. It will be deleted in a follow-up in `webservices-infra`.

# Context

* Follow-up of #1546 and #1593
* https://mozilla-hub.atlassian.net/browse/WT-1169