### PR TITLE
Easteregg fix

### DIFF
--- a/media/css/cms/components/flare-navigation.css
+++ b/media/css/cms/components/flare-navigation.css
@@ -85,6 +85,12 @@ html {
     z-index: 1;
 }
 
+/* Easter egg: once the hover WebM has buffered (JS adds .fl-video-ready), hide
+   the static wordmark <img>. Removing the video on teardown reverses this. */
+.fl-logo-fx:has(.fl-video-ready) img {
+    display: none;
+}
+
 /* A custom navigation snippet supplies its own logo image(s) instead of the theme's CSS logo.  */
 .fl-logo-fx-custom {
     align-items: center;

--- a/media/js/cms/easter-egg-logo.es6.js
+++ b/media/js/cms/easter-egg-logo.es6.js
@@ -58,10 +58,10 @@ const setupEasterEggLogo = () => {
     const activate = () => {
         if (teardown) return;
 
-        const existingLogo = logoLink.querySelector('img');
-        if (existingLogo) existingLogo.remove();
-
-        // Hide the wordmark that .fl-logo-fx paints as a background.
+        // Hide the wordmark that .fl-logo-fx paints as a background. The static
+        // <img> logo is left in the DOM and hidden via CSS
+        // (.fl-logo-fx:has(.fl-video-ready) img) so teardown restores it for
+        // free — no need to remove and re-insert the node here.
         logoLink.style.backgroundImage = 'none';
         // Widen the logo container so the WebM's flame lands at the same visual
         // size as the SVG wordmark, and shift it back so the layout doesn't move.
@@ -94,6 +94,10 @@ const setupEasterEggLogo = () => {
         video.addEventListener(
             'canplaythrough',
             () => {
+                // Signal to CSS that the video is showing its first frame, so
+                // the static wordmark <img> can be hidden.
+                wrapper.classList.add('fl-video-ready');
+
                 video.addEventListener('mouseover', () => {
                     if (isPlaying || hoverTimer) return;
                     if (Date.now() < cooldownUntil) return;

--- a/media/js/cms/easter-egg-logo.es6.js
+++ b/media/js/cms/easter-egg-logo.es6.js
@@ -34,73 +34,121 @@ const setupEasterEggLogo = () => {
     if (!logoLink) return;
     if (logoLink.querySelector('.fl-video')) return;
 
-    const existingLogo = logoLink.querySelector('img');
-    if (existingLogo) existingLogo.remove();
+    // The WebM is the white/light wordmark, so it only reads against a dark
+    // nav. The theme swaps --fl-logo-url between a dark wordmark (light theme)
+    // and the white one (dark theme); reuse that signal so we only run where
+    // the video won't disappear into a white background (e.g. /features/protection).
+    // Read the custom property rather than the resolved background-image: the
+    // variable stays readable even after activate() blanks background-image, so
+    // we can re-evaluate it when the color scheme flips.
+    const wantsVideo = () =>
+        window
+            .getComputedStyle(logoLink)
+            .getPropertyValue('--fl-logo-url')
+            .includes('logo-word-hor-white');
 
-    // Hide the wordmark that .fl-logo-fx paints as a background.
-    logoLink.style.backgroundImage = 'none';
-    // Widen the logo container so the WebM's flame lands at the same visual
-    // size as the SVG wordmark, and shift it back so the layout doesn't move.
-    logoLink.style.setProperty('inline-size', '130px');
-    logoLink.style.setProperty('block-size', '55px');
-    logoLink.style.setProperty('margin-inline-start', '-5px');
+    // Set by activate(); calling it removes the video and restores the logo.
+    let teardown = null;
 
-    const wrapper = document.createElement('div');
-    wrapper.className = 'fl-video';
-    wrapper.style.setProperty('max-block-size', '56px');
+    const activate = () => {
+        if (teardown) return;
 
-    const video = document.createElement('video');
-    video.muted = true;
+        const existingLogo = logoLink.querySelector('img');
+        if (existingLogo) existingLogo.remove();
 
-    const source = document.createElement('source');
-    source.src = 'https://assets.mozilla.net/wc/logo-1-alpha.webm';
-    source.type = 'video/webm';
+        // Hide the wordmark that .fl-logo-fx paints as a background.
+        logoLink.style.backgroundImage = 'none';
+        // Widen the logo container so the WebM's flame lands at the same visual
+        // size as the SVG wordmark, and shift it back so the layout doesn't move.
+        logoLink.style.setProperty('inline-size', '130px');
+        logoLink.style.setProperty('block-size', '55px');
+        logoLink.style.setProperty('margin-inline-start', '-5px');
 
-    video.appendChild(source);
-    wrapper.appendChild(video);
-    logoLink.appendChild(wrapper);
+        const wrapper = document.createElement('div');
+        wrapper.className = 'fl-video';
+        wrapper.style.setProperty('max-block-size', '56px');
 
-    const HOVER_INTENT_MS = 1000;
-    const COOLDOWN_MS = 10000;
+        const video = document.createElement('video');
+        video.muted = true;
 
-    let hoverTimer = null;
-    let isPlaying = false;
-    let cooldownUntil = 0;
+        const source = document.createElement('source');
+        source.src = 'https://assets.mozilla.net/wc/logo-1-alpha.webm';
+        source.type = 'video/webm';
 
-    video.addEventListener(
-        'canplaythrough',
-        () => {
-            video.addEventListener('mouseover', () => {
-                if (isPlaying || hoverTimer) return;
-                if (Date.now() < cooldownUntil) return;
+        video.appendChild(source);
+        wrapper.appendChild(video);
+        logoLink.appendChild(wrapper);
 
-                hoverTimer = setTimeout(() => {
-                    hoverTimer = null;
-                    isPlaying = true;
-                    video.play().catch((error) => {
-                        if (error && error.name === 'AbortError') return;
-                        throw error;
-                    });
-                }, HOVER_INTENT_MS);
-            });
+        const HOVER_INTENT_MS = 1000;
+        const COOLDOWN_MS = 10000;
 
-            video.addEventListener('mouseout', () => {
-                // Cancel a pending start if the user leaves before hover-intent fires.
-                // Do NOT stop an in-progress animation — let it play through.
-                if (hoverTimer) {
-                    clearTimeout(hoverTimer);
-                    hoverTimer = null;
-                }
-            });
+        let hoverTimer = null;
+        let isPlaying = false;
+        let cooldownUntil = 0;
 
-            video.addEventListener('ended', () => {
-                isPlaying = false;
-                cooldownUntil = Date.now() + COOLDOWN_MS;
-                video.currentTime = 0;
-            });
-        },
-        { once: true }
-    );
+        video.addEventListener(
+            'canplaythrough',
+            () => {
+                video.addEventListener('mouseover', () => {
+                    if (isPlaying || hoverTimer) return;
+                    if (Date.now() < cooldownUntil) return;
+
+                    hoverTimer = setTimeout(() => {
+                        hoverTimer = null;
+                        isPlaying = true;
+                        video.play().catch((error) => {
+                            if (error && error.name === 'AbortError') return;
+                            throw error;
+                        });
+                    }, HOVER_INTENT_MS);
+                });
+
+                video.addEventListener('mouseout', () => {
+                    // Cancel a pending start if the user leaves before hover-intent fires.
+                    // Do NOT stop an in-progress animation — let it play through.
+                    if (hoverTimer) {
+                        clearTimeout(hoverTimer);
+                        hoverTimer = null;
+                    }
+                });
+
+                video.addEventListener('ended', () => {
+                    isPlaying = false;
+                    cooldownUntil = Date.now() + COOLDOWN_MS;
+                    video.currentTime = 0;
+                });
+            },
+            { once: true }
+        );
+
+        teardown = () => {
+            if (hoverTimer) clearTimeout(hoverTimer);
+            wrapper.remove();
+            // Restore the CSS-painted wordmark and our sizing overrides.
+            logoLink.style.removeProperty('background-image');
+            logoLink.style.removeProperty('inline-size');
+            logoLink.style.removeProperty('block-size');
+            logoLink.style.removeProperty('margin-inline-start');
+        };
+    };
+
+    const deactivate = () => {
+        if (!teardown) return;
+        teardown();
+        teardown = null;
+    };
+
+    const sync = () => (wantsVideo() ? activate() : deactivate());
+
+    sync();
+
+    // Keep in sync if the OS color scheme flips at runtime (devtools emulation,
+    // macOS auto dark-at-sunset) so the video doesn't linger on a white nav.
+    if (window.matchMedia) {
+        window
+            .matchMedia('(prefers-color-scheme: dark)')
+            .addEventListener('change', sync);
+    }
 };
 
 if (document.readyState === 'loading') {

--- a/media/js/cms/easter-egg-logo.es6.js
+++ b/media/js/cms/easter-egg-logo.es6.js
@@ -33,6 +33,11 @@ const setupEasterEggLogo = () => {
 
     if (!logoLink) return;
     if (logoLink.querySelector('.fl-video')) return;
+    // Custom navigation snippets paint a partner/brand <img> logo and no CSS
+    // wordmark (.fl-logo-fx-custom { background-image: none }). Leave those
+    // alone — the WebM is the Firefox flame, and we'd have no wordmark to
+    // restore on teardown anyway.
+    if (logoLink.classList.contains('fl-logo-fx-custom')) return;
 
     // The WebM is the white/light wordmark, so it only reads against a dark
     // nav. The theme swaps --fl-logo-url between a dark wordmark (light theme)
@@ -97,8 +102,12 @@ const setupEasterEggLogo = () => {
                         hoverTimer = null;
                         isPlaying = true;
                         video.play().catch((error) => {
+                            // AbortError from pause/teardown races is expected.
+                            // For anything else, reset state so a later hover
+                            // can retry — don't rethrow (a throw here escapes
+                            // as an uncatchable unhandled rejection).
                             if (error && error.name === 'AbortError') return;
-                            throw error;
+                            isPlaying = false;
                         });
                     }, HOVER_INTENT_MS);
                 });


### PR DESCRIPTION
## Fix easter egg logo on light-theme pages

The easter egg logo WebM is the white wordmark, so it only shows up on a dark nav. On light-theme pages (e.g. `/features/protection`) it rendered white-on-white and disappeared.

### Changes
- **Only run on a dark nav.** Activate the video only when the theme is showing the white wordmark, so it never lands on a white background.
- **React to live theme changes.** Swap the logo in/out when the OS color scheme flips at runtime (devtools, macOS auto dark-at-sunset) instead of needing a refresh.
- **Skip custom/brand logos.** Custom navigation snippets reuse the `fl-logo-fx` class; leave those alone so the Firefox flame never replaces a partner logo.
- **Clean up `play()` error handling.** Reset state instead of rethrowing, avoiding an uncatchable unhandled rejection and a stuck-state bug.

### Testing
- Verify the easter egg still plays on hover on dark-nav pages (e.g. homepage).
- Confirm it no longer appears on light-theme pages.
- Toggle light/dark in devtools and confirm the logo updates without a refresh.
- Confirm custom-logo pages are unaffected.