### PR TITLE
Set `type=button` on dialog close button

### DIFF
--- a/springfield/cms/templates/components/dialog.html
+++ b/springfield/cms/templates/components/dialog.html
@@ -6,7 +6,7 @@
 
 <dialog id="{{ id }}" class="fl-dialog" closedby="any"{% if testid %} data-testid="{{ testid }}"{% endif %}>
 
-  <button class="fl-dialog-close-button" aria-label="Close">
+  <button type="button" class="fl-dialog-close-button" aria-label="Close">
     <include:icon icon_name="close" />
   </button>
 


### PR DESCRIPTION
## One-line summary

Sets `type=button` on close button in dialog component so that the `<dialog>` can be nested within `<form>`, since otherwise the close button submits the form.

## Significant changes and points to review

In a modal state, a dialog element becomes the only active content in a page (i.e. all other content is inert and not a part of the accessibility tree). This means it’s totally fine to nest a `<dialog>` element wherever in a document, including within forms. This pattern can be helpful since it allows one to colocate the `<dialog>` element with its trigger and other relevant content (e.g. imagine creating dialog and dialog triggers in a loop).

## Issue / Bugzilla link

- N/A

## Testing

- Confirm an existing dialog still works.
