### PR TITLE
Add `label` and `aria_labelledby` attributes to dialog component

### DIFF
--- a/springfield/cms/templates/components/dialog.html
+++ b/springfield/cms/templates/components/dialog.html
@@ -5,9 +5,10 @@
 #}
 
 <dialog id="{{ id }}" class="fl-dialog" closedby="any"
-  {% if label %}aria-label="{{ label }}"{% endif %}
-  {% if aria_labelledby %}aria-labelledby="{{ aria_labelledby }}"{% endif %}
-  {% if testid %}data-testid="{{ testid }}"{% endif %}>
+  {%- if label %} aria-label="{{ label }}"{% endif -%}
+  {%- if aria_labelledby %} aria-labelledby="{{ aria_labelledby }}"{% endif -%}
+  {%- if testid %} data-testid="{{ testid }}"{% endif -%}
+>
 
   <button type="button" class="fl-dialog-close-button" aria-label="Close">
     <include:icon icon_name="close" />

--- a/springfield/cms/templates/components/dialog.html
+++ b/springfield/cms/templates/components/dialog.html
@@ -4,7 +4,10 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<dialog id="{{ id }}" class="fl-dialog" closedby="any"{% if testid %} data-testid="{{ testid }}"{% endif %}>
+<dialog id="{{ id }}" class="fl-dialog" closedby="any"
+  {% if label %}aria-label="{{ label }}"{% endif %}
+  {% if aria_labelledby %}aria-labelledby="{{ aria_labelledby }}"{% endif %}
+  {% if testid %}data-testid="{{ testid }}"{% endif %}>
 
   <button type="button" class="fl-dialog-close-button" aria-label="Close">
     <include:icon icon_name="close" />


### PR DESCRIPTION
## One-line summary

Adds a `label` and `aria_labelledby` attribute to the dialog component so we can meet the requirement of labelling `<dialog>` elements.

## Significant changes and points to review

[Dialogs should have a label][1]. This adds the following to the dialog component:

- A `label` attribute which maps to `aria-label`.
- An `aria_labelledby` attribute which maps to `aria-labelledby`.

Typically the latter is preferred as it’s generally better to have a visible label that matches (e.g. a heading).

[1]: https://w3c.github.io/aria/#dialog:~:text=Authors%20SHOULD%20provide%20an%20accessible%20name%20for%20a%20dialog%2C%20which%20can%20be%20done%20with%20the%20aria-label%20or%20aria-labelledby%20attribute


## Issue / Bugzilla link

- N/A

## Testing

- No tests and not used, but I can add tests.
