### PR TITLE
Add `closedby=any` to dialog component as a progressive enhancement

### DIFF
--- a/springfield/cms/templates/components/dialog.html
+++ b/springfield/cms/templates/components/dialog.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<dialog id="{{ id }}" class="fl-dialog"{% if testid %} data-testid="{{ testid }}"{% endif %}>
+<dialog id="{{ id }}" class="fl-dialog" closedby="any"{% if testid %} data-testid="{{ testid }}"{% endif %}>
 
   <button class="fl-dialog-close-button" aria-label="Close">
     <include:icon icon_name="close" />


### PR DESCRIPTION
## One-line summary

Our dialog component can only be opened in a modal state and we can get “light dismiss” behaviour using the `closedby=any` attribute.

## Significant changes and points to review

Our dialog component is only opened with `showModal()` and so it likely makes sense to make them light dismissable (e.g. clicking the backdrop closes them). This adds the `closedby=any` attribute to the element which gives us this behaviour for free. In the future, we can add some JS to handle this for browsers that don’t support the feature, but it makes for an easy progressive enhancement for now.

## Issue / Bugzilla link

N/A

## Testing

Open a dialog (e.g. on the `/download/all/`) page and check that the help modals can be light dismissed.
