### PR TITLE
chore(Plausible): Add a new additive, env-driven PLAUSIBLE_EXTRA_COUNTRIES setting

### DIFF
--- a/springfield/firefox/templatetags/misc.py
+++ b/springfield/firefox/templatetags/misc.py
@@ -42,10 +42,14 @@ def needs_data_consent(country_code):
 def plausible_enabled(country_code):
     """
     Global helper that determines whether the Plausible analytics script
-    should be injected. Plausible is loaded only for EU/consent countries
-    when the `plausible` switch is on and a domain is configured.
+    should be injected. Plausible is loaded for EU/consent countries, plus
+    any extra countries listed in PLAUSIBLE_EXTRA_COUNTRIES (e.g. Brazil for
+    a temporary comparison against GA), when the `plausible` switch is on and
+    a domain is configured. The extra-country clause is additive and does not
+    affect the cookie-consent banner or GA consent-mode behavior.
     """
-    return bool(settings.PLAUSIBLE_DOMAIN and needs_data_consent(country_code) and switch("plausible"))
+    plausible_country = needs_data_consent(country_code) or country_code in settings.PLAUSIBLE_EXTRA_COUNTRIES
+    return bool(settings.PLAUSIBLE_DOMAIN and plausible_country and switch("plausible"))
 
 
 def _strip_img_prefix(url):

--- a/springfield/firefox/templatetags/misc.py
+++ b/springfield/firefox/templatetags/misc.py
@@ -43,8 +43,7 @@ def plausible_enabled(country_code):
     """
     Global helper that determines whether the Plausible analytics script
     should be injected. Plausible is loaded for EU/consent countries, plus
-    any extra countries listed in PLAUSIBLE_EXTRA_COUNTRIES (e.g. Brazil for
-    a temporary comparison against GA), when the `plausible` switch is on and
+    any extra countries listed in PLAUSIBLE_EXTRA_COUNTRIES, when the `plausible` switch is on and
     a domain is configured. The extra-country clause is additive and does not
     affect the cookie-consent banner or GA consent-mode behavior.
     """

--- a/springfield/firefox/tests/test_helper_misc.py
+++ b/springfield/firefox/tests/test_helper_misc.py
@@ -1163,6 +1163,7 @@ class TestFxALinkFragment(TestCase):
         ("GB", "True"),  # United Kingdom
         ("US", "False"),  # United States
         ("CA", "False"),  # Canada
+        ("BR", "False"),  # Brazil is not a consent country (GA keeps loading by default)
     ],
 )
 def test_needs_data_consent(country_code, expected):
@@ -1174,11 +1175,14 @@ def test_needs_data_consent(country_code, expected):
     "country_code, domain, switch_on, expected",
     [
         ("DE", "firefox.com", True, True),
+        ("BR", "firefox.com", True, True),  # Brazil: Plausible enabled, though not a consent country
         ("US", "firefox.com", True, False),
         ("DE", "firefox.com", False, False),
+        ("BR", "firefox.com", False, False),
         ("DE", "", True, False),
+        ("BR", "", True, False),
     ],
 )
 def test_plausible_enabled(country_code, domain, switch_on, expected):
-    with override_settings(PLAUSIBLE_DOMAIN=domain), patch.object(misc, "switch", return_value=switch_on):
+    with override_settings(PLAUSIBLE_DOMAIN=domain, PLAUSIBLE_EXTRA_COUNTRIES=["BR"]), patch.object(misc, "switch", return_value=switch_on):
         assert misc.plausible_enabled(country_code) is expected

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1186,10 +1186,25 @@ DATA_CONSENT_COUNTRIES = [
 ]
 
 # Extra countries (beyond DATA_CONSENT_COUNTRIES) where the Plausible
-# analytics script should load. This is intentionally env-driven: set the
-# PLAUSIBLE_EXTRA_COUNTRIES env var (comma-separated ISO codes, e.g. "BR")
-# to enable or disable per environment.
-PLAUSIBLE_EXTRA_COUNTRIES = config("PLAUSIBLE_EXTRA_COUNTRIES", default="", parser=ListOf(str))
+# analytics script should load. This is intentionally env-driven so we can
+# turn a country on or off per environment (dev/stage/prod) without a code
+# change or deploy, and so it can be reverted instantly if needed. Additionally,
+# this is likely a temporary measurement addition.
+# Set the PLAUSIBLE_EXTRA_COUNTRIES env var to a comma-separated list of
+# ISO country codes, e.g.: PLAUSIBLE_EXTRA_COUNTRIES=BR,CA
+# Empty by default (no extra countries). filter(None, ...) drops empty tokens
+# (e.g. a trailing comma) so the list never contains an empty string that
+# could match a blank country code.
+PLAUSIBLE_EXTRA_COUNTRIES = list(
+    filter(
+        None,
+        config(
+            "PLAUSIBLE_EXTRA_COUNTRIES",
+            default="",
+            parser=ListOf(str, allow_empty=True),
+        ),
+    )
+)
 
 
 # RELAY =========================================================================================

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1185,6 +1185,12 @@ DATA_CONSENT_COUNTRIES = [
     "GB",  # United Kingdom
 ]
 
+# Extra countries (beyond DATA_CONSENT_COUNTRIES) where the Plausible
+# analytics script should load. This is intentionally env-driven: set the
+# PLAUSIBLE_EXTRA_COUNTRIES env var (comma-separated ISO codes, e.g. "BR")
+# to enable or disable per environment.
+PLAUSIBLE_EXTRA_COUNTRIES = config("PLAUSIBLE_EXTRA_COUNTRIES", default="", parser=ListOf(str))
+
 
 # RELAY =========================================================================================
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1192,19 +1192,10 @@ DATA_CONSENT_COUNTRIES = [
 # this is likely a temporary measurement addition.
 # Set the PLAUSIBLE_EXTRA_COUNTRIES env var to a comma-separated list of
 # ISO country codes, e.g.: PLAUSIBLE_EXTRA_COUNTRIES=BR,CA
-# Empty by default (no extra countries). filter(None, ...) drops empty tokens
-# (e.g. a trailing comma) so the list never contains an empty string that
-# could match a blank country code.
-PLAUSIBLE_EXTRA_COUNTRIES = list(
-    filter(
-        None,
-        config(
-            "PLAUSIBLE_EXTRA_COUNTRIES",
-            default="",
-            parser=ListOf(str, allow_empty=True),
-        ),
-    )
-)
+# Empty by default (no extra countries). The `if c.strip()` guard drops empty
+# tokens (e.g. a trailing comma) so the set never contains a blank string that
+# could match an empty country code.
+PLAUSIBLE_EXTRA_COUNTRIES = {c.strip() for c in config("PLAUSIBLE_EXTRA_COUNTRIES", default="").split(",") if c.strip()}
 
 
 # RELAY =========================================================================================


### PR DESCRIPTION
## One-line summary

Enable Plausible analytics for Brazil alongside GA, in order to test analytics parity.

## Significant changes and points to review

- New `PLAUSIBLE_EXTRA_COUNTRIES` setting (`springfield/settings/base.py`): additive, env-driven, defaults to `BR`.
- `plausible_enabled()` (`springfield/firefox/templatetags/misc.py`) now loads Plausible for consent countries **OR** any country in `PLAUSIBLE_EXTRA_COUNTRIES`. The existing consent-country path is unchanged.

This deliberately does **not** add `BR` to `DATA_CONSENT_COUNTRIES`. That list is shared with the cookie-consent banner and Google Consent Mode (`data-needs-consent` -> `consentRequired()` in `gtm-snippet.es6.js`). Adding `BR` there would flip Brazil into consent-required mode and stop GA4 from loading by default, which would degrade GA data and break the comparison. Keeping `BR` out of the consent list and only in the Plausible extra-list means GA4 keeps loading by default in Brazil while Plausible now loads too.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1510

## Testing

- `test_plausible_enabled`: added `BR` cases (enabled with switch + domain; disabled when switch off or domain empty).
- `test_needs_data_consent`: added `BR -> False` to confirm Brazil is not a consent country (guards GA behavior).

