### PR TITLE
Update Nightly WNP release frequency info

### DIFF
--- a/l10n/en/firefox/whatsnew/nightly/evergreen.ftl
+++ b/l10n/en/firefox/whatsnew/nightly/evergreen.ftl
@@ -1,4 +1,3 @@
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -12,7 +11,7 @@ nightly-whatsnew-youve-just-been = You’ve just been upgraded to { -brand-name-
 nightly-whatsnew-your-firefox-nightly = Your { -brand-name-firefox-nightly } has been updated.
 nightly-whatsnew-firefox-nightly = { -brand-name-firefox-nightly }
 
-nightly-whatsnew-every-4-to-5-weeks = Every 4 to 5 weeks, a new major version of { -brand-name-firefox } is released and as a result, the { -brand-name-nightly } version increases as well.
+nightly-whatsnew-every-2-to-3-weeks = Every 2 to 3 weeks, a new major version of { -brand-name-firefox } is released and as a result, the { -brand-name-nightly } version increases as well.
 
 nightly-whatsnew-this-is-a-good = This is a good time to thank you for helping us make { -brand-name-firefox } better and to give you some pointers to documentation, communication channels and news sites related to { -brand-name-nightly } that may be of interest to you.
 

--- a/springfield/firefox/templates/firefox/whatsnew/nightly/evergreen.html
+++ b/springfield/firefox/templates/firefox/whatsnew/nightly/evergreen.html
@@ -65,9 +65,9 @@
       <p>{{ ftl('nightly-whatsnew-if-you-want-to', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mastodon.social/@FirefoxNightly"', bluesky='href="https://bsky.app/profile/firefoxnightly.bsky.social"') }}</p>
 
       <p>
-          {% set attrs = 'href="#" class="nightly-experiments-link"' %}
-          {{ ftl('nightly-whatsnew-want-to-know-which', attrs=attrs) }}
-        </p>
+        {% set attrs = 'href="#" class="nightly-experiments-link"' %}
+        {{ ftl('nightly-whatsnew-want-to-know-which', attrs=attrs) }}
+      </p>
 
       <p>{{ ftl('nightly-whatsnew-do-you-experience', bugzilla='https://bugzilla.mozilla.org') }}</p>
 
@@ -81,5 +81,5 @@
   {{ js_bundle('whatsnew_nightly') }}
 {% endblock %}
 
-{# Exclude stub attribution for in-product pages: issus 9620 #}
+{# Exclude stub attribution for in-product pages, see bedrock#9620 #}
 {% block stub_attribution %}{% endblock %}

--- a/springfield/firefox/templates/firefox/whatsnew/nightly/evergreen.html
+++ b/springfield/firefox/templates/firefox/whatsnew/nightly/evergreen.html
@@ -18,7 +18,7 @@
 {% block page_title %}{{ ftl('nightly-whatsnew-youve-just-been', version=num_version) }}{% endblock %}
 {% block page_title_prefix %}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
-{% block page_desc %}{{ ftl('nightly-whatsnew-every-4-to-5-weeks') }}{% endblock %}
+{% block page_desc %}{{ ftl('nightly-whatsnew-every-2-to-3-weeks') }}{% endblock %}
 {% block page_image %}{{ static('protocol/img/logos/firefox/browser/nightly/og.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/nightly/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/nightly/favicon-196x196.png') }}{% endblock %}
@@ -58,7 +58,7 @@
       </section>
       <br>
       {% endif %}
-      <p>{{ ftl('nightly-whatsnew-every-4-to-5-weeks') }}</p>
+      <p>{{ ftl('nightly-whatsnew-every-2-to-3-weeks') }}</p>
 
       <p>{{ ftl('nightly-whatsnew-this-is-a-good') }}</p>
 


### PR DESCRIPTION
## One-line summary

New timing in Nightly WNP intro content.

## Significant changes and points to review

Fallback ftl is not used, changing the length right away, with English fallback expected/accepted.

## Issue / Bugzilla link

#1640

## Testing

http://localhost:8000/en-CA/whatsnew/123.0a1/
http://localhost:8000/es-AR/whatsnew/123.0a1/