### PR TITLE
Use pa.firefox.com custom domain for Plausible

### DIFF
--- a/media/js/base/plausible/plausible.es6.js
+++ b/media/js/base/plausible/plausible.es6.js
@@ -42,6 +42,12 @@ Plausible.loadScript = () => {
     const script = document.createElement('script');
     script.defer = true;
     script.setAttribute('data-domain', domain);
+    // Post events to the origin the script is served from (our custom domain)
+    // rather than the plausible.io default.
+    script.setAttribute(
+        'data-api',
+        `${new URL(src, window.location.href).origin}/api/event`
+    );
     script.src = src;
     document.head.appendChild(script);
 };

--- a/media/js/base/plausible/plausible.es6.js
+++ b/media/js/base/plausible/plausible.es6.js
@@ -44,10 +44,7 @@ Plausible.loadScript = () => {
     script.setAttribute('data-domain', domain);
     // Post events to the origin the script is served from (our custom domain)
     // rather than the plausible.io default.
-    script.setAttribute(
-        'data-api',
-        `${new URL(src, window.location.href).origin}/api/event`
-    );
+    script.setAttribute('data-api', new URL('/api/event', src).href);
     script.src = src;
     document.head.appendChild(script);
 };

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1070,6 +1070,8 @@ ADMINS = MANAGERS = config("ADMINS", parser=json.loads, default="[]")
 
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")
 
+# The site identifier events are attributed to (rendered as `data-domain`), not
+# where the tracker is hosted. See PLAUSIBLE_SCRIPT_URL for the tracker origin.
 PLAUSIBLE_DOMAIN = config("PLAUSIBLE_DOMAIN", default="")
 # Served from our own subdomain so the script and its events endpoint are both
 # first-party. plausible.es6.js derives /api/event on this same origin.

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -1071,7 +1071,9 @@ ADMINS = MANAGERS = config("ADMINS", parser=json.loads, default="[]")
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")
 
 PLAUSIBLE_DOMAIN = config("PLAUSIBLE_DOMAIN", default="")
-PLAUSIBLE_SCRIPT_URL = config("PLAUSIBLE_SCRIPT_URL", default="https://plausible.io/js/script.js")
+# Served from our own subdomain so the script and its events endpoint are both
+# first-party. plausible.es6.js derives /api/event on this same origin.
+PLAUSIBLE_SCRIPT_URL = config("PLAUSIBLE_SCRIPT_URL", default="https://pa.firefox.com/js/script.js")
 
 # Transcend Consent Management - airgap.js script URL
 TRANSCEND_AIRGAP_URL = config("TRANSCEND_AIRGAP_URL", default="")

--- a/tests/unit/spec/base/plausible/plausible.js
+++ b/tests/unit/spec/base/plausible/plausible.js
@@ -151,18 +151,6 @@ describe('plausible.es6.js', function () {
             );
             expect(script.src).toBe('https://pa.firefox.com/js/script.js');
         });
-
-        it('should resolve a relative src against the current page', function () {
-            html.setAttribute('data-plausible-domain', 'firefox.com');
-            html.setAttribute('data-plausible-src', '/js/script.js');
-
-            Plausible.loadScript();
-
-            const script = appendChildSpy.calls.mostRecent().args[0];
-            expect(script.getAttribute('data-api')).toBe(
-                `${window.location.origin}/api/event`
-            );
-        });
     });
 
     describe('trackEvent', function () {

--- a/tests/unit/spec/base/plausible/plausible.js
+++ b/tests/unit/spec/base/plausible/plausible.js
@@ -134,6 +134,35 @@ describe('plausible.es6.js', function () {
             expect(script.getAttribute('data-domain')).toBe('firefox.com');
             expect(script.src).toBe('https://plausible.example/js/script.js');
         });
+
+        it('should point data-api at the origin the script is served from', function () {
+            html.setAttribute('data-plausible-domain', 'firefox.com');
+            html.setAttribute(
+                'data-plausible-src',
+                'https://pa.firefox.com/js/script.js'
+            );
+
+            Plausible.loadScript();
+
+            expect(appendChildSpy).toHaveBeenCalled();
+            const script = appendChildSpy.calls.mostRecent().args[0];
+            expect(script.getAttribute('data-api')).toBe(
+                'https://pa.firefox.com/api/event'
+            );
+            expect(script.src).toBe('https://pa.firefox.com/js/script.js');
+        });
+
+        it('should resolve a relative src against the current page', function () {
+            html.setAttribute('data-plausible-domain', 'firefox.com');
+            html.setAttribute('data-plausible-src', '/js/script.js');
+
+            Plausible.loadScript();
+
+            const script = appendChildSpy.calls.mostRecent().args[0];
+            expect(script.getAttribute('data-api')).toBe(
+                `${window.location.origin}/api/event`
+            );
+        });
     });
 
     describe('trackEvent', function () {


### PR DESCRIPTION
## One-line summary

Serve the Plausible tracker from our `pa.firefox.com` custom domain instead of `plausible.io`.

## Significant changes and points to review

- **`PLAUSIBLE_SCRIPT_URL` default** (`springfield/settings/base.py:1045`) — now `https://pa.firefox.com/js/script.js`. **Most critical part to review:** no environment sets this env var, so the code default governs prod, stage and demos, and merging moves them all at once. `config()` is kept so any environment can override without a code change.
- **`data-api` on the injected tag** (`media/js/base/plausible/plausible.es6.js:45-49`) — Plausible requires both `src` and `data-api` to point at the custom domain, else events still POST to `plausible.io`. Derived from the script URL's origin rather than a second setting, since it can only ever be that origin + `/api/event`.
- **CONFIRM NO CSP ADJUSTMENTS ARE NEEDED** — `springfield/settings/__init__.py:138-142` already derives the allowlist host from `PLAUSIBLE_SCRIPT_URL` for `script-src` and `connect-src`. Confirmed against a live response header.
- **`PLAUSIBLE_DOMAIN` unaffected** — it only supplies `data-domain` (which site an event belongs to), independent of tracker host, so stage keeps its own value. Out of scope but worth confirming: stage's domain must exist as a site in the Plausible account behind `pa.firefox.com` or its events 404.
- **Tests** — two specs for the derived endpoint and relative-`src` resolution. Mechanical.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1530

## Testing

1. Enable Plausible locally (off unless `PLAUSIBLE_DOMAIN` is set, and the `plausible` switch falls back to `settings.DEV`, which `docker/envfiles/local.env` pins to `False`):

   ```yaml
   # /tmp/plausible.yml
   services:
     app:
       environment:
         DEV: "True"
         PLAUSIBLE_DOMAIN: "firefox.com"
   ```
   ```
   make run DC="docker compose -f docker-compose.yml -f /tmp/plausible.yml"
   ```
   Leave `PLAUSIBLE_SCRIPT_URL` unset so the new default is exercised.

2. Visit `http://localhost:8000/en-US/?geo=DE` (`?geo=` required — only consent countries render the block).
3. Console: `document.querySelector('script[data-domain]').outerHTML` should give
   `<script defer data-domain="firefox.com" data-api="https://pa.firefox.com/api/event" src="https://pa.firefox.com/js/script.js">`
4. Network: `pa.firefox.com/js/script.js` returns 200. CSP header lists `pa.firefox.com` under `script-src` and `connect-src`.
5. Expect **no** POST to `/api/event` — the tracker aborts on localhost. Event delivery can only be verified on a deployed environment (expect 202).
6. `npm run jasmine` (479 specs) and `pytest springfield/firefox/tests/test_helper_misc.py` (132) pass.

