### PR TITLE
Remove some whitespace in code output

### DIFF
--- a/springfield/cms/templates/cms/article_index_page.html
+++ b/springfield/cms/templates/cms/article_index_page.html
@@ -7,8 +7,8 @@
 {% extends "cms/base-flare.html" %}
 
 {% block flare_header %}
-  {% set theme = "dark" %}
-  {% include 'cms/includes/site-header.html' %}
+  {%- set theme = "dark" -%}
+  {%- include 'cms/includes/site-header.html' %}
 {% endblock %}
 
 {% block main_class %}{% endblock %}
@@ -28,13 +28,13 @@
             subheading_text="{{ page.sub_title }}"
           />
 
-          {% if featured_articles|length > 0 %}
+          {%- if featured_articles|length > 0 %}
           <include:cards-list container_width="narrow">
             {% for article in featured_articles %}
               <include:card variant="filled" align="center" expand_link="true">
                 <content:body>
                   <a class="fl-card-heading-link" href="{{ article.url }}">
-                    {% set tag = article.get_tag() %}
+                    {%- set tag = article.get_tag() -%}
                     <include:heading
                       level="h2"
                       heading_size="fl-heading-size-3"
@@ -43,30 +43,30 @@
                     />
                   </a>
                   <div class="fl-card-media fl-card-media-pictogram">
-                    {% if article.sticker %}
-                      {% set classes = image_variant_classes(article.sticker_dark_mode, article.sticker_mobile, article.sticker_dark_mode_mobile) %}
+                    {%- if article.sticker %}
+                      {%- set classes = image_variant_classes(article.sticker_dark_mode, article.sticker_mobile, article.sticker_dark_mode_mobile) -%}
                       <div class="image-variants-display">
                         {{ image(article.sticker, "width-400", class=classes.primary) }}
-                        {% if article.sticker_mobile %}
+                        {%- if article.sticker_mobile %}
                           {{ image(article.sticker_mobile, "width-400", class=classes.mobile) }}
-                        {% endif %}
-                        {% if article.sticker_dark_mode_mobile %}
+                        {%- endif %}
+                        {%- if article.sticker_dark_mode_mobile %}
                           {{ image(article.sticker_dark_mode_mobile, "width-400", class=classes.dark_mode_mobile) }}
-                        {% endif %}
-                        {% if article.sticker_dark_mode %}
+                        {%- endif %}
+                        {%- if article.sticker_dark_mode %}
                           {{ image(article.sticker_dark_mode, "width-400", class=classes.dark_mode) }}
-                        {% endif %}
+                        {%- endif %}
                       </div>
-                    {% else %}
+                    {%- else %}
                       <img src="/media/img/firefox/flare/independence-sticker.png" alt="" />
-                    {% endif %}
+                    {%- endif %}
                   </div>
                   <div class="fl-body">{{ article.description|richtext }}</div>
                 </content:body>
               </include:card>
-            {% endfor %}
+            {%- endfor %}
           </include:cards-list>
-          {% endif %}
+          {%- endif %}
         </div>
       </section>
     </div>
@@ -84,7 +84,7 @@
 
             <include:cards-list container_width="fill" cards_per_row="3">
               {% for article in list_articles %}
-                {% if page.index_card_type == "outline_card" %}
+                {%- if page.index_card_type == "outline_card" %}
                   <include:card variant="outline" expand_link="true">
                     <content:body>
                       <hgroup class="fl-card-heading-group">
@@ -100,11 +100,11 @@
                       </div>
                     </content:body>
                   </include:card>
-                {% elif page.index_card_type == "illustration_card" %}
+                {%- elif page.index_card_type == "illustration_card" %}
                   <include:card expand_link="true">
                     <content:media>
-                      {% if article.featured_image %}
-                        {% set classes = image_variant_classes(article.featured_image_dark_mode, article.featured_image_mobile, article.featured_image_dark_mode_mobile) %}
+                      {%- if article.featured_image %}
+                        {%- set classes = image_variant_classes(article.featured_image_dark_mode, article.featured_image_mobile, article.featured_image_dark_mode_mobile) -%}
                         <div class="image-variants-display">
                           {{ srcset_image(
                               article.featured_image,
@@ -114,7 +114,7 @@
                               loading="lazy",
                               class=classes.primary,
                           ) }}
-                          {% if article.featured_image_mobile %}
+                          {%- if article.featured_image_mobile %}
                             {{ srcset_image(
                                 article.featured_image_mobile,
                                 "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}",
@@ -123,8 +123,8 @@
                                 loading="lazy",
                                 class=classes.mobile,
                             ) }}
-                          {% endif %}
-                          {% if article.featured_image_dark_mode_mobile %}
+                          {%- endif %}
+                          {%- if article.featured_image_dark_mode_mobile %}
                             {{ srcset_image(
                                 article.featured_image_dark_mode_mobile,
                                 "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}",
@@ -133,8 +133,8 @@
                                 loading="lazy",
                                 class=classes.dark_mode_mobile,
                             ) }}
-                          {% endif %}
-                          {% if article.featured_image_dark_mode %}
+                          {%- endif %}
+                          {%- if article.featured_image_dark_mode %}
                             {{ srcset_image(
                                 article.featured_image_dark_mode,
                                 "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}",
@@ -143,15 +143,15 @@
                                 loading="lazy",
                                 class=classes.dark_mode,
                             ) }}
-                          {% endif %}
+                          {%- endif %}
                         </div>
-                      {% else %}
+                      {%- else %}
                         <img src="/media/img/firefox/flare/card-placeholder.png" alt="" />
-                      {% endif %}
+                      {%- endif %}
                     </content:media>
                     <content:body>
-                      {% set tag = article.get_tag() %}
-                      {% if tag %}<p class="fl-superheading">{{ tag.name }}</p>{% endif %}
+                      {%- set tag = article.get_tag() -%}
+                      {%- if tag %}<p class="fl-superheading">{{ tag.name }}</p>{% endif %}
                       <h3 class="fl-heading fl-heading-size-3">
                         <a href="{{ article.url }}" class="fl-card-heading-link fl-link-expand">
                           {{ article.index_page_heading or article.title }}
@@ -160,33 +160,33 @@
                       <div class="fl-body">{{ article.description|richtext }}</div>
                     </content:body>
                   </include:card>
-                {% else %}
+                {%- else %}
                   {# pictogram_card (default) #}
                   <include:card expand_link="true">
-                    {% if article.sticker %}
+                    {%- if article.sticker %}
                       <content:media>
                         <div class="fl-card-media fl-card-media-pictogram">
-                          {% set classes = image_variant_classes(article.sticker_dark_mode, article.sticker_mobile, article.sticker_dark_mode_mobile) %}
+                          {%- set classes = image_variant_classes(article.sticker_dark_mode, article.sticker_mobile, article.sticker_dark_mode_mobile) -%}
                           <div class="image-variants-display">
                             {{ image(article.sticker, "width-400", class=classes.primary) }}
-                            {% if article.sticker_mobile %}
+                            {%- if article.sticker_mobile %}
                               {{ image(article.sticker_mobile, "width-400", class=classes.mobile) }}
-                            {% endif %}
-                            {% if article.sticker_dark_mode_mobile %}
+                            {%- endif %}
+                            {%- if article.sticker_dark_mode_mobile %}
                               {{ image(article.sticker_dark_mode_mobile, "width-400", class=classes.dark_mode_mobile) }}
-                            {% endif %}
-                            {% if article.sticker_dark_mode %}
+                            {%- endif %}
+                            {%- if article.sticker_dark_mode %}
                               {{ image(article.sticker_dark_mode, "width-400", class=classes.dark_mode) }}
-                            {% endif %}
+                            {%- endif %}
                           </div>
                         </div>
                       </content:media>
-                    {% else %}
+                    {%- else %}
                       <img src="/media/img/logos/firefox/firefox-logo.svg" alt="" />
-                    {% endif %}
+                    {%- endif %}
                     <content:body>
-                      {% set tag = article.get_tag() %}
-                      {% if tag %}<p class="fl-superheading">{{ tag.name }}</p>{% endif %}
+                      {%- set tag = article.get_tag() -%}
+                      {%- if tag %}<p class="fl-superheading">{{ tag.name }}</p>{% endif %}
                       <h3 class="fl-heading fl-heading-size-3">
                         <a href="{{ article.url }}" class="fl-card-heading-link fl-link-expand">
                           {{ article.index_page_heading or article.title }}
@@ -195,8 +195,8 @@
                       <div class="fl-body">{{ article.description|richtext }}</div>
                     </content:body>
                   </include:card>
-                {% endif %}
-              {% endfor %}
+                {%- endif %}
+              {%- endfor %}
             </include:cards-list>
 
         </div>

--- a/springfield/cms/templates/cms/base-flare.html
+++ b/springfield/cms/templates/cms/base-flare.html
@@ -13,43 +13,43 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   data-needs-consent="{{ needs_data_consent(country_code) }}"
   data-latest-firefox="{{ latest_firefox_version }}"
   data-esr-versions="{{ esr_firefox_versions|join(' ') }}"
-  {% if settings.GTM_CONTAINER_ID %}
+  {%- if settings.GTM_CONTAINER_ID %}
   data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"
-  {% endif %}
-  {% if plausible_enabled(country_code) %}
+  {%- endif %}
+  {%- if plausible_enabled(country_code) %}
   data-plausible-domain="{{ settings.PLAUSIBLE_DOMAIN }}"
   data-plausible-src="{{ settings.PLAUSIBLE_SCRIPT_URL }}"
-  {% endif %}
-  {% if settings.STUB_ATTRIBUTION_RATE %}
+  {%- endif %}
+  {%- if settings.STUB_ATTRIBUTION_RATE %}
   data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"
-  {% endif %}
-  {% if settings.SENTRY_FRONTEND_DSN %}
+  {%- endif %}
+  {%- if settings.SENTRY_FRONTEND_DSN %}
   data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"
-  {% endif %}
-  {% block stub_attribution_overrides %}
-  {% if page and page.stub_attr_utm_campaign_mode and page.stub_attr_utm_campaign_value %}
-  {% if page.stub_attr_utm_campaign_mode == "default" %}data-stub-attribution-campaign="{{ page.stub_attr_utm_campaign_value }}"{% endif %}
-  {% if page.stub_attr_utm_campaign_mode == "override" %}data-stub-attribution-campaign-override="{{ page.stub_attr_utm_campaign_value }}"{% endif %}
-  {% if page.stub_attr_utm_campaign_mode == "force" %}data-stub-attribution-campaign-force="{{ page.stub_attr_utm_campaign_value }}"{% endif %}
-  {% endif %}
-  {% endblock %}
-  {% block marketing_attribution %}
-    {% if page is defined and page.enable_marketing_attribution is defined %}data-promoted-page="{{ page.enable_marketing_attribution }}"{% endif %}
-  {% endblock marketing_attribution %}
+  {%- endif %}
+  {%- block stub_attribution_overrides %}
+  {%- if page and page.stub_attr_utm_campaign_mode and page.stub_attr_utm_campaign_value %}
+  {%- if page.stub_attr_utm_campaign_mode == "default" %} data-stub-attribution-campaign="{{ page.stub_attr_utm_campaign_value }}"{% endif %}
+  {%- if page.stub_attr_utm_campaign_mode == "override" %} data-stub-attribution-campaign-override="{{ page.stub_attr_utm_campaign_value }}"{% endif %}
+  {%- if page.stub_attr_utm_campaign_mode == "force" %} data-stub-attribution-campaign-force="{{ page.stub_attr_utm_campaign_value }}"{% endif %}
+  {%- endif %}
+  {%- endblock %}
+  {%- block marketing_attribution %}
+    {%- if page is defined and page.enable_marketing_attribution is defined %} data-promoted-page="{{ page.enable_marketing_attribution }}"{% endif %}
+  {%- endblock marketing_attribution %}
   {% block html_attrs %}{% endblock %}
 >
 
   <head>
     <meta charset="utf-8">
-     {% include 'includes/transcend-consent.html' %}
+     {%- include 'includes/transcend-consent.html' %}
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% block extra_meta %}{% endblock %}
+    {%- block extra_meta %}{% endblock %}
 
-    {% block shared_meta %}
+    {%- block shared_meta %}
     <title>{% filter striptags %}{% block page_title_full %}{% block page_title_prefix %}{% endblock %}{% block page_title %}{{ (page.og_title or page.title) if page is defined and page.title is defined else 'Firefox' }}{% endblock %}{% endblock page_title_full %}{% block page_title_suffix %} — Firefox.com{% endblock %}{% endfilter %}</title>
-    {% set page_desc_content %}{% block page_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset %}
-    {% set page_desc_content = page_desc_content|striptags|trim %}
+    {%- set page_desc_content %}{% block page_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset %}
+    {%- set page_desc_content = page_desc_content|striptags|trim %}
     {%- if page_desc_content %}
     <meta name="description" content="{{ page_desc_content }}">
     {%- endif %}
@@ -61,8 +61,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <meta property="og:image:width" content="{% block page_image_width %}{% if page and page.og_image %}{% set img = image(page.og_image, "width-1200") %}{{ img.width }}{% else %}1200{% endif %}{% endblock %}">
     <meta property="og:image:height" content="{% block page_image_height %}{% if page and page.og_image %}{% set img = image(page.og_image, "width-1200") %}{{ img.height }}{% else %}630{% endif %}{% endblock %}">
     <meta property="og:title" content="{% filter striptags %}{% block page_og_title %}{{ (page.og_title or page.title) if page is defined and page.title is defined else 'Firefox'  }}{% endblock %}{% endfilter %}">
-    {% set page_og_desc_content %}{% block page_og_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset %}
-    {% set page_og_desc_content = page_og_desc_content|striptags|trim %}
+    {%- set page_og_desc_content %}{% block page_og_desc %}{{ page.og_description if page is defined and page.og_description is defined }}{% endblock %}{% endset %}
+    {%- set page_og_desc_content = page_og_desc_content|striptags|trim %}
     {%- if page_og_desc_content %}
     <meta property="og:description" content="{{ page_og_desc_content }}">
     {%- endif %}
@@ -80,26 +80,26 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <link rel="icon" type="image/png" sizes="196x196" href="{% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}">
     <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}">
     <link rel="me" href="https://mastodon.social/@FirefoxOfficial">
-    {% block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
-    {% endblock shared_meta %}
+    {%- block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
+    {%- endblock shared_meta %}
 
-    {% block structured_data %}
-      {% if page is defined %}
-        {% set breadcrumb_ancestors = page.get_breadcrumb_ancestors() %}
-        {% if breadcrumb_ancestors %}
+    {%- block structured_data %}
+      {%- if page is defined %}
+        {%- set breadcrumb_ancestors = page.get_breadcrumb_ancestors() %}
+        {%- if breadcrumb_ancestors %}
         <script type="application/ld+json">
         {
           "@context": "https://schema.org",
           "@type": "BreadcrumbList",
           "itemListElement": [
-            {% for ancestor in breadcrumb_ancestors %}
+            {%- for ancestor in breadcrumb_ancestors %}
             {
               "@type": "ListItem",
               "position": {{ loop.index }},
               "name": {{ ancestor.title|tojson }},
               "item": {{ ancestor.full_url|tojson }}
             },
-            {% endfor %}
+            {%- endfor %}
             {
               "@type": "ListItem",
               "position": {{ breadcrumb_ancestors|length + 1 }},
@@ -108,85 +108,85 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           ]
         }
         </script>
-        {% endif %}
-      {% endif %}
-    {% endblock %}
+        {%- endif %}
+      {%- endif %}
+    {%- endblock %}
 
-    {% block site_css %}
-    {% if settings.FLARECSS_LEGACY_MODE %}
+    {%- block site_css %}
+    {%- if settings.FLARECSS_LEGACY_MODE %}
     {{ css_bundle('flare_base') }}
-    {% else %}
+    {%- else %}
     {{ css_bundle('flare_base', target_old_ie=True) }}
     {{ css_bundle('flare') }}
-    {% endif %}
-    {% endblock %}
+    {%- endif %}
+    {%- endblock %}
 
-    {% block page_css %}
-      {% if page is defined and page.enable_marketing_attribution %}
+    {%- block page_css %}
+      {%- if page is defined and page.enable_marketing_attribution %}
         {{ css_bundle('firefox_marketing_opt_out') }}
-      {% endif %}
-      {% if page is defined and page.body_class %}
+      {%- endif %}
+      {%- if page is defined and page.body_class %}
         {{ css_bundle(page.body_class) }}
-      {% endif %}
-      {% if page is defined and page.theme %}
+      {%- endif %}
+      {%- if page is defined and page.theme %}
         {{ css_bundle("flare-theme-" ~ page.theme) }}
-      {% endif %}
-    {% endblock %}
+      {%- endif %}
+    {%- endblock %}
 
     {# site bundle must load in head before analytics #}
     {{ js_bundle('site') }}
-    {% block experiments %}{% endblock %}
-    {% block google_analytics %}
-    {% if settings.GTM_CONTAINER_ID %}
+    {%- block experiments %}{% endblock %}
+    {%- block google_analytics %}
+    {%- if settings.GTM_CONTAINER_ID %}
     {{ js_bundle('gtm-snippet') }}
-    {% endif %}
-    {% endblock %}
-    {% block plausible %}
-    {% if plausible_enabled(country_code) %}
+    {%- endif %}
+    {%- endblock %}
+    {%- block plausible %}
+    {%- if plausible_enabled(country_code) %}
     {{ js_bundle('plausible') }}
-    {% endif %}
-    {% endblock %}
+    {%- endif %}
+    {%- endblock %}
   </head>
 
   <body
-    {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}
+    {%- if self.body_id() %} id="{% block body_id %}{% endblock %}" {%- endif %}
     class="
       html-{{ DIR }}
-      {% block body_class %}{% if page and page.body_class %}{{ page.body_class }}{% endif %}{% endblock %}
-      {% if page and page.theme %}fl-theme-{{ page.theme }}{% endif %}
+      {% block body_class %}{% if page and page.body_class %} {{ page.body_class }}{% endif %}{% endblock %}
+      {% if page and page.theme %} fl-theme-{{ page.theme }}{% endif -%}
     "
-    {% block body_attrs %}{% endblock %}
+    {% block body_attrs %}{% endblock -%}
   >
     {{ wagtailuserbar() }}
 
-    {% block pencil_banners %}
-      {% if page is defined and page.pencil_banners is defined %}
-        {% for value in page.pencil_banners %}
-          {% include "cms/snippets/pencil-banner.html" %}
-        {% endfor %}
-      {% endif %}
-    {% endblock %}
+    {%- block pencil_banners %}
+      {%- if page is defined and page.pencil_banners is defined %}
+        {%- for value in page.pencil_banners %}
+          {%- include "cms/snippets/pencil-banner.html" %}
+        {%- endfor %}
+      {%- endif %}
+    {%- endblock %}
 
-    {% block flare_header %}
-      {% include 'cms/includes/site-header.html' %}
-    {% endblock %}
+    {%- block flare_header %}
+      {%- include 'cms/includes/site-header.html' %}
+    {%- endblock %}
 
-    {% block sub_navigation %}
-    {% endblock %}
+    {%- block sub_navigation %}
+    {%- endblock %}
 
     <main class="{% block main_class %}fl26-content{% endblock %}"{% block main_attrs %}{% endblock %}>
-    {% block content %}
+    {%- block content %}
       <div class="fl26-content-inner">
         <h1>{{ page.title if page is defined and page.title is defined else 'Firefox' }}</h1>
       </div>
-    {% endblock %}
+    {%- endblock %}
 
-    {% block pre_footer %}
+    {%- block pre_footer %}
 
-      {% set pre_footer_cta = get_pre_footer_cta_snippet() %}
-      {% if pre_footer_cta %}
-        {% set analytics_text = pre_footer_cta.label %}
-        {% set analytics_position = "pre-footer-cta" %}
+      {%- set pre_footer_cta = get_pre_footer_cta_snippet() %}
+      {%- if pre_footer_cta %}
+        {%- set analytics_text = pre_footer_cta.label %}
+        {%- set analytics_position = "pre-footer-cta" %}
           <include:conditional-display firefox_condition="not-firefox">
           <include:pre-footer-cta
             label="{{ pre_footer_cta.label }}"
@@ -196,13 +196,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             analytics_id="{{ pre_footer_cta.analytics_id }}"
           />
           </include:conditional-display>
-      {% endif %}
+      {%- endif %}
 
-      {% set pre_footer_cta_form = get_pre_footer_cta_form_snippet() %}
-      {% if pre_footer_cta_form %}
-        {% set analytics_text = pre_footer_cta_form.heading|richtext|remove_tags %}
-        {% set analytics_position = "pre-footer-cta-form" %}
-        {% set analytics_id = pre_footer_cta_form.analytics_id %}
+      {%- set pre_footer_cta_form = get_pre_footer_cta_form_snippet() %}
+      {%- if pre_footer_cta_form %}
+        {%- set analytics_text = pre_footer_cta_form.heading|richtext|remove_tags %}
+        {%- set analytics_position = "pre-footer-cta-form" %}
+        {%- set analytics_id = pre_footer_cta_form.analytics_id %}
           <include:conditional-display firefox_condition="is-firefox">
             <include:newsletter-form theme="dark" illustration="{{ page.pre_footer_image|default('kit', true) }}">
               <include:heading
@@ -213,69 +213,69 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
               />
               </include:newsletter-form>
           </include:conditional-display>
-      {% endif %}
+      {%- endif %}
 
-    {% endblock pre_footer %}
+    {%- endblock pre_footer %}
     </main>
 
-    {% block flare_footer %}
+    {%- block flare_footer %}
       <include:flare-footer />
-    {% endblock %}
+    {%- endblock %}
 
-    {% block consent_banner %}
-      {% include 'includes/banners/consent-banner-flare.html' %}
-    {% endblock %}
+    {%- block consent_banner %}
+      {%- include 'includes/banners/consent-banner-flare.html' %}
+    {%- endblock %}
 
-    {% block qr_code_snippet %}
-      {% if page and page.show_floating_qr_code_snippet and floating_qr_snippet %}
-        {% set value = floating_qr_snippet %}
-        {% include "cms/snippets/qr-code-floating-snippet.html" %}
-      {% elif page and page.show_qr_code_snippet %}
-        {% set qr_code_snippet = get_qr_code_snippet() %}
-        {% if qr_code_snippet %}
-          {% set value = qr_code_snippet %}
-          {% include "cms/snippets/qr-code-snippet.html" %}
-        {% endif %}
-      {% endif %}
-    {% endblock %}
+    {%- block qr_code_snippet %}
+      {%- if page and page.show_floating_qr_code_snippet and floating_qr_snippet %}
+        {%- set value = floating_qr_snippet %}
+        {%- include "cms/snippets/qr-code-floating-snippet.html" %}
+      {%- elif page and page.show_qr_code_snippet %}
+        {%- set qr_code_snippet = get_qr_code_snippet() %}
+        {%- if qr_code_snippet %}
+          {%- set value = qr_code_snippet %}
+          {%- include "cms/snippets/qr-code-snippet.html" %}
+        {%- endif %}
+      {%- endif %}
+    {%- endblock %}
 
 
     {# Issue 8444 #}
-    {% block sentry_client %}
-      {% if settings.SENTRY_FRONTEND_DSN and switch('sentry-js') %}
+    {%- block sentry_client %}
+      {%- if settings.SENTRY_FRONTEND_DSN and switch('sentry-js') %}
         <!--[if !IE]><!-->
           {# Sentry only runs on evergreen browsers so we exclude it from IE. #}
           {{ js_bundle('sentry') }}
         <!--<![endif]-->
-      {% endif %}
-    {% endblock %}
+      {%- endif %}
+    {%- endblock %}
 
-    {% block site_js %}
+    {%- block site_js %}
     {{ js_bundle('lib') }}
     {{ js_bundle('data') }}
     {{ js_bundle('firefox-cms-flare') }}
     {{ js_bundle('ui-tour-buttons') }}
     {{ js_bundle('flare-navigation') }}
     {{ js_bundle('flare-lang-switcher') }}
-    {% if switch('easter-egg-logo') %}
+    {%- if switch('easter-egg-logo') %}
     {{ js_bundle('easter-egg-logo') }}
-    {% endif %}
-    {% endblock %}
+    {%- endif %}
+    {%- endblock %}
 
-    {% block consent_banner_js %}
+    {%- block consent_banner_js %}
     <!--[if IE 9]><!-->
       {# Consent banner is shown to all evergreen browsers plus IE9 and above #}
       {{ js_bundle('consent-banner') }}
     <!--<![endif]-->
-    {% endblock %}
+    {%- endblock %}
 
-    {% block stub_attribution %}
-      {% if settings.STUB_ATTRIBUTION_RATE %}
+    {%- block stub_attribution %}
+      {%- if settings.STUB_ATTRIBUTION_RATE %}
         <!--[if IE 9]><!-->
           {# Stub attribution is run on all evergreen browsers plus IE9 and above. #}
           {{ js_bundle('download-attribution-init-essential') }}
         <!--<![endif]-->
-      {% endif %}
+      {%- endif %}
 
       {# Download as default needs to come after stub attribution #}
       {{ js_bundle('download_as_default-v2') }}
@@ -285,17 +285,17 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
          campaign data attrs or URL utm_campaign; no-op otherwise. #}
       {{ js_bundle('mobile-attribution') }}
 
-      {% if page is defined and page.enable_marketing_attribution %}
+      {%- if page is defined and page.enable_marketing_attribution %}
         <!--[if IE 9]><!-->
-          {# Marketing opt-out runs on all evergreen browsers plus IE9 and above. #}
+          {#- Marketing opt-out runs on all evergreen browsers plus IE9 and above. -#}
           {{ js_bundle('firefox_marketing_opt_out') }}
         <!--<![endif]-->
-      {% endif %}
-    {% endblock %}
+      {%- endif %}
+    {%- endblock %}
 
-    {% block js %}
+    {%- block js %}
       {# Page specific JavaScript #}
-    {% endblock js %}
+    {%- endblock js %}
   </body>
 
 </html>

--- a/springfield/cms/templates/cms/blocks/card.html
+++ b/springfield/cms/templates/cms/blocks/card.html
@@ -4,10 +4,10 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set block_level = block_level or 1 %}
+{%- set block_level = block_level or 1 -%}
 
-{% set first_heading = value.content.first_block_by_name("heading") %}
-{% set block_text = first_heading.value.heading_text | richtext | remove_tags if first_heading else "" %}
+{%- set first_heading = value.content.first_block_by_name("heading") -%}
+{%- set block_text = first_heading.value.heading_text | richtext | remove_tags if first_heading else "" -%}
 
 <include:conditional-display
   condition_settings="{{ value.settings.show_to }}">
@@ -15,20 +15,20 @@
     variant="{{ value.settings.variant }}"
     align="{{ value.settings.align or 'start' }}"
     expand_link="{{ value.settings.expand_link }}">
-    {% if value.media %}
-      <content:media>{% include_block value.media %}</content:media>
-    {% endif %}
+    {%- if value.media %}
+      <content:media>{%- include_block value.media %}</content:media>
+    {%- endif %}
     <content:body>
-      {% for content_block in value.content %}
-        {% set block_position = block_position ~ ".item-" ~ loop.index ~ "-" ~ content_block.block_type %}
-        {% if content_block.block_type == "heading" %}
-          {% with heading_size = "fl-heading-size-3" %}
-            {% include_block content_block %}
-          {% endwith %}
-        {% else %}
-          {% include_block content_block %}
-        {% endif %}
-      {% endfor %}
+      {%- for content_block in value.content %}
+        {%- set block_position = block_position ~ ".item-" ~ loop.index ~ "-" ~ content_block.block_type %}
+        {%- if content_block.block_type == "heading" %}
+          {%- with heading_size = "fl-heading-size-3" %}
+            {%- include_block content_block %}
+          {%- endwith %}
+        {%- else %}
+          {%- include_block content_block %}
+        {%- endif %}
+      {%- endfor %}
     </content:body>
   </include:card>
 </include:conditional-display>

--- a/springfield/cms/templates/cms/blocks/cards-list.html
+++ b/springfield/cms/templates/cms/blocks/cards-list.html
@@ -4,21 +4,21 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set block_level = block_level or 1 %}
-{% set container_width = value.settings.container_width if value.settings is defined else '' %}
-{% set cards_per_row = value.settings.cards_per_row if value.settings is defined else '' %}
-{% set two_wide_xs = value.settings.two_wide_xs if value.settings is defined else False %}
-{% set is_scroll = container_width == 'scroll' %}
+{%- set block_level = block_level or 1 -%}
+{%- set container_width = value.settings.container_width if value.settings is defined else '' -%}
+{%- set cards_per_row = value.settings.cards_per_row if value.settings is defined else '' -%}
+{%- set two_wide_xs = value.settings.two_wide_xs if value.settings is defined else False -%}
+{%- set is_scroll = container_width == 'scroll' -%}
 
 <include:cards-list
   container_width="{{ container_width }}"
   cards_per_row="{{ cards_per_row }}"
   two_wide_xs="{{ two_wide_xs }}">
-  {% for card in value.cards %}
-    {% set card_index = loop.index %}
-    {% set block_position = block_position ~ ".card-" ~ card_index %}
-    {% if is_scroll %}<div class="fl-card-grid-scroll-item">{% endif %}
-    {% include_block card %}
-    {% if is_scroll %}</div>{% endif %}
-  {% endfor %}
+  {%- for card in value.cards %}
+    {%- set card_index = loop.index -%}
+    {%- set block_position = block_position ~ ".card-" ~ card_index -%}
+    {%- if is_scroll %}<div class="fl-card-grid-scroll-item">{% endif %}
+    {%- include_block card %}
+    {%- if is_scroll %}</div>{% endif %}
+  {%- endfor %}
 </include:cards-list>

--- a/springfield/cms/templates/cms/blocks/download-support.html
+++ b/springfield/cms/templates/cms/blocks/download-support.html
@@ -6,10 +6,10 @@
 
 {% from "firefox/includes/macros.html" import firefox_download_desktop_button_linux with context %}
 
-{% set source = utm_parameters.get("utm_source", "www.firefox.com") %}
-{% set medium = utm_parameters.get("utm_medium", "referral") %}
-{% set campaign = utm_parameters.get("utm_campaign", "firefox-download-thanks") %}
-{% set params = '?utm_source=' ~ source ~ '&utm_medium=' ~ medium ~ '&utm_campaign=' ~ campaign %}
+{%- set source = utm_parameters.get("utm_source", "www.firefox.com") -%}
+{%- set medium = utm_parameters.get("utm_medium", "referral") -%}
+{%- set campaign = utm_parameters.get("utm_campaign", "firefox-download-thanks") -%}
+{%- set params = '?utm_source=' ~ source ~ '&utm_medium=' ~ medium ~ '&utm_campaign=' ~ campaign -%}
 
 <section class="fl-section">
   <div class="fl-section-container">
@@ -41,22 +41,22 @@
       <div class="fl-support-install">
         <include:conditional-display platform_conditions="{{ ['osx'] }}">
           <p>
-            {% set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) %}
+            {%- set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) -%}
             {{ ftl('firefox-desktop-download-get-help', attrs=support_mac_attrs) }}
           </p>
         </include:conditional-display>
         <include:conditional-display platform_conditions="{{ ['windows'] }}">
           <p>
-            {% set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-install-firefox-windows%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) %}
+            {%- set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-install-firefox-windows%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) -%}
             {{ ftl('firefox-desktop-download-get-help', attrs=support_windows_attrs) }}
           </p>
         </include:conditional-display>
         <include:conditional-display platform_conditions="{{ ['linux'] }}">
           {{ firefox_download_desktop_button_linux(flare_styles=true) }}
         </include:conditional-display>
-        {% set other_platforms %}
+        {%- set other_platforms -%}
           <p>
-            {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) %}
+            {%- set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-text="Get help with your installation"'|safe|format(params) -%}
             {{ ftl('firefox-desktop-download-get-help', attrs=support_else_attrs) }}
           </p>
         {% endset %}
@@ -71,9 +71,9 @@
         </include:conditional-display>
 
         {# Edge-case platform support messaging #}
-        {% set unsupported_message %}
+        {%- set unsupported_message -%}
           <p>
-            {% set unsupported_href = firefox_url('desktop', 'all') %}
+            {%- set unsupported_href = firefox_url('desktop', 'all') -%}
             {{ ftl('firefox-desktop-download-your-system-may-not', url=unsupported_href)}}
           </p>
         {% endset %}

--- a/springfield/cms/templates/cms/blocks/heading.html
+++ b/springfield/cms/templates/cms/blocks/heading.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set heading_size = heading_size or ('fl-heading-size-' ~ block_level if block_level else 'fl-heading-size-2') %}
+{%- set heading_size = heading_size or ('fl-heading-size-' ~ block_level if block_level else 'fl-heading-size-2') -%}
 
 <include:heading
   level="{{ 'h' ~ block_level if block_level else 'h2' }}"

--- a/springfield/cms/templates/cms/blocks/image-variants.html
+++ b/springfield/cms/templates/cms/blocks/image-variants.html
@@ -4,14 +4,14 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set sizes = sizes or "(min-width: 1200px) 680px, (min-width: 600px) 50vw, 100vw" %}
-{% set widths = widths or "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}" %}
-{% set break_at = break_at or "sm" %}
+{%- set sizes = sizes or "(min-width: 1200px) 680px, (min-width: 600px) 50vw, 100vw" -%}
+{%- set widths = widths or "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}" -%}
+{%- set break_at = break_at or "sm" -%}
 
-{% set classes = image_variant_classes(value.settings.dark_mode_image, value.settings.mobile_image, value.settings.dark_mode_mobile_image, break_at=break_at) %}
+{%- set classes = image_variant_classes(value.settings.dark_mode_image, value.settings.mobile_image, value.settings.dark_mode_mobile_image, break_at=break_at) -%}
 
 <div class="image-variants-display">
-{# Default/desktop light mode image #}
+{#- Default/desktop light mode image -#}
 {{ srcset_image(
     value.image,
     widths,
@@ -22,8 +22,8 @@
     class=classes.primary,
 ) }}
 
-{# Light mode mobile image #}
-{% if value.settings.mobile_image %}
+{#- Light mode mobile image -#}
+{%- if value.settings.mobile_image %}
   {{ srcset_image(
       value.settings.mobile_image,
       widths,
@@ -33,10 +33,10 @@
       loading="lazy",
       class=classes.mobile,
   ) }}
-{% endif %}
+{%- endif %}
 
-{# Dark mode mobile image #}
-{% if value.settings.dark_mode_mobile_image %}
+{#- Dark mode mobile image -#}
+{%- if value.settings.dark_mode_mobile_image %}
   {{ srcset_image(
       value.settings.dark_mode_mobile_image,
       widths,
@@ -46,10 +46,10 @@
       loading="lazy",
       class=classes.dark_mode_mobile,
   ) }}
-{% endif %}
+{%- endif %}
 
-{# Dark mode desktop image #}
-{% if value.settings.dark_mode_image %}
+{#- Dark mode desktop image -#}
+{%- if value.settings.dark_mode_image %}
   {{ srcset_image(
       value.settings.dark_mode_image,
       widths,
@@ -59,5 +59,5 @@
       loading="lazy",
       class=classes.dark_mode,
   ) }}
-{% endif %}
+{%- endif %}
 </div>

--- a/springfield/cms/templates/cms/blocks/related-article-card.html
+++ b/springfield/cms/templates/cms/blocks/related-article-card.html
@@ -7,28 +7,28 @@
 <include:card expand_link="true">
   <content:body>
     <div class="fl-card-media fl-card-media-pictogram">
-      {% set img = value.get_pictogram() %}
-      {% if img %}
+      {%- set img = value.get_pictogram() -%}
+      {%- if img %}
         {{ image(img, "width-400") }}
-      {% else %}
+      {%- else %}
         <img src="/media/img/logos/firefox/firefox-logo.svg" alt="" />
-      {% endif %}
+      {%- endif %}
     </div>
-    {% set superheading = value.get_superheading() %}
+    {%- set superheading = value.get_superheading() -%}
     <hgroup class="fl-heading-group">
-      {% if superheading %}
+      {%- if superheading %}
         <p class="fl-superheading">{{ superheading }}</p>
-      {% endif %}
+      {%- endif %}
       <h3 class="fl-heading">
         <a href="{{ value.get_link_url() }}">{{ value.get_title() }}</a>
       </h3>
     </hgroup>
-    {% if value.tags %}
+    {%- if value.tags %}
       <div>
         {% for tag in value.tags %}
-          {% include_block tag %}
-        {% endfor %}
+          {%- include_block tag %}
+        {%- endfor %}
       </div>
-    {% endif %}
+    {%- endif %}
   </content:body>
 </include:card>

--- a/springfield/cms/templates/cms/blocks/sections/home-kit-banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/home-kit-banner.html
@@ -4,8 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set block_position = block_position or "banner" %}
-{% set block_text = value.heading.heading_text|richtext|remove_tags %}
+{%- set block_position = block_position or "banner" -%}
+{%- set block_text = value.heading.heading_text|richtext|remove_tags -%}
 
 <include:conditional-display
   condition_settings="{{ value.settings.show_to }}">
@@ -15,7 +15,7 @@
     anchor_id="{{ value.settings.anchor_id }}">
 
     <content:heading>
-      {% set heading_level = 'h' ~ block_level if block_level else 'h2' %}
+      {%- set heading_level = 'h' ~ block_level if block_level else 'h2' -%}
       <include:heading
         level="{{ heading_level }}"
         heading_size="fl-heading-size-2"
@@ -31,7 +31,7 @@
       <content:content>
         <div class="fl-buttons">
           {% for button in value.buttons %}
-            {% set block_position = block_position ~ ".button-" ~ loop.index %}
+            {%- set block_position = block_position ~ ".button-" ~ loop.index -%}
             {% include_block button %}
           {% endfor %}
         </div>

--- a/springfield/cms/templates/cms/blocks/sections/kit-banner.html
+++ b/springfield/cms/templates/cms/blocks/sections/kit-banner.html
@@ -4,8 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set block_position = block_position or "banner" %}
-{% set block_text = value.heading.heading_text|richtext|remove_tags %}
+{%- set block_position = block_position or "banner" -%}
+{%- set block_text = value.heading.heading_text|richtext|remove_tags -%}
 
 <include:conditional-display
   condition_settings="{{ value.settings.show_to }}">

--- a/springfield/cms/templates/cms/blocks/sections/section.html
+++ b/springfield/cms/templates/cms/blocks/sections/section.html
@@ -5,31 +5,31 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set block_text = value.heading.heading_text|richtext|remove_tags %}
+{%- set block_text = value.heading.heading_text|richtext|remove_tags -%}
 
 <include:conditional-display
   condition_settings="{{ value.settings.show_to }}">
   <include:section anchor_id="{{ value.settings.anchor_id }}">
     <content:heading>
-      {% with alignment_class="text-center" %}
-        {% include_block value.heading %}
-      {% endwith %}
+      {%- with alignment_class="text-center" %}
+        {%- include_block value.heading %}
+      {%- endwith %}
     </content:heading>
     <content:content>
-      {% for block in value.content %}
-        {% set block_position = block_position ~ ".item-" ~ loop.index ~ "-" ~ block.block_type %}
-        {% with block_level = block_level + 1 if block_level else 2 %}
-          {% include_block block %}
-        {% endwith %}
-      {% endfor %}
+      {%- for block in value.content %}
+        {%- set block_position = block_position ~ ".item-" ~ loop.index ~ "-" ~ block.block_type -%}
+        {%- with block_level = block_level + 1 if block_level else 2 %}
+          {%- include_block block %}
+        {%- endwith %}
+      {%- endfor %}
     </content:content>
-    {% if value.cta %}
+    {%- if value.cta %}
       <content:cta>
-        {% for cta in value.cta %}
-          {% set block_position = block_position ~ ".cta-" ~ loop.index %}
-          {% include_block cta %}
-        {% endfor %}
+        {%- for cta in value.cta %}
+          {%- set block_position = block_position ~ ".cta-" ~ loop.index -%}
+          {%- include_block cta %}
+        {%- endfor %}
       </content:cta>
-    {% endif %}
+    {%- endif %}
   </include:section>
 </include:conditional-display>

--- a/springfield/cms/templates/cms/home_page.html
+++ b/springfield/cms/templates/cms/home_page.html
@@ -92,7 +92,7 @@
 {% block body_class %}fl-home-body{% endblock %}
 
 {% block flare_header %}
-  {% set theme = "dark" %}
+  {%- set theme = "dark" -%}
   {% include 'cms/includes/site-header.html' %}
 {% endblock %}
 
@@ -102,35 +102,35 @@
 <div class="fl-page">
   <div class="fl-main">
     <div class="fl-split-page-upper">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 1 %}
-      {% for block in page.upper_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "upper-block-" ~ block_index + "-" + block_type %}
+      {%- set ns = namespace(headings=0) -%}
+      {%- set block_level = 1 -%}
+      {%- for block in page.upper_content %}
+        {%- set block_index = loop.index -%}
+        {%- set block_type = block.block_type -%}
+        {%- set block_position = "upper-block-" ~ block_index + "-" + block_type -%}
 
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
+        {%- if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
+          {%- set block_level = 1 if ns.headings == 0 else 2 -%}
+          {%- set ns.headings = ns.headings + 1 -%}
+        {%- endif %}
 
-        {% include_block block %}
-      {% endfor %}
+        {%- include_block block %}
+      {%- endfor %}
     </div>
 
     <div class="fl-split-page-lower has-gradient-top">
-      {% for block in page.lower_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "lower-block-" ~ block_index + "-" + block_type %}
+      {%- for block in page.lower_content %}
+        {%- set block_index = loop.index -%}
+        {%- set block_type = block.block_type -%}
+        {%- set block_position = "lower-block-" ~ block_index + "-" + block_type -%}
 
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
+        {%- if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
+          {%- set block_level = 1 if ns.headings == 0 else 2 -%}
+          {%- set ns.headings = ns.headings + 1 -%}
+        {%- endif %}
 
-        {% include_block block %}
-      {% endfor %}
+        {%- include_block block %}
+      {%- endfor %}
     </div>
   </div>
 </div>

--- a/springfield/cms/templates/cms/includes/flare-menus/browser.html
+++ b/springfield/cms/templates/cms/includes/flare-menus/browser.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set params='?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=browser' %}
+{%- set params='?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=browser' -%}
 
 <include:nav-folder
   label="{{ ftl('navigation-browser') }}"
@@ -32,7 +32,7 @@
       />
     </ul>
 
-    {% if LANG.startswith('en-') or LANG == 'fr' or LANG == 'de' %}
+    {%- if LANG.startswith('en-') or LANG == 'fr' or LANG == 'de' %}
       <span class="fl-nav-separator"></span>
       <ul>
         <include:nav-link

--- a/springfield/cms/templates/cms/includes/lang-switcher.html
+++ b/springfield/cms/templates/cms/includes/lang-switcher.html
@@ -12,11 +12,11 @@
     <label for="page-language-select">{{ ftl('footer-language') }}</label>
     <div class="fl-language-switcher-select-wrapper fl-icon-chevron-down">
       <select id="page-language-select" class="fl-language-switcher-select" name="lang" dir="ltr" data-testid="footer-language-select">
-        {% for code, label in available_languages|dictsort -%}
+        {%- for code, label in available_languages|dictsort -%}
           {# Don't escape the label as it may include entity references
           # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
           <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
-        {% endfor %}
+        {%- endfor %}
       </select>
     </div>
     <button type="submit">{{ ftl('footer-go') }}</button>

--- a/springfield/cms/templates/cms/includes/nav-cta.html
+++ b/springfield/cms/templates/cms/includes/nav-cta.html
@@ -4,9 +4,9 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if not custom_nav_cta %}
+{%- if not custom_nav_cta %}
 <div
-    class="nav-cta-wrap {% if hide_nav_cta %}hide-cta-on-desktop{% endif %} {% if hide_nav_download_button %}hide-nav-download-on-desktop{% endif %}"
+    class="nav-cta-wrap{% if hide_nav_cta %} hide-cta-on-desktop{% endif %}{% if hide_nav_download_button %} hide-nav-download-on-desktop{% endif %}"
 >
   <include:download-firefox-button
     analytics_id="nav-download-firefox"
@@ -18,6 +18,6 @@
     exclude_unsupported_content="True"
   />
 </div>
-{% else %}
+{%- else %}
   {{ custom_nav_cta }}
-{% endif %}
+{%- endif %}

--- a/springfield/cms/templates/cms/includes/site-header.html
+++ b/springfield/cms/templates/cms/includes/site-header.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{#
+{#-
  Renders the site header via the flare-header component, injecting the page's
  custom navigation snippet into the nav slot when one is available and falling
  back to the default navigation otherwise.
@@ -13,41 +13,41 @@
  this partial (all read from context by the flare-header component): theme,
  no_menu, disable_sticky, no_menu_dropdowns, hide_nav_cta,
  hide_nav_download_button, custom_nav_cta.
-#}
+-#}
 
-{% set page_navigation = custom_navigation or get_default_navigation() %}
+{%- set page_navigation = custom_navigation or get_default_navigation() -%}
 
-{% if page_navigation and page_navigation.cta_button %}
-  {% set custom_nav_cta %}
-    {% set block_position = "topnav" %}
-    {% set utm_parameters = {
+{%- if page_navigation and page_navigation.cta_button %}
+  {%- set custom_nav_cta -%}
+    {%- set block_position = "topnav" -%}
+    {%- set utm_parameters = {
         "utm_source": "www.firefox.com",
         "utm_medium": "referral",
         "utm_campaign": "nav",
         "utm_content": "topnav"
-    } %}
-    {% include_block page_navigation.cta_button %}
-  {% endset %}
-{% endif %}
+    } -%}
+    {%- include_block page_navigation.cta_button %}
+  {%- endset -%}
+{%- endif -%}
 
 <include:flare-header>
-  {% if page_navigation and page_navigation.logo %}
-    {% set logo_href = page_navigation.logo_link[0].value.get_url() if page_navigation.logo_link else "/" + LANG + "/" %}
-    {% set logo_classes = image_variant_classes(page_navigation.logo_dark) %}
+  {%- if page_navigation and page_navigation.logo %}
+    {%- set logo_href = page_navigation.logo_link[0].value.get_url() if page_navigation.logo_link else "/" + LANG + "/" -%}
+    {%- set logo_classes = image_variant_classes(page_navigation.logo_dark) -%}
     <content:custom_logo>
       <a href="{{ logo_href }}" class="fl-logo-fx fl-logo-fx-custom" aria-label="Firefox">
         {{ image(page_navigation.logo, "width-400", class=logo_classes.primary) }}
-        {% if page_navigation.logo_dark %}
+        {%- if page_navigation.logo_dark %}
           {{ image(page_navigation.logo_dark, "width-400", class=logo_classes.dark_mode) }}
-        {% endif %}
+        {%- endif %}
       </a>
     </content:custom_logo>
-  {% endif %}
-  {% if page_navigation %}
+  {%- endif %}
+  {%- if page_navigation %}
     <content:nav>
-      {% with value = page_navigation %}
-        {% include 'cms/snippets/navigation-snippet.html' %}
-      {% endwith %}
+      {%- with value = page_navigation -%}
+        {%- include 'cms/snippets/navigation-snippet.html' %}
+      {%- endwith -%}
     </content:nav>
-  {% endif %}
+  {%- endif -%}
 </include:flare-header>

--- a/springfield/cms/templates/cms/smart_window_page.html
+++ b/springfield/cms/templates/cms/smart_window_page.html
@@ -13,9 +13,9 @@
 {% block main_class %}{% endblock %}
 
 {% block flare_header %}
-  {% set custom_nav_cta %}
+  {%- set custom_nav_cta -%}
     <div class="nav-cta-wrap">
-      {% set nav_smart_window %}
+      {%- set nav_smart_window -%}
           <include:uitour_button
             theme_class="{{ ui_tour_class }}"
             label="{{ page.smart_window_button_label }}"
@@ -27,7 +27,7 @@
             {% endif %}
           />
       {% endset %}
-      {% set nav_download %}
+      {%- set nav_download -%}
           <include:download-firefox-button
             analytics_id="{{ page.nav_download_button_uid }}"
             label="{{ page.download_button_label }}"
@@ -49,16 +49,16 @@
       {% endif %}
     </div>
   {% endset %}
-  {% set theme = "dark" %}
-  {% set hide_nav_cta = true %}
-  {% set disable_sticky = true %}
-  {% set no_menu_dropdowns = true %}
+  {%- set theme = "dark" -%}
+  {%- set hide_nav_cta = true -%}
+  {%- set disable_sticky = true -%}
+  {%- set no_menu_dropdowns = true -%}
   {% include 'cms/includes/site-header.html' %}
 {% endblock %}
 
 {% block content %}
 
-{% set intro_download %}
+{%- set intro_download -%}
   <include:download-firefox-button
     analytics_id="{{ page.intro_download_button_uid }}"
     label="{{ page.download_button_label }}"
@@ -70,7 +70,7 @@
   />
 {% endset %}
 
-{% set copy_to_clipboard %}
+{%- set copy_to_clipboard -%}
   <include:copy-to-clipboard-button
     theme_class="button-secondary"
     value="{{ request.build_absolute_uri() }}"
@@ -79,7 +79,7 @@
   />
 {% endset %}
 
-{% set intro_smart_window %}
+{%- set intro_smart_window -%}
     <include:uitour_button
       theme_class="{{ ui_tour_class }}"
       label="{{ page.smart_window_button_label }}"
@@ -92,7 +92,7 @@
     />
 {% endset %}
 
-{% set update_instructions %}
+{%- set update_instructions -%}
   <include:button
     link="{{ page.update_link }}"
     label="{{ page.update_button_label }}"
@@ -102,7 +102,7 @@
   />
 {% endset %}
 
-{% set form %}
+{%- set form -%}
   <form id="newsletter-form" class="fl-smart-window-form fl-newsletterform" action="{{ settings.BASKET_SUBSCRIBE_URL }}" method="post" novalidate data-testid="newsletter-form">
     <div hidden>
       <input type="checkbox" name="newsletters" value="smart-window-waitlist" checked>
@@ -209,7 +209,7 @@
           </div>
 
           {% if page.animation %}
-            {% set img = image(page.image, "width-1200") %}
+            {%- set img = image(page.image, "width-1200") -%}
             <div class="fl-smart-window-intro-featured-image">
               <include:animation
                 video_url="{{ page.animation }}"
@@ -220,7 +220,7 @@
               />
             </div>
           {% else %}
-            {% set classes = image_variant_classes(page.image_dark_mode, page.image_mobile, page.image_dark_mode_mobile) %}
+            {%- set classes = image_variant_classes(page.image_dark_mode, page.image_mobile, page.image_dark_mode_mobile) -%}
             <div class="fl-smart-window-intro-featured-image">
               <div class="image-variants-display">
                 {{ srcset_image(
@@ -272,10 +272,10 @@
 
       <div class="fl-split-page-lower no-gap">
         {% for block in page.content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = "block-" ~ block_index ~ "-" ~ block_type %}
-          {% set block_level = 2 %}
+          {%- set block_index = loop.index -%}
+          {%- set block_type = block.block_type -%}
+          {%- set block_position = "block-" ~ block_index ~ "-" ~ block_type -%}
+          {%- set block_level = 2 -%}
           {% include_block block %}
         {% endfor %}
       </div>

--- a/springfield/cms/templates/components/button.html
+++ b/springfield/cms/templates/components/button.html
@@ -4,45 +4,45 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if link %}
+{%- if link %}
 <a
   href="{{ link }}"
-{% else %}
+{%- else %}
 <button type="button"
-{% endif %}
+{%- endif %}
 
   class="fl-button {{ theme_class }} {{ size_class }} {{ extra_classes }}"
-  {% if disabled %}disabled{% endif %}
-  {% if id %}id="{{ id }}"{% endif %}
-  {% if external %}target="_blank" rel="external noopener"{% endif %}
-  {% if analytics_text %}
+  {%- if disabled %} disabled{% endif %}
+  {%- if id %} id="{{ id }}"{% endif %}
+  {%- if external %} target="_blank" rel="external noopener"{% endif %}
+  {%- if analytics_text %}
     data-cta-position="{{ analytics_position }}"
     data-cta-text="{{ analytics_text|escape }}"
     data-cta-uid="{{ analytics_id }}"
-  {% endif %}
-  {% if aria_labelledby %}aria-labelledby="{{ aria_labelledby }}"{% endif %}
-  {% if data_target_id %}data-target-id="{{ data_target_id }}"{% endif %}
+  {%- endif %}
+  {%- if aria_labelledby %} aria-labelledby="{{ aria_labelledby }}"{% endif %}
+  {%- if data_target_id %} data-target-id="{{ data_target_id }}"{% endif %}
 >
-  {% if icon_name and icon_position == "left" %}
-    {% set extra_class = "fl-icon-left" %}
+  {%- if icon_name and icon_position == "left" %}
+    {%- set extra_class = "fl-icon-left" %}
     <include:icon
       icon_name="{{ icon_name }}"
       hidden=true
       extra_class="{{ extra_class }}"
     />
-  {% endif %}
+  {%- endif %}
   {{ label }}
-  {% if icon_name and icon_position == "right" %}
-    {% set extra_class = "fl-icon-right" %}
+  {%- if icon_name and icon_position == "right" %}
+    {%- set extra_class = "fl-icon-right" %}
     <include:icon
       icon_name="{{ icon_name }}"
       hidden=true
       extra_class="{{ extra_class }}"
     />
-  {% endif %}
+  {%- endif %}
 
-{% if not link %}
+{%- if not link %}
 </button>
-{% else %}
+{%- else %}
 </a>
-{% endif %}
+{%- endif %}

--- a/springfield/cms/templates/components/buttons.html
+++ b/springfield/cms/templates/components/buttons.html
@@ -5,7 +5,7 @@
 #}
 
 <div class="fl-buttons {% if orientation == 'stacked' %}is-stacked{% else %}is-horizontal{% endif %} {% if center %}is-center{% endif %}">
-  {% for btn in buttons %}
+  {%- for btn in buttons -%}
     <div>
       <include:button
         label="{{ btn.label }}"
@@ -17,5 +17,5 @@
         icon_position="{{ btn.icon_position }}"
       />
     </div>
-  {% endfor %}
+  {%- endfor -%}
 </div>

--- a/springfield/cms/templates/components/card-gallery.html
+++ b/springfield/cms/templates/components/card-gallery.html
@@ -5,15 +5,15 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set card_heading_level = card_heading_level or "h3" %}
+{%- set card_heading_level = card_heading_level or "h3" -%}
 
 <section class="fl-section">
   <div class="fl-section-container">
     <div class="fl-card-gallery">
       <div class="fl-heading-group">
-        {% if contents.heading %}
+        {%- if contents.heading %}
           {{ contents.heading }}
-        {% endif %}
+        {%- endif %}
       </div>
 
       <div class="fl-card-gallery-grid swap-mobile-images-at-md">
@@ -40,11 +40,11 @@
         </div>
       </div>
 
-      {% if contents.cta %}
+      {%- if contents.cta %}
         <div class="fl-section-cta-wrap">
           {{ contents.cta }}
         </div>
-      {% endif %}
+      {%- endif %}
     </div>
   </div>
 </section>

--- a/springfield/cms/templates/components/card.html
+++ b/springfield/cms/templates/components/card.html
@@ -4,19 +4,19 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# props variant="" align="start" expand_link=0 #}
+{#- props variant="" align="start" expand_link=0 #}
 
 <article
   class="
     fl-card
     fl-card-{{ align or 'start' }}
-    {% if variant %}fl-card-{{ variant }}{% endif %}
-    {% if expand_link %}fl-card-expand-link{% endif %}
-    {% if variant == 'filled' %} fl-force-light-theme{% endif %}
+    {%- if variant %} fl-card-{{ variant }}{% endif %}
+    {%- if expand_link %} fl-card-expand-link{% endif %}
+    {%- if variant == 'filled' %} fl-force-light-theme{% endif %}
   "
 >
-  {% if contents.media %}
+  {%- if contents.media %}
     <div class="fl-card-top-media">{{ contents.media }}</div>
-  {% endif %}
+  {%- endif %}
   <div class="fl-card-content">{{ contents.body }}</div>
 </article>

--- a/springfield/cms/templates/components/cards-list.html
+++ b/springfield/cms/templates/components/cards-list.html
@@ -4,18 +4,18 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# props extra_class="", scroll=0, container_width="", cards_per_row=0, two_wide_xs=0 #}
+{#- props extra_class="", scroll=0, container_width="", cards_per_row=0, two_wide_xs=0 #}
 
 <div
   class="fl-card-grid
-  {% if extra_class %} {{ extra_class }}{% endif %}
-  {% if container_width %} container-{{ container_width }}{% endif %}
-  {% if two_wide_xs %} two-col-xs{% endif %}
-  {% if cards_per_row %} cols-{{ cards_per_row }}-md{% endif %}
-  {% if container_width == 'scroll' %} fl-card-grid-scroll{% endif %}"
-  {% if container_width == 'scroll' %}data-js="fl-card-grid-scroll"{% endif %}
+  {%- if extra_class %} {{ extra_class }}{% endif %}
+  {%- if container_width %} container-{{ container_width }}{% endif %}
+  {%- if two_wide_xs %} two-col-xs{% endif %}
+  {%- if cards_per_row %} cols-{{ cards_per_row }}-md{% endif %}
+  {%- if container_width == 'scroll' %} fl-card-grid-scroll{% endif %}"
+  {%- if container_width == 'scroll' %} data-js="fl-card-grid-scroll"{% endif %}
 >
-  {% if container_width == 'scroll' %}<div class="fl-card-grid-scroll-inner">{% endif %}
+  {%- if container_width == 'scroll' %}<div class="fl-card-grid-scroll-inner">{% endif %}
   {{ contents }}
-  {% if container_width == 'scroll' %}</div>{% endif %}
+  {%- if container_width == 'scroll' %}</div>{% endif %}
 </div>

--- a/springfield/cms/templates/components/conditional-display.html
+++ b/springfield/cms/templates/components/conditional-display.html
@@ -4,103 +4,103 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# platform_conditions=[], firefox_condition="", auth_state_condition="", default_browser_condition="", geo_conditions="", min_version="", max_version="", ai_controls_condition="", bind_to_uitour=False, condition_settings={} #}
+{#- platform_conditions=[], firefox_condition="", auth_state_condition="", default_browser_condition="", geo_conditions="", min_version="", max_version="", ai_controls_condition="", bind_to_uitour=False, condition_settings={} -#}
 
-{% set condition_settings = condition_settings or {} %}
-{% set platform_conditions = platform_conditions or condition_settings.get("platforms") %}
-{% set firefox_condition = firefox_condition or condition_settings.get("firefox") %}
-{% set auth_state_condition = auth_state_condition or condition_settings.get("auth_state") %}
-{% set default_browser_condition = default_browser_condition or condition_settings.get("default_browser") %}
-{% set geo_conditions = geo_conditions or condition_settings.get("geo") %}
-{% set ai_controls_condition = ai_controls_condition or condition_settings.get("ai_controls") %}
-{% set bind_to_uitour = bind_to_uitour or condition_settings.get("bind_to_uitour") %}
-{% set min_version = min_version or condition_settings.get("min_version") %}
-{% set max_version = max_version or condition_settings.get("max_version") %}
+{%- set condition_settings = condition_settings or {} -%}
+{%- set platform_conditions = platform_conditions or condition_settings.get("platforms") -%}
+{%- set firefox_condition = firefox_condition or condition_settings.get("firefox") -%}
+{%- set auth_state_condition = auth_state_condition or condition_settings.get("auth_state") -%}
+{%- set default_browser_condition = default_browser_condition or condition_settings.get("default_browser") -%}
+{%- set geo_conditions = geo_conditions or condition_settings.get("geo") -%}
+{%- set ai_controls_condition = ai_controls_condition or condition_settings.get("ai_controls") -%}
+{%- set bind_to_uitour = bind_to_uitour or condition_settings.get("bind_to_uitour") -%}
+{%- set min_version = min_version or condition_settings.get("min_version") -%}
+{%- set max_version = max_version or condition_settings.get("max_version") -%}
 
-{% if platform_conditions %}
+{%- if platform_conditions %}
   <div class="conditional-display {% for condition in platform_conditions %}condition-{{ condition }} {% endfor %} {% if is_preview %}is-preview{% endif %}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Conditions: {{ platform_conditions | join(", ") }}</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
-{% if firefox_condition %}
+{%- if firefox_condition %}
   <div class="conditional-display condition-{{ firefox_condition }} {% if is_preview %}is-preview{% endif %}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Condition: {{ firefox_condition }}</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
-{% if auth_state_condition %}
+{%- if auth_state_condition %}
   <div class="conditional-display condition-{{ auth_state_condition }} {% if is_preview %}is-preview{% endif %}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Condition: {{ auth_state_condition }}</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
-{% if default_browser_condition %}
+{%- if default_browser_condition %}
   <div class="conditional-display condition-{{ default_browser_condition }} {% if is_preview %}is-preview{% endif %}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Condition: {{ default_browser_condition }}</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
-{% if geo_conditions %}
+{%- if geo_conditions %}
   <div class="conditional-display condition-geo {% if is_preview %}is-preview{% endif %}"
     data-geo-conditions="{{ ','.join(geo_conditions) }}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Condition: {{ geo_conditions }}</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
-{% if ai_controls_condition %}
+{%- if ai_controls_condition %}
   <div class="conditional-display condition-ai-controls-{{ ai_controls_condition }} {% if is_preview %}is-preview{% endif %}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Condition: AI Controls {{ ai_controls_condition }}</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
-{% if min_version or max_version %}
+{%- if min_version or max_version %}
   <div class="conditional-display condition-fx-version {% if is_preview %}is-preview{% endif %}"
-    {% if min_version %}data-min-version="{{ min_version }}"{% endif %}
-    {% if max_version %}data-max-version="{{ max_version }}"{% endif %}>
-    {% if is_preview %}
+    {%- if min_version %} data-min-version="{{ min_version }}"{% endif %}
+    {%- if max_version %} data-max-version="{{ max_version }}"{% endif %}>
+    {%- if is_preview %}
       <span class="preview-indicator">Condition:
-        {% if min_version %}FX version >= {{ min_version }}{% endif %}
-        {% if max_version %}FX version <= {{ max_version }}{% endif %}</span>
-    {% endif %}
-{% endif %}
+        {%- if min_version %} FX version >= {{ min_version }}{% endif %}
+        {%- if max_version %} FX version <= {{ max_version }}{% endif %}</span>
+    {%- endif %}
+{%- endif %}
 
-{% if bind_to_uitour %}
+{%- if bind_to_uitour %}
   <div class="conditional-display condition-bind-uitour {% if is_preview %}is-preview{% endif %}">
-    {% if is_preview %}
+    {%- if is_preview %}
       <span class="preview-indicator">Condition: bound to UI Tour</span>
-    {% endif %}
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
 {{ contents }}
 
-{% if bind_to_uitour %}
+{%- if bind_to_uitour %}
   </div>
-{% endif %}
-{% if min_version or max_version %}
+{%- endif %}
+{%- if min_version or max_version %}
   </div>
-{% endif %}
-{% if ai_controls_condition %}
+{%- endif %}
+{%- if ai_controls_condition %}
   </div>
-{% endif %}
-{% if geo_conditions %}
+{%- endif %}
+{%- if geo_conditions %}
   </div>
-{% endif %}
-{% if default_browser_condition  %}
+{%- endif %}
+{%- if default_browser_condition  %}
   </div>
-{% endif %}
-{% if auth_state_condition  %}
+{%- endif %}
+{%- if auth_state_condition  %}
   </div>
-{% endif %}
-{% if firefox_condition %}
+{%- endif %}
+{%- if firefox_condition %}
   </div>
-{% endif %}
-{% if platform_conditions %}
+{%- endif %}
+{%- if platform_conditions %}
   </div>
-{% endif %}
+{%- endif %}

--- a/springfield/cms/templates/components/download-firefox-button.html
+++ b/springfield/cms/templates/components/download-firefox-button.html
@@ -4,17 +4,17 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button, apple_app_store_button with context %}
+{%- from "macros.html" import google_play_button, apple_app_store_button with context %}
 
-{% set is_forced = specific_version and specific_version != "default" %}
-{% set resolved_os = specific_version if is_forced else "win" %}
-{% set download_firefox_thanks_link = download_firefox_thanks_link(os=resolved_os) %}
-{% set link_href = download_firefox_thanks_link['download_link_direct'] if is_forced else download_firefox_thanks_link['transition_url'] %}
+{%- set is_forced = specific_version and specific_version != "default" %}
+{%- set resolved_os = specific_version if is_forced else "win" %}
+{%- set download_firefox_thanks_link = download_firefox_thanks_link(os=resolved_os) %}
+{%- set link_href = download_firefox_thanks_link['download_link_direct'] if is_forced else download_firefox_thanks_link['transition_url'] %}
 
-{#
+{#-
   Required selector for Stub Attribution: '.c-button-download-thanks > .download-link'
   media/js/base/mozilla-utils.js
-#}
+-#}
 
 <div class="fl-download-firefox-button c-button-download-thanks" id="{{ analytics_id }}">
   <a href="{{ link_href }}"
@@ -28,64 +28,64 @@
      data-cta-position="{{ block_position }}"
      data-cta-uid="{{ analytics_id }}"
   >
-    {% if icon_name and icon_position == "left" %}
+    {%- if icon_name and icon_position == "left" %}
       <include:icon
         icon_name="{{ icon_name }}"
         hidden=true
         extra_class="fl-icon-left"
       />
-    {% endif %}
+    {%- endif %}
     {{ label }}
-    {% if icon_name and icon_position == "right" %}
+    {%- if icon_name and icon_position == "right" %}
       <include:icon
         icon_name="{{ icon_name }}"
         hidden=true
         extra_class="fl-icon-right"
       />
-    {% endif %}
+    {%- endif %}
   </a>
-  {% if enable_marketing_attribution %}
+  {%- if enable_marketing_attribution %}
     <label for="{{ analytics_id }}-marketing-opt-out" class="marketing-opt-out-checkbox-label hidden">
       <input type="checkbox" id="{{ analytics_id }}-marketing-opt-out" class="marketing-opt-out-checkbox-input">
       <span class="marketing-opt-out-text">
-        {% set attrs = 'href="https://support.mozilla.org/kb/marketing-data" target="_blank" rel="noopener"' %}
+        {%- set attrs = 'href="https://support.mozilla.org/kb/marketing-data" target="_blank" rel="noopener"' %}
         {{ ftl('download-button-share-how-you-discovered', attrs=attrs) }}
       </span>
     </label>
-  {% elif show_default_browser_checkbox  %}
-    {% set checkbox %}
+  {%- elif show_default_browser_checkbox  %}
+    {%- set checkbox %}
       <label for="{{ analytics_id }}-default-browser" class="default-browser-label hidden">
         <input type="checkbox" checked id="{{ analytics_id }}-default-browser" class="default-browser-checkbox">
         {{ ftl('block-set-as-default')}}
       </label>
-    {% endset %}
-    {% if is_preview %}
+    {%- endset %}
+    {%- if is_preview %}
       <include:conditional-display platform_conditions="{{ ['windows'] }}">
         {{ checkbox }}
       </include:conditional-display>
-    {% else %}
+    {%- else %}
       {{ checkbox }}
-    {% endif %}
-  {% endif %}
+    {%- endif %}
+  {%- endif %}
 
-  {% if show_store_button %}
-    {% set campaign = (utm_parameters or {}).get("utm_campaign") %}
-    {% set ios_url = app_store_url('firefox', campaign) %}
-    {% set android_url = play_store_url('firefox', campaign) %}
+  {%- if show_store_button %}
+    {%- set campaign = (utm_parameters or {}).get("utm_campaign") %}
+    {%- set ios_url = app_store_url('firefox', campaign) %}
+    {%- set android_url = play_store_url('firefox', campaign) %}
     {{ apple_app_store_button(href=ios_url, class_name="fl-store-button fl-store-button-ios") }}
     {{ google_play_button(href=android_url, id='playStoreLink-primary', class_name="fl-store-button fl-store-button-android") }}
-  {% endif %}
+  {%- endif %}
 
-  {% if not exclude_unsupported_content %}
+  {%- if not exclude_unsupported_content %}
     {# ESR download buttons to display on unsupported systems: issue 13317 #}
-    {% with flare_styles=True %}
-      {% include 'firefox/includes/download-unsupported.html' %}
-    {% endwith %}
+    {%- with flare_styles=True %}
+      {%- include 'firefox/includes/download-unsupported.html' %}
+    {%- endwith %}
 
     <small class="{% if flare_styles %}fl-privacy-link{% else %}mzp-c-button-download-privacy-link{% endif %}">
       <a href="https://www.mozilla.org/{{ LANG }}/privacy/firefox/{{ params }}">
         {{ ftl('download-button-firefox-privacy-notice') }}
       </a>
     </small>
-  {% endif %}
+  {%- endif %}
 </div>

--- a/springfield/cms/templates/components/flare-footer.html
+++ b/springfield/cms/templates/components/flare-footer.html
@@ -12,27 +12,27 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     {# TODO: refactor both sections into a single one while keeping design consistent #}
 
     <div class="fl-footer-sections-list fl-footer-sections-list-desktop" data-testid="fl-footer-desktop">
-      {% include 'cms/includes/flare-footer/download.html' %}
-      {% include 'cms/includes/flare-footer/builds.html' %}
-      {% include 'cms/includes/flare-footer/community.html' %}
-      {% include 'cms/includes/flare-footer/resources.html' %}
-      {% include 'cms/includes/flare-footer/follow.html' %}
-      {% include 'cms/includes/flare-footer/lang-switcher.html' %}
+      {%- include 'cms/includes/flare-footer/download.html' %}
+      {%- include 'cms/includes/flare-footer/builds.html' %}
+      {%- include 'cms/includes/flare-footer/community.html' %}
+      {%- include 'cms/includes/flare-footer/resources.html' %}
+      {%- include 'cms/includes/flare-footer/follow.html' %}
+      {%- include 'cms/includes/flare-footer/lang-switcher.html' %}
     </div>
 
     <div class="fl-footer-sections-list fl-footer-sections-list-mobile" data-testid="fl-footer-mobile">
       <div class="fl-footer-sections-list-column">
-        {% include 'cms/includes/flare-footer/download.html' %}
-        {% include 'cms/includes/flare-footer/resources.html' %}
+        {%- include 'cms/includes/flare-footer/download.html' %}
+        {%- include 'cms/includes/flare-footer/resources.html' %}
       </div>
 
       <div class="fl-footer-sections-list-column">
-        {% include 'cms/includes/flare-footer/builds.html' %}
-        {% include 'cms/includes/flare-footer/community.html' %}
-        {% include 'cms/includes/flare-footer/follow.html' %}
+        {%- include 'cms/includes/flare-footer/builds.html' %}
+        {%- include 'cms/includes/flare-footer/community.html' %}
+        {%- include 'cms/includes/flare-footer/follow.html' %}
       </div>
 
-      {% include 'cms/includes/flare-footer/lang-switcher.html' %}
+      {%- include 'cms/includes/flare-footer/lang-switcher.html' %}
     </div>
 
   </div>
@@ -40,10 +40,10 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <div class="fl-footer-secondary">
     <div class="fl-footer-legal">
       <ul class="fl-footer-terms">
-        {% if LANG == "de" %}
+        {%- if LANG == "de" %}
           {# Legal requirement in Germany see bedrock issue #14240 #}
           <li><a href="https://www.mozilla.org/de/about/legal/impressum/" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
-        {% endif %}
+        {%- endif %}
         <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/{{ params }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
         <li><a href="https://www.mozilla.org/about/legal/terms/firefox/{{ params }}" data-link-position="footer" data-link-text="Terms of Use">{{ ftl('footer-terms-of-use') }}</a></li>
         <li>

--- a/springfield/cms/templates/components/flare-header.html
+++ b/springfield/cms/templates/components/flare-header.html
@@ -4,28 +4,28 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set nav %}
-  {% if contents.nav %}
+{%- set nav %}
+  {%- if contents.nav %}
     {{ contents.nav }}
-  {% else %}
+  {%- else %}
     <ul class="fl-nav-menu">
-      {% include 'cms/includes/flare-menus/browser.html' %}
-      {% include 'cms/includes/flare-menus/features.html' %}
-      {% include 'cms/includes/flare-menus/resources.html' %}
+      {%- include 'cms/includes/flare-menus/browser.html' %}
+      {%- include 'cms/includes/flare-menus/features.html' %}
+      {%- include 'cms/includes/flare-menus/resources.html' %}
     </ul>
-  {% endif %}
-{% endset %}
+  {%- endif %}
+{%- endset %}
 
 <header class="fl-header
-  {% if no_menu %}fl-header-no-menu{% endif %}
-    {% if not disable_sticky %}enable-sticky{% endif %}
-    {% if theme == 'dark' %}fl-force-dark-theme{% endif %}
-    {% if theme == 'light' %}fl-force-light-theme{% endif %}
+  {%- if no_menu %} fl-header-no-menu{% endif %}
+    {%- if not disable_sticky %} enable-sticky{% endif %}
+    {%- if theme == 'dark' %} fl-force-dark-theme{% endif %}
+    {%- if theme == 'light' %} fl-force-light-theme{% endif -%}
 ">
   <div class="fl-header-inner">
-    {% if contents.custom_logo %}
+    {%- if contents.custom_logo %}
       {{ contents.custom_logo }}
-    {% else %}
+    {%- else %}
       <a href="/{{LANG}}/" class="fl-logo-fx" aria-label="Firefox">
         <img
           src="/media/img/logos/firefox/logo-word-hor-2026.svg"
@@ -34,22 +34,22 @@
           height="40"
         />
       </a>
-    {% endif %}
+    {%- endif %}
 
-    {% if not no_menu %}
+    {%- if not no_menu %}
     <nav class="fl-nav" data-testid="navigation-menu-items">
-      {% if not no_menu_dropdowns %}
+      {%- if not no_menu_dropdowns %}
         {{ nav }}
-      {% endif %}
+      {%- endif %}
       <div class="fl-nav-mobile-download-link">
-        {% include 'cms/includes/nav-cta.html' %}
+        {%- include 'cms/includes/nav-cta.html' %}
       </div>
     </nav>
     <div class="fl-header-buttons">
       <div class="fl-header-main-download-button">
-        {% include 'cms/includes/nav-cta.html' %}
+        {%- include 'cms/includes/nav-cta.html' %}
       </div>
-      {% if not no_menu_dropdowns %}
+      {%- if not no_menu_dropdowns %}
         <button class="fl-show-mobile-menu" type="button" data-testid="navigation-menu-button">
           <span class="fl-show-mobile-menu-content">
             <span class="fl-icon fl-icon-app-menu" aria-label="{{ ftl('ui-menu') }}"></span>
@@ -57,9 +57,9 @@
             <span class="fallback-text">Menu</span>
           </span>
         </button>
-      {% endif %}
+      {%- endif %}
     </div>
-    {% endif %}
+    {%- endif %}
 
     <div class="fl-ie-only fl-nav">
       <a class="ie-menu-button" href="#">Menu</a>

--- a/springfield/cms/templates/components/heading.html
+++ b/springfield/cms/templates/components/heading.html
@@ -4,24 +4,24 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if superheading_text or subheading_text %}
+{%- if superheading_text or subheading_text %}
   <hgroup class="fl-heading-group {{ alignment_class }}">
-    {% if superheading_text %}
+    {%- if superheading_text %}
       <p class="fl-superheading">
         {{ superheading_text }}
       </p>
-    {% endif %}
-    {% if heading_text %}
+    {%- endif %}
+    {%- if heading_text %}
       <{{ level|default('h2') }} class="fl-heading  {{ heading_size }}" {% if id %}id="{{ id }}"{% endif %}>
         {{ heading_text }}
       </{{ level|default('h2') }}>
-    {% endif %}
-    {% if subheading_text %}
+    {%- endif %}
+    {%- if subheading_text %}
       <p class="fl-subheading {{ subheading_size }} {{ alignment_class }}">{{ subheading_text }}</p>
-    {% endif %}
+    {%- endif %}
   </hgroup>
-{% elif heading_text %}
+{%- elif heading_text %}
   <{{ level|default('h2') }} class="fl-heading {{ alignment_class }} {{ heading_size }}">
     {{ heading_text }}
   </{{ level|default('h2') }}>
-{% endif %}
+{%- endif %}

--- a/springfield/cms/templates/components/icon.html
+++ b/springfield/cms/templates/components/icon.html
@@ -4,4 +4,4 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<span class="fl-icon {{ extra_class }} {% if icon_name %} fl-icon-{{ icon_name }}{% endif %}" {% if hidden %}aria-hidden="true" {% endif %}{% if aria_label %} aria-label="{{ aria_label }}" {% endif %}></span>
+<span class="fl-icon {{ extra_class }} {% if icon_name %} fl-icon-{{ icon_name }}{% endif %}" {% if hidden %} aria-hidden="true"{% endif %}{% if aria_label %} aria-label="{{ aria_label }}"{% endif %}></span>

--- a/springfield/cms/templates/components/intro.html
+++ b/springfield/cms/templates/components/intro.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# props
+{#- props
   media_position="after"
   anchor_id=""
   vertical=""
@@ -12,33 +12,33 @@
   slim=""
   superheading_is_pill=False
   remove_border_radius=False
-#}
+-#}
 
 <div
   class="
     fl-intro
-    {% if contents.media %} fl-intro-has-media{% endif %}
-    {% if contents.media and media_position %} fl-intro-media-{{ media_position }}{% endif %}
-    {% if vertical %}fl-intro-vertical{% endif %}
-    {% if full_width %}fl-intro-full-width{% endif %}
-    {% if slim %}is-slim{% endif %}
-    {% if remove_border_radius %}remove-border-radius-from-media{% endif %}
-    {% if superheading_is_pill %}superheading-is-pill{% endif %}
+    {%- if contents.media %} fl-intro-has-media{% endif %}
+    {%- if contents.media and media_position %} fl-intro-media-{{ media_position }}{% endif %}
+    {%- if vertical %} fl-intro-vertical{% endif %}
+    {%- if full_width %} fl-intro-full-width{% endif %}
+    {%- if slim %} is-slim{% endif %}
+    {%- if remove_border_radius %} remove-border-radius-from-media{% endif %}
+    {%- if superheading_is_pill %} superheading-is-pill{% endif %}
   "
   {% if anchor_id %}id="{{ anchor_id }}"{% endif %}
 >
-  {% if contents.media and media_position == 'before' %}
+  {%- if contents.media and media_position == 'before' %}
     <div class="fl-intro-media">
       {{ contents.media }}
     </div>
-  {% endif %}
+  {%- endif %}
   <div class="fl-intro-content">
     {{ contents.heading }}
     {{ contents.content }}
   </div>
-  {% if contents.media and not media_position == 'before' %}
+  {%- if contents.media and not media_position == 'before' %}
     <div class="fl-intro-media">
       {{ contents.media }}
     </div>
-  {% endif %}
+  {%- endif %}
 </div>

--- a/springfield/cms/templates/components/media-content.html
+++ b/springfield/cms/templates/components/media-content.html
@@ -10,16 +10,16 @@
   class="
     fl-mediacontent
     fl-mediacontent-feature
-    {% if media_after %}fl-mediacontent-reverse{% endif %}
-    {% if narrow %}is-narrow{% endif %}
-    {% if remove_border_radius %}remove-border-radius-from-media{% endif %}
+    {%- if media_after %} fl-mediacontent-reverse{% endif %}
+    {%- if narrow %} is-narrow{% endif %}
+    {%- if remove_border_radius %} remove-border-radius-from-media{% endif %}
   "
 >
-  {% if contents.media %}
+  {%- if contents.media %}
     <div class="fl-mediacontent-media">
       {{ contents.media }}
     </div>
-  {% endif %}
+  {%- endif %}
   <div class="fl-mediacontent-content">
     {{ contents.heading }}
     {{ contents.content }}

--- a/springfield/cms/templates/components/nav-column.html
+++ b/springfield/cms/templates/components/nav-column.html
@@ -4,11 +4,11 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{#
+{#-
  A single column inside a folder's dropdown panel. The contents are a mix
  of link lists (`<ul>`), horizontal rules and buttons, assembled by the
  column block template.
-#}
+-#}
 
 <div class="fl-menu-panel-content-column">
   {{ contents }}

--- a/springfield/cms/templates/components/nav-folder.html
+++ b/springfield/cms/templates/components/nav-folder.html
@@ -4,10 +4,10 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{#
+{#-
  A top-level navigation category whose label opens a dropdown panel.
  The panel's columns are passed in as the component contents.
-#}
+-#}
 
 <li class="fl-menu-category" data-testid="{{ category_testid or panel_id }}">
   <a class="fl-menu-title"{% if href %} href="{{ href }}"{% endif %}{% if link_testid %} data-testid="{{ link_testid }}"{% endif %}>

--- a/springfield/cms/templates/components/nav-link.html
+++ b/springfield/cms/templates/components/nav-link.html
@@ -4,12 +4,12 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{#
+{#-
  A single navigation link. Plain links render as an `<li>` (grouped into a
  `<ul>` by the column template); button-style links render as a standalone
  ghost button, outside any list. `external` appends the up-right arrow icon;
  `new_window` controls whether it opens in a new tab.
-#}
+-#}
 
 {% if button_style %}
   <include:button
@@ -29,22 +29,22 @@
     <a
       class="fl-nav-link"
       href="{{ href }}"
-      {% if testid %}data-testid="{{ testid }}"{% endif %}
-      {% if new_window %}target="_blank" rel="external noopener"{% endif %}
-      {% if analytics_text %}data-cta-text="{{ analytics_text }}"{% endif %}
-      {% if analytics_position %}data-cta-position="{{ analytics_position }}"{% endif %}
-      {% if analytics_id %}data-cta-uid="{{ analytics_id }}"{% endif %}
+      {%- if testid %} data-testid="{{ testid }}"{% endif %}
+      {%- if new_window %} target="_blank" rel="external noopener"{% endif %}
+      {%- if analytics_text %} data-cta-text="{{ analytics_text }}"{% endif %}
+      {%- if analytics_position %} data-cta-position="{{ analytics_position }}"{% endif %}
+      {%- if analytics_id %} data-cta-uid="{{ analytics_id }}"{% endif -%}
     >
-      {% if icon_name and icon_position != "right" %}
+      {%- if icon_name and icon_position != "right" %}
         <include:icon icon_name="{{ icon_name }}" hidden="true" />
-      {% endif %}
+      {%- endif %}
       {{ label }}
-      {% if icon_name and icon_position == "right" %}
+      {%- if icon_name and icon_position == "right" %}
         <include:icon icon_name="{{ icon_name }}" hidden="true" />
-      {% endif %}
-      {% if external %}
+      {%- endif %}
+      {%- if external %}
         <span class="fl-icon fl-nav-icon-up-right-arrow" aria-hidden="true"></span>
-      {% endif %}
+      {%- endif %}
     </a>
   </li>
 {% endif %}

--- a/springfield/firefox/templates/firefox/browsers/desktop/base.html
+++ b/springfield/firefox/templates/firefox/browsers/desktop/base.html
@@ -15,14 +15,14 @@
 
 {% block body_class %}fl-download-page{% endblock %}
 
-{% set params = link_params or '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' %}
+{%- set params = link_params or '?utm_source=www.firefox.com&utm_medium=referral&utm_campaign=firefox-desktop' -%}
 
 {# meta #}
-{% set meta_title_prefix = meta_title_prefix or ftl('firefox-new-download-browser', fallback='firefox-new-download-firefox') %}
-{% set meta_title = ftl('firefox-new-fast') if ftl_has_messages('firefox-new-fast') else meta_title or ftl('firefox-new-free-web-browser') %}
-{% set meta_desc = meta_desc or ftl('firefox-new-desc', fallback='firefox-new-faster-page-loading-less-memory') %}
-{% set og_title = og_title or ftl('firefox-new-download-browser', fallback='firefox-new-download-the-fastest-firefox') %}
-{% set og_desc = og_desc or ftl('firefox-new-desc', fallback='firefox-new-faster-page-loading-less-memory') %}
+{%- set meta_title_prefix = meta_title_prefix or ftl('firefox-new-download-browser', fallback='firefox-new-download-firefox') -%}
+{%- set meta_title = ftl('firefox-new-fast') if ftl_has_messages('firefox-new-fast') else meta_title or ftl('firefox-new-free-web-browser') -%}
+{%- set meta_desc = meta_desc or ftl('firefox-new-desc', fallback='firefox-new-faster-page-loading-less-memory') -%}
+{%- set og_title = og_title or ftl('firefox-new-download-browser', fallback='firefox-new-download-the-fastest-firefox') -%}
+{%- set og_desc = og_desc or ftl('firefox-new-desc', fallback='firefox-new-faster-page-loading-less-memory') -%}
 
 {# page title #}
 {%- block page_title_prefix -%}{{ meta_title_prefix }}{%- endblock -%}
@@ -32,25 +32,25 @@
 {% block page_og_desc %}{{ og_desc }}{% endblock %}
 
 {# hero #}
-{% set hero_title = hero_title or ftl('firefox-new-get-the-latest-firefox') %}
-{% set hero_img = hero_img or 'img/firefox/browsers/desktop/platform/browser-window.svg' %}
+{%- set hero_title = hero_title or ftl('firefox-new-get-the-latest-firefox') -%}
+{%- set hero_img = hero_img or 'img/firefox/browsers/desktop/platform/browser-window.svg' -%}
 
 {# small links #}
-{% set small_advanced = small_advanced or ftl('firefox-new-advanced-install-options') %}
-{% set small_lang = small_lang or ftl('firefox-new-download-in-another-language') %}
-{% set small_help = small_help or ftl('firefox-new-need-help') %}
+{%- set small_advanced = small_advanced or ftl('firefox-new-advanced-install-options') -%}
+{%- set small_lang = small_lang or ftl('firefox-new-download-in-another-language') -%}
+{%- set small_help = small_help or ftl('firefox-new-need-help') -%}
 
 {# blocks #}
 
 {% if ftl_file_is_active('firefox/download/platform') %}
-  {% set small_advanced = ftl('new-platform-advanced-install-options') %}
-  {% set small_lang = ftl('new-platform-download-in-another') %}
-  {% set small_help = ftl('new-platform-need-help') %}
+  {%- set small_advanced = ftl('new-platform-advanced-install-options') -%}
+  {%- set small_lang = ftl('new-platform-download-in-another') -%}
+  {%- set small_help = ftl('new-platform-need-help') -%}
 {# else it will fall back to the strings from new/download.ftl specified in base_download #}
 {% endif %}
 
 {% block flare_header %}
-  {% set hide_nav_cta = true %}
+  {%- set hide_nav_cta = true -%}
   <include:flare-header theme="dark" />
 {% endblock %}
 

--- a/springfield/firefox/templates/firefox/includes/download-unsupported.html
+++ b/springfield/firefox/templates/firefox/includes/download-unsupported.html
@@ -4,19 +4,19 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if channel == 'beta' %}
-  {% set channel_name = 'Firefox Beta' %}
-{% elif channel == 'alpha' %}
-  {% set channel_name = 'Firefox Developer Edition' %}
-{% elif channel == 'nightly' %}
-  {% set channel_name = 'Firefox Nightly' %}
-{% else %}
-  {% set channel_name = 'Firefox' %}
-{% endif %}
+{%- if channel == 'beta' %}
+  {%- set channel_name = 'Firefox Beta' %}
+{%- elif channel == 'alpha' %}
+  {%- set channel_name = 'Firefox Developer Edition' %}
+{%- elif channel == 'nightly' %}
+  {%- set channel_name = 'Firefox Nightly' %}
+{%- else %}
+  {%- set channel_name = 'Firefox' %}
+{%- endif %}
 
 {# ESR115 builds do not exist for "sat" and "skr" languages (see issue #15437). #}
-{% set win_download_lang = 'en-US' if LANG in ["sat", "skr"] else LANG %}
-{% set mac_download_lang = 'ja-JP-mac' if LANG == "ja" else win_download_lang %}
+{%- set win_download_lang = 'en-US' if LANG in ["sat", "skr"] else LANG %}
+{%- set mac_download_lang = 'ja-JP-mac' if LANG == "ja" else win_download_lang %}
 
 <div class="fx-unsupported-message win" data-nosnippet="true">
   <p><strong>{{ ftl('download-button-unsupported-platform', channel_name=channel_name, help_url='https://support.mozilla.org/kb/firefox-users-windows-7-8-and-81-moving-extended-support', os_version='Windows 8.1') }}</strong></p>


### PR DESCRIPTION
## One-line summary

Totally unnecessary white space clean up.

## Significant changes and points to review

Through some trial and error I found it was not safe to do this with global config options. _Some_ of our whitespace needs to be preserved. My goal was to find places where there were ~6 or more empty lines in code output and get that down to 3 or fewer. But once I was editing a file, I edited it.

Leaving this as a draft for now and will talk to Steve about HTML minimization instead on Tuesday.

## Issue / Bugzilla link

n/a

## Testing

The places that need most careful review are ones where the if statement begins and ends on the same line and is inside an open HTML tag. Example: `{%- if disabled %} disabled{% endif %}` It needs to have a space included after the opening if block.