### PR TITLE
WT-1479: Align importer with actual CSV format 

### DIFF
--- a/springfield/firefox/management/commands/update_referral_data.py
+++ b/springfield/firefox/management/commands/update_referral_data.py
@@ -15,30 +15,18 @@ from springfield.firefox.referral.crypto import invite_code_to_referral_id
 from springfield.firefox.referral.models import FirefoxReferralData
 from springfield.utils.management.decorators import alert_sentry_on_exception
 
-_HEADER_ROW = ("invite_code", "count")
-
 
 def _iter_rows(reader):
     """Yield (invite_code, count_str) tuples from a csv.reader.
 
-    Tolerates an optional header row: if the first row exactly matches
-    the expected column names ('invite_code', 'count'), skip it.
-    Any other first row — including a malformed data row — is yielded so
-    _decrypt_rows / _validated_iter can count it as skipped rather than
-    silently dropping it here. Also skips blank lines and rows without
-    exactly two columns.
+    The CSV has no header row. Skips blank lines and rows without exactly
+    two columns (surfaces schema drift rather than silently ignoring extras).
     """
-    header_checked = False
     for row in reader:
         if not row:
             continue
         if len(row) != 2:
-            # Surface schema drift rather than silently accepting extra columns.
             continue
-        if not header_checked:
-            header_checked = True
-            if (row[0].strip().lower(), row[1].strip().lower()) == _HEADER_ROW:
-                continue
         yield row[0], row[1]
 
 
@@ -65,11 +53,9 @@ class Command(BaseCommand):
     help = (
         "Refreshes the FirefoxReferralData table from the newest CSV published "
         "to GCS by Data Engineering. Data Eng writes one CSV per publish, named "
-        "'{REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX}-YYYY-MM-DDZHH:MM:SS.csv'; the "
-        "command lists that prefix, picks the lex-newest name (chronologically "
-        "latest for this timestamp format), and imports it. Expected CSV shape "
-        "(header optional):\n"
-        "    invite_code,count\n"
+        "'{REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX}-YYYY-MM-DD.csv'; the command "
+        "lists that prefix, picks the lex-newest name (chronologically latest "
+        "for that date format), and imports it. Expected CSV shape (no header):\n"
         "    1ABCDEFGHJKMNPQST,42\n"
         "Each invite code is decrypted to a referral ID before storage. "
         "Skips when the newest blob has not been updated since the last "

--- a/springfield/firefox/referral/tests/test_management_commands.py
+++ b/springfield/firefox/referral/tests/test_management_commands.py
@@ -25,8 +25,8 @@ INVITE_CODE_B = "1BBBBBBBBBBBBBBBB"  # decrypts → BBBBBBBBBBBBBBBB
 REFERRAL_ID_A = INVITE_CODE_A[1:]
 REFERRAL_ID_B = INVITE_CODE_B[1:]
 
-FIXTURE_CSV = f"invite_code,count\n{INVITE_CODE_A},42\n{INVITE_CODE_B},3\n"
-DEFAULT_BLOB_NAME = "referral_data-2026-07-22Z10:00:00.csv"
+FIXTURE_CSV = f"{INVITE_CODE_A},42\n{INVITE_CODE_B},3\n"
+DEFAULT_BLOB_NAME = "referral_data-2026-07-22.csv"
 
 
 def _make_blob(updated, csv_body=FIXTURE_CSV, name=DEFAULT_BLOB_NAME):
@@ -95,12 +95,12 @@ class TestUpdateReferralDataCommand(TestCase):
         older = _make_blob(
             updated=timezone.now() - timedelta(days=1),
             csv_body=old_body,
-            name="referral_data-2026-07-21Z10:00:00.csv",
+            name="referral_data-2026-07-21.csv",
         )
         newer = _make_blob(
             updated=timezone.now(),
             csv_body=new_body,
-            name="referral_data-2026-07-22Z10:00:00.csv",
+            name="referral_data-2026-07-22.csv",
         )
         # List in intentionally scrambled order to prove we sort, not "trust list order".
         with _patch_storage_client([newer, older]):
@@ -174,41 +174,11 @@ class TestUpdateReferralDataCommand(TestCase):
 
         self.assertEqual(FirefoxReferralData.objects.count(), 1)
 
-    def test_header_row_is_tolerated(self):
-        blob = _make_blob(updated=timezone.now())
-        with _patch_storage_client(blob):
-            call_command(COMMAND, quiet=True)
-
-        # Header skipped: only the two data rows are in the table.
-        self.assertEqual(FirefoxReferralData.objects.count(), 2)
-        self.assertFalse(FirefoxReferralData.objects.filter(referral_id="nvite_code").exists())
-
-    def test_malformed_first_data_row_is_counted_as_skipped_not_header(self):
-        # If the first row doesn't match the expected header names but has a
-        # non-integer count, it must NOT be silently swallowed as a "header"
-        # — it should reach refresh() and be counted as a skipped row.
-        body = f"{INVITE_CODE_A},not-an-int\n{INVITE_CODE_B},5\n"
-        blob = _make_blob(updated=timezone.now(), csv_body=body)
-        with _patch_storage_client(blob):
-            call_command(COMMAND, quiet=True)
-
-        # INVITE_CODE_B decrypts and loads; INVITE_CODE_A counted as skipped.
-        self.assertEqual(FirefoxReferralData.objects.count(), 1)
-        self.assertTrue(FirefoxReferralData.objects.filter(referral_id=REFERRAL_ID_B).exists())
-
-    def test_headerless_csv_loads_all_rows(self):
-        body = f"{INVITE_CODE_A},42\n{INVITE_CODE_B},3\n"
-        blob = _make_blob(updated=timezone.now(), csv_body=body)
-        with _patch_storage_client(blob):
-            call_command(COMMAND, quiet=True)
-
-        self.assertEqual(FirefoxReferralData.objects.count(), 2)
-
     def test_rows_with_extra_columns_are_dropped(self):
         # _iter_rows requires exactly two columns. If Data Eng ever emits a
         # third column, those rows are dropped rather than silently accepted
         # with the extras ignored, so the schema drift is more visible.
-        body = f"invite_code,count\n{INVITE_CODE_A},42\n{INVITE_CODE_B},3,unexpected\n"
+        body = f"{INVITE_CODE_A},42\n{INVITE_CODE_B},3,unexpected\n"
         blob = _make_blob(updated=timezone.now(), csv_body=body)
         with _patch_storage_client(blob):
             call_command(COMMAND, quiet=True)
@@ -221,7 +191,7 @@ class TestUpdateReferralDataCommand(TestCase):
         # An invite code that fails decryption is counted as a skipped row,
         # not a crash. The remaining valid codes are still imported.
         bad_code = "NOTAVALIDCODE1234"  # wrong length/format, decrypt will raise
-        body = f"invite_code,count\n{bad_code},42\n{INVITE_CODE_B},3\n"
+        body = f"{bad_code},42\n{INVITE_CODE_B},3\n"
         blob = _make_blob(updated=timezone.now(), csv_body=body)
 
         # Override: bad_code raises, good code decrypts normally.
@@ -243,11 +213,11 @@ class TestUpdateReferralDataCommand(TestCase):
         self.assertTrue(FirefoxReferralData.objects.filter(referral_id=REFERRAL_ID_B).exists())
 
     def test_empty_csv_raises_and_preserves_existing_data(self):
-        # An empty (or header-only) snapshot from Data Eng must not wipe the
-        # table. The command should let refresh()'s ValueError propagate so
-        # run-db-update.sh flags failure_detected and DMS is not pinged.
+        # An empty snapshot from Data Eng must not wipe the table. The command
+        # should let refresh()'s ValueError propagate so run-db-update.sh
+        # flags failure_detected and DMS is not pinged.
         FirefoxReferralData.objects.create(referral_id="KEEP000001", install_count=99)
-        blob = _make_blob(updated=timezone.now(), csv_body="invite_code,count\n")
+        blob = _make_blob(updated=timezone.now(), csv_body="")
         with _patch_storage_client(blob), self.assertRaisesRegex(ValueError, "no valid rows"):
             call_command(COMMAND, quiet=True)
 

--- a/springfield/firefox/referral/tests/test_management_commands.py
+++ b/springfield/firefox/referral/tests/test_management_commands.py
@@ -90,8 +90,8 @@ class TestUpdateReferralDataCommand(TestCase):
         # by lex-sort of the blob name (chronological for their format).
         invite_code_old = "1CCCCCCCCCCCCCCC1"
         invite_code_new = "1DDDDDDDDDDDDDDD1"
-        old_body = f"invite_code,count\n{invite_code_old},1\n"
-        new_body = f"invite_code,count\n{invite_code_new},2\n"
+        old_body = f"{invite_code_old},1\n"
+        new_body = f"{invite_code_new},2\n"
         older = _make_blob(
             updated=timezone.now() - timedelta(days=1),
             csv_body=old_body,

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -579,7 +579,7 @@ GS_PROJECT_ID = config("GS_PROJECT_ID", default="")
 # Data Eng writes one CSV per publish, named
 # `{REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX}-YYYY-MM-DD.csv`; the
 # command picks the lex-newest name (which sorts chronologically for that
-# timestamp format). Empty bucket name disables the import as a no-op.
+# date format). Empty bucket name disables the import as a no-op.
 REFERRAL_DATA_GCS_BUCKET = config("REFERRAL_DATA_GCS_BUCKET", default="")
 REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX = config("REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX", default="referral_data")
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -577,7 +577,7 @@ GS_PROJECT_ID = config("GS_PROJECT_ID", default="")
 # Distinct GCS bucket where Data Engineering publishes periodic
 # (referral_id, install_count) snapshots consumed by update_referral_data.
 # Data Eng writes one CSV per publish, named
-# `{REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX}-YYYY-MM-DDZHH:MM:SS.csv`; the
+# `{REFERRAL_DATA_GCS_OBJECT_NAME_PREFIX}-YYYY-MM-DD.csv`; the
 # command picks the lex-newest name (which sorts chronologically for that
 # timestamp format). Empty bucket name disables the import as a no-op.
 REFERRAL_DATA_GCS_BUCKET = config("REFERRAL_DATA_GCS_BUCKET", default="")


### PR DESCRIPTION
This changeset slightly amends our data-importer with two tweaks to match what Data Engineering actually publishes:

- Filename format is `{prefix}-YYYY-MM-DD.csv`, not `YYYY-MM-DDZHH:MM:SS` which is simpler and easier to handle. There will only be one per day, effectively.

- No header row in the CSV - the spec didn't have it and our handling of an optional header row just adds noise and complexity. Can live without.
