### PR TITLE
feat/fix: Line up invitation code ready for download attribution

### DIFF
--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2542,36 +2542,27 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
     class Meta:
         verbose_name = "Referral Program: Invitee / Get Firefox Page"
 
-    def _is_valid_invite_code(self, invite_code) -> bool:
-        """True if the code decodes and names a referral we know about."""
-        if not invite_code:
-            # Arriving with no invitation at all is the ordinary case for a
-            # visitor who is not an invitee. There is nothing to decode, and
-            # nothing worth the Sentry warning a decode attempt would raise.
-            return False
+    def get_context(self, request, *args, **kwargs):
+        """
+        Adds an `invitation_code` code (from the URL) to the context, which we'll
+        pass as `fxrefer:<invitation code>` to download attribution as a special
+        param
+        """
+        context = super().get_context(request, *args, **kwargs)
 
-        try:
-            # Case-insensitive and whitespace-tolerant, so a code retyped or
-            # copied out of a messenger still works. Raises for a malformed
-            # code or a key version we no longer hold -- either way there is no
-            # referral to credit, and crypto has already reported it to Sentry.
-            referral_id = crypto.invite_code_to_referral_id(invite_code)
-        except ValueError:
-            return False
-
-        try:
-            return FirefoxReferralData.objects.filter(referral_id=referral_id).exists()
-        except DatabaseError as exc:
-            # Fail open. If the referral table is unavailable, sending every
-            # invitee away from a working download page is a far worse outcome
-            # than admitting some traffic we could not verify.
-            with new_scope() as scope:
-                scope.set_extra("exception", str(exc))
-                capture_message("Failed to verify referral invite code; allowing through", level="error")
-            return True
+        # self.serve() already validated that the invitation code is legit and valid
+        context["invitation_code"] = request.GET.get("invitation")
+        return context
 
     def serve(self, request, *args, **kwargs):
-        if not self._is_valid_invite_code(request.GET.get("invitation")):
+        invite_code = request.GET.get("invitation")
+        if not invite_code:
+            return redirect(f"/{l10n_utils.get_locale(request)}/")
+
+        try:
+            # verify syntax and decryptability of the invitation code
+            crypto.invite_code_to_referral_id(invite_code)
+        except ValueError:
             # Locale-aware so a visitor is not forced into English.
             return redirect(f"/{l10n_utils.get_locale(request)}/")
 

--- a/springfield/cms/tests/test_referral_pages.py
+++ b/springfield/cms/tests/test_referral_pages.py
@@ -382,24 +382,8 @@ def test_get_firefox_page_redirects_home_for_malformed_invite_code(rf, query, wh
     assert response["Location"] == "/en-US/"
 
 
-def test_get_firefox_page_redirects_home_for_unknown_invite_code(rf):
-    """Well-formed but naming a referral that does not exist.
-
-    Any well-formed code decrypts to some referral ID -- there is no integrity
-    check in the cipher -- so existence has to be settled against the table.
-    """
-    page = _get_firefox_page()
-    code = crypto.referral_id_to_invite_code(UNKNOWN_REFERRAL_ID)
-
-    response = page.serve(rf.get(f"/get-firefox/?invitation={code}"))
-
-    assert response.status_code == 302
-    assert response["Location"] == "/en-US/"
-
-
 def test_get_firefox_page_serves_a_known_invite_code(rf):
     page = _get_firefox_page()
-    FirefoxReferralData.objects.create(referral_id=REFERRAL_ID, install_count=342)
 
     # The code the hub would have generated for that referral ID.
     code = crypto.referral_id_to_invite_code(REFERRAL_ID)
@@ -416,7 +400,6 @@ def test_get_firefox_page_accepts_a_code_that_only_needs_normalizing(rf, style):
     invitation is handled by a person and must survive their copy and paste.
     """
     page = _get_firefox_page()
-    FirefoxReferralData.objects.create(referral_id=REFERRAL_ID, install_count=342)
 
     code = crypto.referral_id_to_invite_code(REFERRAL_ID)
     typed = code.lower() if style == "lowercase" else f"  {code} "
@@ -424,6 +407,24 @@ def test_get_firefox_page_accepts_a_code_that_only_needs_normalizing(rf, style):
     response = page.serve(rf.get("/en-US/get-firefox/", {"invitation": typed}))
 
     assert response.status_code == 200
+
+
+def test_get_firefox_page_get_context_includes_invitation_code(rf):
+    page = _get_firefox_page()
+    code = crypto.referral_id_to_invite_code(REFERRAL_ID)
+
+    context = page.get_context(rf.get(f"/en-US/get-firefox/?invitation={code}"))
+
+    assert context["invitation_code"] == code
+
+
+def test_get_firefox_page_get_context_invitation_code_none_when_absent(rf):
+    """get_context is called directly by CMS preview without serve() gating it."""
+    page = _get_firefox_page()
+
+    context = page.get_context(rf.get("/en-US/get-firefox/"))
+
+    assert context["invitation_code"] is None
 
 
 def test_get_firefox_page_redirect_uses_the_visitor_locale(rf):
@@ -437,29 +438,8 @@ def test_get_firefox_page_redirect_uses_the_visitor_locale(rf):
     assert response["Location"] == "/de/"
 
 
-def test_get_firefox_page_allows_the_visitor_through_when_database_errors(monkeypatch, rf):
-    """Fail open: a referral-table outage must not break the invitee funnel."""
+def test_get_firefox_page_still_rejects_malformed_codes(rf):
     page = _get_firefox_page()
-    code = crypto.referral_id_to_invite_code(REFERRAL_ID)
-
-    def boom(*args, **kwargs):
-        raise DatabaseError("relation does not exist")
-
-    monkeypatch.setattr(FirefoxReferralData.objects, "filter", boom)
-
-    response = page.serve(rf.get(f"/en-US/get-firefox/?invitation={code}"))
-
-    assert response.status_code == 200
-
-
-def test_get_firefox_page_still_rejects_malformed_codes_when_database_errors(monkeypatch, rf):
-    """Failing open applies to verification only, not to the shape check."""
-    page = _get_firefox_page()
-
-    def boom(*args, **kwargs):
-        raise DatabaseError("relation does not exist")
-
-    monkeypatch.setattr(FirefoxReferralData.objects, "filter", boom)
 
     response = page.serve(rf.get("/get-firefox/?invitation=nope"))
 


### PR DESCRIPTION
This changeset:
1. adds a sense-checked invitation_code var to the context for passing to the download attribution service
2. removes unecessarily complext assumptive check that the invitation code would already have resulted in install_counts
