### PR TITLE
fix: Pass UTM parameters through to the Google Play Store link on Android

### DIFF
--- a/springfield/firefox/firefox_details.py
+++ b/springfield/firefox/firefox_details.py
@@ -5,7 +5,7 @@
 import re
 from collections import OrderedDict
 from operator import itemgetter
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 from django.conf import settings
 
@@ -346,7 +346,7 @@ class FirefoxAndroid(_ProductDetails):
         "release": "fennec-latest",
     }
 
-    store_url = settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS
+    store_url = settings.GOOGLE_PLAY_FIREFOX_LINK
     # Product IDs defined on Google Play
     # Nightly reuses the Aurora ID to migrate the user base
     store_product_ids = {
@@ -464,7 +464,7 @@ class FirefoxAndroid(_ProductDetails):
         # We don't have pre-release builds yet
         return []
 
-    def get_download_url(self, channel="release", arch="arm", locale="multi", force_direct=False):
+    def get_download_url(self, channel="release", arch="arm", locale="multi", force_direct=False, utm_params=None):
         """
         Get direct download url for the product.
         :param channel: one of self.version_map.keys() such as nightly, beta.
@@ -472,8 +472,13 @@ class FirefoxAndroid(_ProductDetails):
         :param locale: e.g. pt-BR.
         :param force_direct: Force the download URL to be direct or bouncer
                 instead of Google Play.
+        :param utm_params: dict of utm_* params to include in the Play Store referrer.
         :return: string url
         """
+        referrer_params = {"utm_source": "www.firefox.com", "utm_medium": "referral", "utm_campaign": "download"}
+        if utm_params:
+            referrer_params = {**referrer_params, **utm_params}
+
         if force_direct:
             # Use a bouncer link
             return "?".join(
@@ -490,11 +495,13 @@ class FirefoxAndroid(_ProductDetails):
                 ]
             )
 
+        store_url = self.store_url
+
         if channel != "release":
             product_id = self.store_product_ids.get(channel, "org.mozilla.firefox")
-            return self.store_url.replace(self.store_product_ids["release"], product_id)
+            store_url = self.store_url.replace(self.store_product_ids["release"], product_id)
 
-        return self.store_url
+        return store_url + "&referrer=" + quote(urlencode(referrer_params))
 
 
 class FirefoxIOS(_ProductDetails):

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -74,9 +74,9 @@ def desktop_builds(
     return builds
 
 
-def android_builds(channel, builds=None):
+def android_builds(channel, builds=None, utm_params=None):
     builds = builds or []
-    link = firefox_android.get_download_url(channel.lower())
+    link = firefox_android.get_download_url(channel.lower(), utm_params=utm_params)
     builds.append({"os": "android", "os_pretty": "Android", "download_link": link})
 
     return builds
@@ -138,7 +138,15 @@ def download_firefox(
 
     if show_android:
         version = firefox_android.latest_version(channel)
-        builds = android_builds(channel, builds)
+
+        query_params = ctx["request"].GET.copy()
+        utm_params = {k: v for k, v in query_params.items() if k.startswith("utm_") and v}
+
+        utm_params.setdefault("utm_source", "www.firefox.com")
+        utm_params.setdefault("utm_medium", "referral")
+        utm_params.setdefault("utm_campaign", "download")
+
+        builds = android_builds(channel, builds, utm_params)
 
     if show_ios:
         version = firefox_ios.latest_version(channel)

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -4,7 +4,7 @@
 
 import json
 from unittest.mock import patch
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, quote
 
 from django.http import HttpResponse
 from django.test import override_settings
@@ -929,3 +929,40 @@ class TestDownloadRedirect(TestCase):
         resp = download_redirect(req)
         assert resp.status_code == 302
         assert resp["Location"] == "/en-US/"
+
+
+class TestFirefoxThanksAndroidUTMParameters(TestCase):
+    def test_thanks_contains_matching_utm(self):
+        resp = self.client.get("/en-US/thanks/?utm_source=www.test.com", follow=True)
+        doc = pq(resp.content)
+        link = doc("#thanks-download-button-android")
+        href = link.attr("href")
+        assert quote("utm_source=www.test.com") in href
+
+    def test_thanks_passes_default_utm_parameters(self):
+        resp = self.client.get("/en-US/thanks/", follow=True)
+        doc = pq(resp.content)
+        link = doc("#thanks-download-button-android")
+        href = link.attr("href")
+        assert quote("utm_source=www.firefox.com") in href
+        assert quote("utm_medium=referral") in href
+        assert quote("utm_campaign=download") in href
+
+    def test_thanks_overwrites_default_utm_parameters(self):
+        resp = self.client.get("/en-US/thanks/?utm_source=www.test.com&utm_medium=test&utm_campaign=test", follow=True)
+        doc = pq(resp.content)
+        link = doc("#thanks-download-button-android")
+        href = link.attr("href")
+        assert quote("utm_source=www.firefox.com") not in href
+        assert quote("utm_source=www.test.com") in href
+        assert quote("utm_medium=referral") not in href
+        assert quote("utm_medium=test") in href
+        assert quote("utm_campaign=download") not in href
+        assert quote("utm_campaign=test") in href
+
+    def test_thanks_passes_all_utm_parameters(self):
+        resp = self.client.get("/en-US/thanks/?utm_source=www.test.com&utm_medium=test&utm_campaign=test&utm_content=abc123", follow=True)
+        doc = pq(resp.content)
+        link = doc("#thanks-download-button-android")
+        href = link.attr("href")
+        assert quote("utm_content=abc123") in href


### PR DESCRIPTION
When an Android user lands on /thanks/ via a link with UTM parameters (e.g. from AMO's RTAMO flow), we were silently dropping those params and replacing them with our own hardcoded defaults in the referrer string sent to Google Play. That meant attribution data was being lost for partner referrals.

This port of mozilla/bedrock#17121 fixes that by dynamically building the &referrer= portion of the Play Store URL from the incoming request's utm_* query params, falling back to sensible defaults (utm_source= www.firefox.com, utm_medium=referral, utm_campaign=download) only when the caller hasn't supplied them.

Resolves WT-1010 / upstream fix: mozilla/bedrock#17121
