### PR TITLE
User Routing 3/4: admin authoring surface

### DIFF
--- a/media/css/cms/routing/admin.css
+++ b/media/css/cms/routing/admin.css
@@ -1,0 +1,169 @@
+/*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+/* User Routing — styles for the routing authoring surface in the Wagtail admin: the
+   condition help beneath each expected-value field, the rules-listing status badges, and the
+   signals reference page. Kept out of wagtail-admin.css so the shared admin stylesheet has no
+   routing-specific rules in it, matching how the resolver page's own styles live in
+   routing/resolver.scss. */
+
+/* stylelint-disable selector-class-pattern, selector-id-pattern -- Two naming rules do not
+   apply cleanly here and neither is ours to change: `#id_routing_config-ADD` is an id Wagtail
+   generates for an InlinePanel's add button, and the source badge modifiers (`--cdn_geo`,
+   `--user_agent`) are the signal registry's own source values, rendered straight into the class
+   name so the badge cannot drift from the data. The remaining BEM modifiers follow those. */
+
+/* User Routing — the kill switch is always exactly one record (auto-added), so hide its
+   InlinePanel "Add" button entirely rather than leaving it greyed. */
+#id_routing_config-ADD {
+    display: none;
+}
+
+/* User Routing — a rule matching all triggered visitors ignores its conditions, so dim them
+   while its checkbox is ticked. Dimmed rather than disabled: the fields stay editable and
+   keep submitting, so ticking the box never quietly discards conditions the author wrote.
+   The explanation is server-rendered next to the checkbox and on the conditions panel. */
+.routing-conditions--ignored {
+    opacity: 0.5;
+}
+
+/* User Routing — dynamic condition help and its invalid state. Theme-aware
+   via Wagtail tokens. The invalid help reads as a small red callout, and the value field
+   gets an immediate red outline so a bad value is obvious before saving. */
+.routing-condition-help {
+    color: var(--w-color-text-context);
+    font-size: 0.8125rem;
+    margin-block-start: 0.35rem;
+}
+
+.routing-condition-help--invalid {
+    /* No tinted background: the fixed critical-50 pink doesn't adapt to dark mode and
+       tanks contrast. Use the theme-adaptive error colour for text + a red left border on
+       the normal page background — reads clearly in both light and dark. */
+    border-inline-start: 3px solid var(--w-color-text-error);
+    color: var(--w-color-text-error);
+    padding-block: 0.3rem;
+    padding-inline-start: 0.6rem;
+}
+
+input[name$='-expected_value'][aria-invalid='true'] {
+    border-color: var(--w-color-text-error);
+    box-shadow: 0 0 0 1px var(--w-color-text-error);
+}
+
+/* User Routing — signals reference page. Theme-aware via Wagtail design tokens so
+   it follows the admin's light/dark theme; badges carry a per-source accent. */
+.routing-signals-reference__note {
+    background: var(--w-color-surface-field-inactive);
+    border-inline-start: 4px solid var(--w-color-border-furniture);
+    border-radius: 3px;
+    color: var(--w-color-text-context);
+    margin-block: 1rem;
+    padding: 0.75rem 1rem;
+}
+
+.routing-signals-reference__table code {
+    color: var(--w-color-text-context);
+}
+
+/* Descriptions come from the registry (detailed, honest) — keep them but visually
+   secondary so the table scans quickly. */
+.routing-signal-description {
+    color: var(--w-color-text-label);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+    max-width: 30rem;
+}
+
+.routing-operators {
+    color: var(--w-color-text-context);
+    font-size: 0.8125rem;
+}
+
+.routing-signal-freetext {
+    color: var(--w-color-text-label);
+    font-size: 0.8125rem;
+    font-style: italic;
+}
+
+/* Known-set string signals (locale / country): long lists collapsed behind a summary. */
+.routing-value-list > summary {
+    color: var(--w-color-text-link-default);
+    cursor: pointer;
+    font-size: 0.8125rem;
+}
+
+.routing-value-list__items {
+    line-height: 1.7;
+    margin-block-start: 0.4rem;
+    max-height: 12rem;
+    max-width: 24rem;
+    overflow-y: auto;
+}
+
+.routing-badge {
+    background: var(--w-color-surface-field-inactive);
+    border: 1px solid var(--w-color-border-furniture);
+    border-inline-start-width: 4px;
+    border-radius: 1em;
+    color: var(--w-color-text-label);
+    display: inline-block;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.6;
+    padding: 0.05em 0.5em;
+    white-space: nowrap;
+}
+
+/* Rules listing status. "Waiting" is the ordinary state of a rule whose target is still being
+   translated or published, so it must not look like an error; "won't fire" is a rule that stays
+   broken until somebody edits it. Accent colours follow the same left-border-only approach as
+   the source badges below, which reads on both light and dark. */
+.routing-badge--active {
+    border-inline-start-color: var(--w-color-text-meta);
+    font-weight: 500;
+}
+
+.routing-badge--pending {
+    border-inline-start-color: #7f5f00;
+}
+
+.routing-badge--wont-fire {
+    border-inline-start-color: var(--w-color-text-error);
+    color: var(--w-color-text-error);
+}
+
+.routing-status-reason {
+    color: var(--w-color-text-context);
+    display: block;
+    font-size: 0.8125rem;
+    margin-block-start: 0.2rem;
+}
+
+/* Per-source accent (left border only, so it reads on both light and dark). */
+.routing-badge--cdn_geo {
+    border-inline-start-color: #0060df;
+}
+
+.routing-badge--user_agent {
+    border-inline-start-color: #008787;
+}
+
+.routing-badge--uitour {
+    border-inline-start-color: #b5007f;
+}
+
+.routing-badge--url {
+    border-inline-start-color: #7f5f00;
+}
+
+.routing-badge--type {
+    border-inline-start-width: 1px;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+/* stylelint-enable selector-class-pattern, selector-id-pattern */

--- a/media/js/cms/routing/condition-help.es6.js
+++ b/media/js/cms/routing/condition-help.es6.js
@@ -352,7 +352,18 @@ export function renderConditionHelp(select, payload, root) {
     if (!help) {
         help = document.createElement('p');
         help.className = HELP_CLASSNAME;
+        help.id =
+            (expected.id || expected.getAttribute('name')) + '-routing-help';
         expected.parentNode.appendChild(help);
+        // Screen readers announce this alongside the field's own description, not only
+        // its aria-invalid state — merge rather than overwrite any existing value.
+        const described = (expected.getAttribute('aria-describedby') || '')
+            .split(/\s+/)
+            .filter(Boolean);
+        if (described.indexOf(help.id) === -1) {
+            described.push(help.id);
+            expected.setAttribute('aria-describedby', described.join(' '));
+        }
     }
     help.textContent = buildHelpText(payload[select.value], operator);
     return help;
@@ -365,15 +376,19 @@ function wireSelect(select, payload, scope) {
     }
     select.dataset[BOUND_FLAG] = '1';
     select.addEventListener('change', function () {
-        renderConditionHelp(select, payload, scope);
+        // filterOperators first: it can replace the selected operator (e.g. resetting to
+        // the new signal's default), and the help text below reads that operator — render
+        // after, or the comma hint reflects the operator that's about to be replaced.
         filterOperators(select, payload, scope);
+        renderConditionHelp(select, payload, scope);
     });
-    // Refresh the help when the operator changes too, so the comma-separated hint
-    // appears/disappears with in / not in.
+    // Revalidate when the operator changes too — the comma-separated hint appears/disappears
+    // with in / not in, and a value that was invalid for the old operator (or vice versa)
+    // needs its error state recomputed, not just the help text.
     const operatorSelect = operatorFieldFor(select, scope);
     if (operatorSelect) {
         operatorSelect.addEventListener('change', function () {
-            renderConditionHelp(select, payload, scope);
+            validateConditionRow(select, payload, scope);
         });
     }
     // Validate this row when the value field is committed (blur/change), so a bad value
@@ -385,9 +400,10 @@ function wireSelect(select, payload, scope) {
         });
     }
     // Initial pass filters from the pre-selected signal, so an existing rule opens with
-    // its operator dropdown already scoped (and its saved operator preserved).
-    renderConditionHelp(select, payload, scope);
+    // its operator dropdown already scoped (and its saved operator preserved) — filtered
+    // before the help text reads it, same reasoning as the change handler above.
     filterOperators(select, payload, scope);
+    renderConditionHelp(select, payload, scope);
 }
 
 function revalidateRuleConditions(checkbox, payload, scope) {

--- a/media/js/cms/routing/condition-help.es6.js
+++ b/media/js/cms/routing/condition-help.es6.js
@@ -1,0 +1,551 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * User Routing — dynamic condition help text in the Wagtail admin.
+ *
+ * When an author picks a signal in a routing condition, this surfaces the valid values
+ * beneath the expected-value field: the enumerated set for enum signals, or a type hint
+ * plus the operator meanings for the rest. Everything human-readable comes from
+ * `window.ROUTING_SIGNAL_PAYLOAD` (the registry, localized server-side), so the
+ * help can never drift from the evaluator and needs no English literals here.
+ */
+
+const HELP_CLASSNAME = 'routing-condition-help';
+// Added to the help element (and aria-invalid on the field) when a value fails
+// pre-submit validation, so the same help line doubles as the correction guidance.
+const ERROR_CLASSNAME = 'routing-condition-help--invalid';
+// Added to a rule's conditions panel while its "match all" box is ticked, so the author can
+// see the conditions are inert. Styled in the admin CSS.
+const IGNORED_CLASSNAME = 'routing-conditions--ignored';
+// Wagtail's wrapper class for a nested InlinePanel — the conditions panel inside a rule.
+const NESTED_PANEL_CLASSNAME = 'w-panel--nested';
+// Flag set on a wired signal <select> so re-scans never double-bind it.
+const BOUND_FLAG = 'springfieldRoutingBound';
+// Flag set on a wired "match all" checkbox, same reason as BOUND_FLAG.
+const MATCH_ALL_BOUND_FLAG = 'springfieldRoutingMatchAllBound';
+// Flag set on the edit <form> so its submit guard is attached only once.
+const SUBMIT_GUARD_FLAG = 'springfieldRoutingSubmitGuard';
+// Set-membership operators carry a comma-separated list (matches the Python convention).
+const MEMBERSHIP_OPERATORS = ['in', 'not_in'];
+// Cap on how many known values are spelled out inline (locale/country are long); the
+// full set lives on the Signals reference page.
+const VALUE_LIST_CAP = 15;
+
+function siblingFieldFor(select, root, suffix) {
+    // The condition's signal select and its sibling fields share an inline-panel prefix
+    // and differ only by the field suffix (Wagtail InlinePanel naming).
+    const name = select.getAttribute('name') || '';
+    const siblingName = name.replace(/-signal$/, suffix);
+    if (siblingName === name) {
+        return null;
+    }
+    return root.querySelector('[name="' + siblingName + '"]');
+}
+
+function expectedFieldFor(select, root) {
+    return siblingFieldFor(select, root, '-expected_value');
+}
+
+function operatorFieldFor(select, root) {
+    return siblingFieldFor(select, root, '-operator');
+}
+
+function joinCapped(values) {
+    const shown = values.slice(0, VALUE_LIST_CAP).join(', ');
+    if (values.length > VALUE_LIST_CAP) {
+        return shown + ', … (' + values.length + ' total)';
+    }
+    return shown;
+}
+
+export function buildHelpText(meta, operator) {
+    if (!meta) {
+        return '';
+    }
+    const parts = [];
+    // Lead with what the signal means, so editors get context in the form.
+    if (meta.description) {
+        parts.push(meta.description);
+    }
+    // Then what to type. For a closed set (enum) or known-set string (locale/country),
+    // list the accepted values — the codes, since those are what the author types. The
+    // operator dropdown already shows the operators, so help never restates them.
+    if (meta.enumValues && meta.enumValues.length) {
+        parts.push(
+            meta.hint +
+                ' ' +
+                meta.enumValues.map((entry) => entry.value).join(', ')
+        );
+    } else if (meta.exampleValues && meta.exampleValues.length) {
+        // The legal set is far larger than is useful to read (any language code), so show
+        // a representative subset. `meta.hint` says these are examples, not the whole set.
+        parts.push(meta.hint + ' ' + joinCapped(meta.exampleValues));
+    } else if (meta.values && meta.values.length) {
+        parts.push(meta.hint + ' ' + joinCapped(meta.values));
+    } else if (meta.hint) {
+        parts.push(meta.hint);
+    }
+    // Only when a set-membership operator is chosen is a comma-separated list meaningful.
+    if (MEMBERSHIP_OPERATORS.indexOf(operator) !== -1 && meta.commaHint) {
+        parts.push(meta.commaHint);
+    }
+    return parts.join(' ');
+}
+
+export function filterOperators(select, payload, root) {
+    // Restrict the operator dropdown to the operators legal for the chosen signal:
+    // an author should never be offered `in` on a version signal. The server-side
+    // RoutingCondition.clean() stays the backstop; this is the usability half.
+    const scope = root || document;
+    const operatorSelect = operatorFieldFor(select, scope);
+    if (!operatorSelect) {
+        return null;
+    }
+    const meta = payload[select.value];
+    // No metadata (blank/unknown signal) ⇒ leave every operator available.
+    const legal =
+        meta && meta.operators
+            ? meta.operators.map((entry) => entry.value)
+            : null;
+
+    let selectedStillLegal = false;
+    Array.prototype.forEach.call(operatorSelect.options, function (option) {
+        const allowed = !legal || legal.indexOf(option.value) !== -1;
+        option.hidden = !allowed;
+        option.disabled = !allowed;
+        if (allowed && option.value === operatorSelect.value) {
+            selectedStillLegal = true;
+        }
+    });
+    // A now-illegal selection (e.g. after switching signals) falls back to the first
+    // legal operator so the field never submits an operator the signal rejects.
+    if (!selectedStillLegal && legal && legal.length) {
+        operatorSelect.value = legal[0];
+    }
+    return operatorSelect;
+}
+
+function splitList(value) {
+    // Set-membership values are entered one-per-line and/or comma-separated, so split on
+    // both (matches the Python RoutingCondition.expected_values() convention).
+    return String(value)
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+export function classifyValue(meta, operator, value) {
+    // Grade a condition value against RoutingCondition.clean():
+    //   'ok'   — acceptable.
+    //   'hard' — the server would reject it, it would silently mis-route (a malformed
+    //            boolean like "yess" → false), or it could never match anything (a value
+    //            outside a signal's complete set). Blocks the save when the field is
+    //            on-screen; a row on an inactive tab still falls through to the server so
+    //            Wagtail owns error/tab routing natively.
+    if (!meta) {
+        return 'ok'; // unknown/blank signal: leave it to the server
+    }
+    // Operator must be legal for the signal (filterOperators narrows the dropdown; this backstops it).
+    if (operator && meta.operators) {
+        const legal = meta.operators.map((entry) => entry.value);
+        if (legal.indexOf(operator) === -1) {
+            return 'hard';
+        }
+    }
+    const raw = String(
+        value === undefined || value === null ? '' : value
+    ).trim();
+    if (!raw) {
+        return 'hard'; // a condition always needs a value
+    }
+    const isMembership = MEMBERSHIP_OPERATORS.indexOf(operator) !== -1;
+    // Enum: a closed set the evaluator depends on — off-list is a hard block.
+    if (meta.enumValues && meta.enumValues.length) {
+        const members = meta.enumValues.map((entry) => entry.value);
+        const parts = isMembership ? splitList(value) : [raw];
+        const allMembers =
+            parts.length > 0 &&
+            parts.every((part) => members.indexOf(part) !== -1);
+        return allMembers ? 'ok' : 'hard';
+    }
+    // Known-set string (locale/country): the set is the signal's *complete* domain, so an
+    // off-list value can never match anything at runtime — the rule would be silently dead.
+    // Treated exactly like an enum; these are enums in all but declaration.
+    if (meta.values && meta.values.length) {
+        const parts = isMembership ? splitList(value) : [raw];
+        const allMembers =
+            parts.length > 0 &&
+            parts.every((part) => meta.values.indexOf(part) !== -1);
+        return allMembers ? 'ok' : 'hard';
+    }
+    if (meta.valueType === 'boolean') {
+        return /^(true|false|1|0)$/i.test(raw) ? 'ok' : 'hard';
+    }
+    if (meta.valueType === 'integer') {
+        return /^-?\d+$/.test(raw) ? 'ok' : 'hard';
+    }
+    if (meta.valueType === 'version') {
+        // Accept bare / rv:-prefixed / dotted forms (matches normalizeVersion).
+        return /^\d+(\.\d+)*$/.test(raw.replace(/^[^\d]*/, '')) ? 'ok' : 'hard';
+    }
+    // Free-text string (utm_*): any non-empty value is acceptable.
+    return 'ok';
+}
+
+export function validateExpectedValue(meta, operator, value) {
+    // The "is this value acceptable?" check that drives the inline red hint. Whether a
+    // failure also *blocks the save* is a separate question — see validateConditionRow,
+    // which additionally requires the field to be visible.
+    return classifyValue(meta, operator, value) === 'ok';
+}
+
+function setConditionError(select, payload, scope, hasError) {
+    // renderConditionHelp resets the line to the normal (valid-values) guidance; on error
+    // prepend an explicit "not valid" message so it reads as an error, not just a red box.
+    const help = renderConditionHelp(select, payload, scope);
+    if (help) {
+        if (hasError) {
+            help.classList.add(ERROR_CLASSNAME);
+            const meta = payload[select.value];
+            if (meta && meta.invalidHint) {
+                help.textContent = meta.invalidHint + ' ' + help.textContent;
+            }
+        } else {
+            help.classList.remove(ERROR_CLASSNAME);
+        }
+    }
+    const expected = expectedFieldFor(select, scope);
+    if (expected) {
+        if (hasError) {
+            expected.setAttribute('aria-invalid', 'true');
+        } else {
+            expected.removeAttribute('aria-invalid');
+        }
+    }
+    return expected;
+}
+
+// --- match-all rules ignore their conditions -------------------------------
+//
+// The serializer drops conditions from a match-all rule, so the editor has to show that
+// rather than leaving an author looking at conditions they wrote which will never be
+// consulted. The *explanation* is server-rendered and translated (the checkbox's help text
+// and the conditions panel's); all this adds is the live state.
+
+function matchAllCheckboxFor(select, root) {
+    // "…-conditions-3-signal" belongs to the rule whose checkbox is "…-match_all".
+    const name = select.getAttribute('name') || '';
+    const checkboxName = name.replace(/-conditions-\d+-signal$/, '-match_all');
+    if (checkboxName === name) {
+        return null;
+    }
+    return root.querySelector('[name="' + checkboxName + '"]');
+}
+
+function conditionIsIgnored(select, root) {
+    const checkbox = matchAllCheckboxFor(select, root);
+    return !!(checkbox && checkbox.checked);
+}
+
+function conditionsPanelFor(checkbox, root) {
+    // Derived from the formset naming rather than the surrounding markup: Wagtail wraps a
+    // nested InlinePanel's rows in "id_<prefix>-FORMS", and the panel around that carries
+    // the heading and the Add button. Falling back to the rows alone keeps the cue working
+    // if that outer wrapper is ever restyled.
+    const name = checkbox.getAttribute('name') || '';
+    const formsId = 'id_' + name.replace(/-match_all$/, '-conditions-FORMS');
+    const forms = root.querySelector('[id="' + formsId + '"]');
+    if (!forms) {
+        return null;
+    }
+    const panel =
+        typeof forms.closest === 'function'
+            ? forms.closest('.' + NESTED_PANEL_CLASSNAME)
+            : null;
+    return panel || forms;
+}
+
+export function syncIgnoredConditions(checkbox, root) {
+    const scope = root || document;
+    const panel = conditionsPanelFor(checkbox, scope);
+    if (!panel) {
+        return null;
+    }
+    if (checkbox.checked) {
+        panel.classList.add(IGNORED_CLASSNAME);
+    } else {
+        panel.classList.remove(IGNORED_CLASSNAME);
+    }
+    return panel;
+}
+
+function isFieldVisible(el) {
+    // "Visible" ⇒ the field is laid out, i.e. the author is on the routing tab. `offsetParent`
+    // is null (and getClientRects() empty) for a `display:none` ancestor — exactly how Wagtail
+    // hides an inactive tab panel — and for a detached node. We deliberately read *rendering*,
+    // not Wagtail tab state (which is brittle and fights Wagtail's own multi-tab error routing).
+    if (!el) {
+        return false;
+    }
+    return !!(el.offsetParent || el.getClientRects().length);
+}
+
+function validateConditionRow(select, payload, scope) {
+    // Skip rows being deleted — they won't be saved.
+    const del = siblingFieldFor(select, scope, '-DELETE');
+    if (del && del.checked) {
+        setConditionError(select, payload, scope, false);
+        return true;
+    }
+    // Skip conditions the server will ignore anyway: blocking a save on a value that has
+    // no effect would be the editor contradicting itself twice over.
+    if (conditionIsIgnored(select, scope)) {
+        setConditionError(select, payload, scope, false);
+        return true;
+    }
+    const operatorSelect = operatorFieldFor(select, scope);
+    const expected = expectedFieldFor(select, scope);
+    const status = classifyValue(
+        payload[select.value],
+        operatorSelect ? operatorSelect.value : '',
+        expected ? expected.value : ''
+    );
+    // Surface the red hint inline for any failure (on blur/change and on a blocked submit).
+    setConditionError(select, payload, scope, status !== 'ok');
+    // Only block when the field is actually on-screen: a row on an inactive tab falls
+    // through to the server, where Wagtail owns error/tab routing natively.
+    if (status === 'hard' && isFieldVisible(expected)) {
+        return false;
+    }
+    return true;
+}
+
+export function validateConditions(root, payload) {
+    const scope = root || document;
+    const selects = scope.querySelectorAll('select[name$="-signal"]');
+    let firstInvalid = null;
+    Array.prototype.forEach.call(selects, function (select) {
+        if (!validateConditionRow(select, payload, scope) && !firstInvalid) {
+            firstInvalid = expectedFieldFor(select, scope);
+        }
+    });
+    if (firstInvalid && typeof firstInvalid.focus === 'function') {
+        firstInvalid.focus();
+    }
+    return firstInvalid === null;
+}
+
+export function renderConditionHelp(select, payload, root) {
+    const scope = root || document;
+    const expected = expectedFieldFor(select, scope);
+    if (!expected || !expected.parentNode) {
+        return null;
+    }
+    // The comma hint depends on the chosen operator, so read it here.
+    const operatorSelect = operatorFieldFor(select, scope);
+    const operator = operatorSelect ? operatorSelect.value : '';
+    let help = expected.parentNode.querySelector('.' + HELP_CLASSNAME);
+    if (!help) {
+        help = document.createElement('p');
+        help.className = HELP_CLASSNAME;
+        expected.parentNode.appendChild(help);
+    }
+    help.textContent = buildHelpText(payload[select.value], operator);
+    return help;
+}
+
+function wireSelect(select, payload, scope) {
+    // Idempotent: a select is bound once, so re-scanning after DOM changes is safe.
+    if (select.dataset[BOUND_FLAG] === '1') {
+        return;
+    }
+    select.dataset[BOUND_FLAG] = '1';
+    select.addEventListener('change', function () {
+        renderConditionHelp(select, payload, scope);
+        filterOperators(select, payload, scope);
+    });
+    // Refresh the help when the operator changes too, so the comma-separated hint
+    // appears/disappears with in / not in.
+    const operatorSelect = operatorFieldFor(select, scope);
+    if (operatorSelect) {
+        operatorSelect.addEventListener('change', function () {
+            renderConditionHelp(select, payload, scope);
+        });
+    }
+    // Validate this row when the value field is committed (blur/change), so a bad value
+    // turns red with its message immediately — not only when the author tries to save.
+    const expected = expectedFieldFor(select, scope);
+    if (expected) {
+        expected.addEventListener('change', function () {
+            validateConditionRow(select, payload, scope);
+        });
+    }
+    // Initial pass filters from the pre-selected signal, so an existing rule opens with
+    // its operator dropdown already scoped (and its saved operator preserved).
+    renderConditionHelp(select, payload, scope);
+    filterOperators(select, payload, scope);
+}
+
+function revalidateRuleConditions(checkbox, payload, scope) {
+    const selects = scope.querySelectorAll('select[name$="-signal"]');
+    Array.prototype.forEach.call(selects, function (select) {
+        if (matchAllCheckboxFor(select, scope) === checkbox) {
+            validateConditionRow(select, payload, scope);
+        }
+    });
+}
+
+function wireMatchAll(checkbox, payload, scope) {
+    // Idempotent, like wireSelect: the observer re-scans on every DOM change.
+    if (checkbox.dataset[MATCH_ALL_BOUND_FLAG] === '1') {
+        return;
+    }
+    checkbox.dataset[MATCH_ALL_BOUND_FLAG] = '1';
+    checkbox.addEventListener('change', function () {
+        syncIgnoredConditions(checkbox, scope);
+        // Ticking clears the red hints on the conditions just made inert; unticking brings
+        // back any that are genuinely wrong. Row-by-row rather than validateConditions(),
+        // which moves focus to the first invalid field — jarring on a checkbox click.
+        revalidateRuleConditions(checkbox, payload, scope);
+    });
+    // Initial pass, so a saved match-all rule opens with its conditions already dimmed.
+    syncIgnoredConditions(checkbox, scope);
+}
+
+function wireAll(payload, scope) {
+    const selects = scope.querySelectorAll('select[name$="-signal"]');
+    Array.prototype.forEach.call(selects, function (select) {
+        wireSelect(select, payload, scope);
+    });
+    const checkboxes = scope.querySelectorAll(
+        'input[type="checkbox"][name$="-match_all"]'
+    );
+    Array.prototype.forEach.call(checkboxes, function (checkbox) {
+        wireMatchAll(checkbox, payload, scope);
+    });
+}
+
+function isRoutingForm(form) {
+    return !!(
+        form &&
+        typeof form.querySelector === 'function' &&
+        form.querySelector('select[name$="-signal"]')
+    );
+}
+
+function attachSubmitGuard(payload, scope) {
+    // Block a save with an illegal condition value inline, instead of round-tripping to a
+    // server error. The Wagtail page form is `novalidate` and saves via a Stimulus
+    // controller whose "Saving…" spinner starts on the button *click* — so intercepting the
+    // `submit` event is too late (the spinner is already up when we cancel the POST). We
+    // therefore guard the submit-button **click** in the CAPTURE phase (runs before
+    // Wagtail's handlers), with a `submit` backstop for keyboard/programmatic submits.
+    // In the real admin `scope` is `document`; in unit tests it's the (detached) form.
+    const isForm = scope.tagName === 'FORM';
+    const target = isForm
+        ? scope
+        : typeof document !== 'undefined'
+          ? document
+          : null;
+    const flagHost = isForm
+        ? scope
+        : typeof document !== 'undefined'
+          ? document.documentElement
+          : null;
+    if (!target || !flagHost || flagHost.dataset[SUBMIT_GUARD_FLAG] === '1') {
+        return;
+    }
+    flagHost.dataset[SUBMIT_GUARD_FLAG] = '1';
+
+    target.addEventListener(
+        'click',
+        function (event) {
+            const node = event.target;
+            // Save/Publish are <button type="submit">; the "Add rule/condition" buttons
+            // are type="button", so they are intentionally not matched here.
+            const button =
+                node && node.closest
+                    ? node.closest(
+                          'button[type="submit"], input[type="submit"]'
+                      )
+                    : null;
+            if (!button) {
+                return;
+            }
+            const form =
+                button.form || (button.closest && button.closest('form'));
+            if (!isRoutingForm(form)) {
+                return;
+            }
+            if (!validateConditions(form, payload)) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+        },
+        true
+    );
+
+    target.addEventListener(
+        'submit',
+        function (event) {
+            if (!isRoutingForm(event.target)) {
+                return;
+            }
+            if (!validateConditions(event.target, payload)) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+        },
+        true
+    );
+}
+
+export function initConditionHelp(options) {
+    const opts = options || {};
+    const payload =
+        opts.payload ||
+        (typeof window !== 'undefined'
+            ? window.ROUTING_SIGNAL_PAYLOAD
+            : null) ||
+        {};
+    const scope = opts.root || document;
+
+    wireAll(payload, scope);
+    attachSubmitGuard(payload, scope);
+
+    // Wagtail hydrates nested InlinePanel rows client-side *after* load, and "Add
+    // rule/condition" inserts more rows later — none of which the one-shot scan above
+    // sees. Without this observer the help never renders on those rows (the confirmed
+    // bug). Re-scan (idempotently) whenever nodes are added.
+    const observeTarget =
+        opts.root || (typeof document !== 'undefined' ? document.body : null);
+    if (observeTarget && typeof MutationObserver !== 'undefined') {
+        const observer = new MutationObserver(function () {
+            wireAll(payload, scope);
+        });
+        observer.observe(observeTarget, { childList: true, subtree: true });
+        return observer;
+    }
+    return null;
+}
+
+// Auto-run in the admin, but only once the payload global is present (the insert_editor_js
+// hook sets it just before this script). Skipping when it's absent keeps the observer out
+// of non-editor pages and unit tests, which drive the exported functions directly.
+if (
+    typeof document !== 'undefined' &&
+    typeof window !== 'undefined' &&
+    window.ROUTING_SIGNAL_PAYLOAD
+) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            initConditionHelp();
+        });
+    } else {
+        initConditionHelp();
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -243,7 +243,8 @@
     },
     {
       "files": [
-        "css/cms/wagtail-admin.css"
+        "css/cms/wagtail-admin.css",
+        "css/cms/routing/admin.css"
       ],
       "name": "wagtail-admin"
     },
@@ -865,6 +866,12 @@
         "js/cms/routing/resolver.es6.js"
       ],
       "name": "cms_routing_resolver"
+    },
+    {
+      "files": [
+        "js/cms/routing/condition-help.es6.js"
+      ],
+      "name": "wagtailadmin-routing-help"
     }
   ]
 }

--- a/springfield/admin/templates/wagtailadmin/routing/rules_index.html
+++ b/springfield/admin/templates/wagtailadmin/routing/rules_index.html
@@ -1,0 +1,54 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/. #}
+{% extends "wagtailadmin/generic/base.html" %}
+{% comment %} SKIP LICENSE INSERTION {% endcomment %}
+
+{% block main_content %}
+  <p class="help-block help-info">
+    Browse-only. Routing rules are authored inline on each page's “User Routing” tab —
+    open a page below to add or edit its rules.
+  </p>
+
+  <table class="listing">
+    <thead>
+      <tr>
+        <th>Rule</th>
+        <th>Page</th>
+        <th>Target</th>
+        <th>Conditions</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+        <tr>
+          <td>{{ row.rule.name|default:"—" }}</td>
+          <td>
+            <a href="{% url 'wagtailadmin_pages:edit' row.rule.page_id %}">{{ row.rule.page }}</a>
+          </td>
+          <td>{{ row.rule.target|default:"—" }}</td>
+          <td>{{ row.rule.conditions.count }}</td>
+          <td>
+            {% if row.problem %}
+              {# Two different situations, deliberately styled differently: a target that is
+                 simply not translated or published *yet* clears itself, while the rest need
+                 an author to change the rule. One badge for both would train authors to
+                 ignore the column during every normal staged translation. #}
+              {% if row.problem.pending %}
+                <span class="routing-badge routing-badge--pending">Waiting</span>
+              {% else %}
+                <span class="routing-badge routing-badge--wont-fire">Won’t fire</span>
+              {% endif %}
+              <span class="routing-status-reason">{{ row.problem.message }}</span>
+            {% else %}
+              <span class="routing-badge routing-badge--active">Will fire</span>
+            {% endif %}
+          </td>
+        </tr>
+      {% empty %}
+        <tr>
+          <td colspan="5">No routing rules have been created yet.</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/springfield/admin/templates/wagtailadmin/routing/rules_index.html
+++ b/springfield/admin/templates/wagtailadmin/routing/rules_index.html
@@ -1,21 +1,24 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/. #}
 {% extends "wagtailadmin/generic/base.html" %}
 {% comment %} SKIP LICENSE INSERTION {% endcomment %}
+{% load i18n %}
 
 {% block main_content %}
   <p class="help-block help-info">
-    Browse-only. Routing rules are authored inline on each page's “User Routing” tab —
-    open a page below to add or edit its rules.
+    {% blocktrans trimmed %}
+      Browse-only. Routing rules are authored inline on each page's “User Routing” tab —
+      open a page below to add or edit its rules.
+    {% endblocktrans %}
   </p>
 
   <table class="listing">
     <thead>
       <tr>
-        <th>Rule</th>
-        <th>Page</th>
-        <th>Target</th>
-        <th>Conditions</th>
-        <th>Status</th>
+        <th>{% trans "Rule" %}</th>
+        <th>{% trans "Page" %}</th>
+        <th>{% trans "Target" %}</th>
+        <th>{% trans "Conditions" %}</th>
+        <th>{% trans "Status" %}</th>
       </tr>
     </thead>
     <tbody>
@@ -34,19 +37,19 @@
                  an author to change the rule. One badge for both would train authors to
                  ignore the column during every normal staged translation. #}
               {% if row.problem.pending %}
-                <span class="routing-badge routing-badge--pending">Waiting</span>
+                <span class="routing-badge routing-badge--pending">{% trans "Waiting" %}</span>
               {% else %}
-                <span class="routing-badge routing-badge--wont-fire">Won’t fire</span>
+                <span class="routing-badge routing-badge--wont-fire">{% trans "Won’t fire" %}</span>
               {% endif %}
               <span class="routing-status-reason">{{ row.problem.message }}</span>
             {% else %}
-              <span class="routing-badge routing-badge--active">Will fire</span>
+              <span class="routing-badge routing-badge--active">{% trans "Will fire" %}</span>
             {% endif %}
           </td>
         </tr>
       {% empty %}
         <tr>
-          <td colspan="5">No routing rules have been created yet.</td>
+          <td colspan="5">{% trans "No routing rules have been created yet." %}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/springfield/admin/templates/wagtailadmin/routing/signals_reference.html
+++ b/springfield/admin/templates/wagtailadmin/routing/signals_reference.html
@@ -1,0 +1,62 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/. #}
+{% extends "wagtailadmin/generic/base.html" %}
+{% comment %} SKIP LICENSE INSERTION {% endcomment %}
+{% load i18n %}
+
+{% block main_content %}
+  <div class="routing-signals-reference">
+    <p class="help-block help-info">
+      {% trans "Auto-generated from the signal registry — this is exactly what the client evaluator reads." %}
+    </p>
+
+    <p class="routing-signals-reference__note">
+      {% blocktrans trimmed %}
+        Signals marked <span class="routing-badge routing-badge--uitour">UITour</span> are read from
+        Firefox only, via a per-key browser ping, and add roughly 500&nbsp;ms to the redirect for a
+        matched visitor. Prefer the faster URL and User-Agent signals where they suffice.
+      {% endblocktrans %}
+    </p>
+
+    <table class="listing routing-signals-reference__table">
+      <thead>
+        <tr>
+          <th>{% trans "Signal" %}</th>
+          <th>{% trans "Source" %}</th>
+          <th>{% trans "Type" %}</th>
+          <th>{% trans "Description" %}</th>
+          <th>{% trans "Operators" %}</th>
+          <th>{% trans "Values" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for signal in signals %}
+          <tr>
+            <td><code class="routing-signal-name">{{ signal.name }}</code></td>
+            <td>
+              <span class="routing-badge routing-badge--{{ signal.source_key }}">{{ signal.source }}</span>
+            </td>
+            <td><span class="routing-badge routing-badge--type">{{ signal.value_type }}</span></td>
+            <td class="routing-signal-description">{{ signal.description }}</td>
+            <td class="routing-operators">
+              {% for operator in signal.operators %}{{ operator }}{% if not forloop.last %}, {% endif %}{% endfor %}
+            </td>
+            <td class="routing-values">
+              {% if signal.enum_values %}
+                {% for value in signal.enum_values %}<code>{{ value.value }}</code>{% if not forloop.last %}, {% endif %}{% endfor %}
+              {% elif signal.values %}
+                <details class="routing-value-list">
+                  <summary>{% blocktrans count counter=signal.values|length %}{{ counter }} value{% plural %}{{ counter }} values{% endblocktrans %}</summary>
+                  <div class="routing-value-list__items">
+                    {% for value in signal.values %}<code>{{ value }}</code>{% if not forloop.last %}, {% endif %}{% endfor %}
+                  </div>
+                </details>
+              {% else %}
+                <span class="routing-signal-freetext">{{ signal.value_example }}</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/springfield/cms/routing/admin.py
+++ b/springfield/cms/routing/admin.py
@@ -1,0 +1,126 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Admin-facing helpers for the routing framework.
+
+``build_signal_payload`` serializes the registry into the payload the condition-help
+admin JS consumes. It is the *only* source of truth for the dynamic help
+text, so the help can never drift from what the evaluator actually reads. Every human
+string is pre-localized server-side from a ``gettext_lazy`` source (the registry's own
+labels or the value-type hints below) — no raw English literals.
+"""
+
+from django.utils.translation import gettext_lazy as _
+
+from springfield.cms.routing.signals import SOURCE_LABELS, Source, ValueType, registry
+from springfield.cms.routing.value_lists import known_value_lists, suggested_value_lists
+
+# "What to type" hint shown beneath the expected-value field. Value-focused only — the
+# operator dropdown already lists the legal operators, so hints never restate them.
+VALUE_TYPE_HINTS = {
+    ValueType.ENUM: _("Enter one of these values:"),
+    ValueType.STRING: _("Free text."),
+    ValueType.BOOLEAN: _("Enter “true” or “false”."),
+    ValueType.VERSION: _("Enter a version, e.g. 129 or 130.0.1."),
+    ValueType.INTEGER: _("Enter a whole number."),
+}
+
+# Appended to the help only when a set-membership operator (in / not in) is selected.
+COMMA_HINT = _("Separate multiple values with commas.")
+
+# Prepended to the help when a value fails client-side validation, so the flagged field
+# reads as an error and not just a red outline.
+INVALID_HINT = _("That value isn’t valid.")
+
+# Lead-in for STRING signals that carry a known value list (locale / country).
+VALUE_LIST_HINT = _("Enter one of these values:")
+
+# Lead-in where the legal set is far larger than what is worth listing — any valid
+# language code is accepted, so the shown values are examples rather than the whole set.
+EXAMPLE_LIST_HINT = _("Enter a language code. Languages we publish in include:")
+
+# Short, editor-facing "what to type" hint shown in the reference page's Values column for
+# signals that have no fixed set (enum values / locale / country are shown as the values
+# themselves instead). Localized.
+VALUE_TYPE_EXAMPLES = {
+    ValueType.STRING: _("Free text"),
+    ValueType.BOOLEAN: _("true or false"),
+    ValueType.VERSION: _("e.g. 129 or 130.0.1"),
+    ValueType.INTEGER: _("e.g. 30"),
+}
+
+
+def build_signal_payload():
+    """Serialize the registry for the admin JS: signal name -> help metadata.
+
+    Strings are resolved to the active admin locale here (server-side), so the JS only
+    concatenates already-localized text.
+    """
+    value_lists = known_value_lists()
+    suggestions = suggested_value_lists()
+    comma_hint = str(COMMA_HINT)
+    invalid_hint = str(INVALID_HINT)
+    payload = {}
+    for signal in registry:
+        entry = {
+            "valueType": signal.value_type.value,
+            # Short signal description leads the help so editors know what it means.
+            "description": str(signal.description),
+            "hint": str(VALUE_TYPE_HINTS[signal.value_type]),
+            "commaHint": comma_hint,
+            "invalidHint": invalid_hint,
+            "operators": [{"value": operator.value, "label": str(operator.label)} for operator in signal.operators],
+            "enumValues": [],
+            "values": [],
+            # Shown instead of ``values`` when the legal set is too large to be useful
+            # guidance; validation still runs against the full ``values``.
+            "exampleValues": [],
+        }
+        if signal.value_type is ValueType.ENUM:
+            entry["enumValues"] = [{"value": enum_value.value, "label": str(enum_value.label)} for enum_value in signal.enum_values]
+        if signal.name in value_lists:
+            # A known value set surfaced as the primary help line, with a
+            # values-oriented lead-in instead of the generic STRING "available operators".
+            entry["values"] = value_lists[signal.name]
+            entry["hint"] = str(VALUE_LIST_HINT)
+        if signal.name in suggestions:
+            entry["exampleValues"] = suggestions[signal.name]
+            entry["hint"] = str(EXAMPLE_LIST_HINT)
+        payload[signal.name] = entry
+    return payload
+
+
+def build_signal_reference():
+    """Rows for the auto-generated Signals reference page.
+
+    Generated straight from the registry — one row per registered signal — so the
+    reference can never drift from the values the evaluator actually reads. Strings are
+    left lazy so the template localizes them; the honest descriptions come
+    through unchanged.
+    """
+    value_lists = known_value_lists()
+    rows = []
+    for signal in registry:
+        rows.append(
+            {
+                "name": signal.name,
+                "description": signal.description,
+                "source": SOURCE_LABELS[signal.source],
+                # Stable source enum value for the per-source badge CSS class + the UITour
+                # note; the human label stays localized in ``source`` above.
+                "source_key": signal.source.value,
+                "is_uitour": signal.source is Source.UITOUR,
+                "value_type": signal.value_type.value,
+                "operators": [operator.label for operator in signal.operators],
+                "enum_values": [{"value": enum_value.value, "label": enum_value.label} for enum_value in signal.enum_values],
+                # Request-time value list for known-set STRING signals (locale / country),
+                # shown collapsed on the reference page; empty for free-text signals.
+                "values": value_lists.get(signal.name, []),
+                # "What to type" hint for signals with no fixed set (true/false, version
+                # examples, whole number, free text); enums/known-sets show their values.
+                "value_example": VALUE_TYPE_EXAMPLES.get(signal.value_type),
+                "browser_state_key": signal.browser_state_key,
+            }
+        )
+    return rows

--- a/springfield/cms/routing/admin_views.py
+++ b/springfield/cms/routing/admin_views.py
@@ -4,9 +4,12 @@
 
 """Admin views for the "User Routing" submenu."""
 
+from django.db.models import Prefetch
 from django.views.generic import TemplateView
 
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
+from wagtail.models import Page
+from wagtail.permissions import page_permission_policy
 
 from springfield.cms.routing.admin import build_signal_reference
 from springfield.cms.routing.models import RoutingRule
@@ -26,7 +29,13 @@ class RoutingRulesIndexView(WagtailAdminTemplateMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        rules = RoutingRule.objects.select_related("page", "target").prefetch_related("conditions").order_by("page_id", "sort_order", "pk")
+        editable_pages = page_permission_policy.instances_user_has_permission_for(self.request.user, "change")
+        rules = (
+            RoutingRule.objects.filter(page__in=editable_pages)
+            .select_related("page", "target")
+            .prefetch_related("conditions")
+            .order_by("page_id", "sort_order", "pk")
+        )
         context["rows"] = _rows_with_status(rules)
         return context
 
@@ -40,15 +49,22 @@ def _rows_with_status(rules):
     target belongs to a different page's subtree, or has no version in this page's language.
 
     Rules arrive ordered by page, so the per-page lookup runs once per page rather than once
-    per rule.
+    per rule. Pages are re-fetched with their own rules/targets/conditions prefetched, since
+    ``rule.page`` (from the rules' own ``select_related``) doesn't carry that — reusing it
+    would make ``rule_problems`` re-query per page.
     """
+    rules = list(rules)
+    page_ids = {rule.page_id for rule in rules}
+    prefetched_rules = RoutingRule.objects.select_related("target").prefetch_related("conditions")
+    pages = Page.objects.filter(pk__in=page_ids).prefetch_related(Prefetch("routing_rules", queryset=prefetched_rules))
+    prefetched_pages = {page.pk: page for page in pages}
     rows = []
     problems = {}
     current_page_id = None
     for rule in rules:
         if rule.page_id != current_page_id:
             current_page_id = rule.page_id
-            problems = rule_problems(rule.page)
+            problems = rule_problems(prefetched_pages[rule.page_id])
         rows.append({"rule": rule, "problem": problems.get(rule.pk)})
     return rows
 

--- a/springfield/cms/routing/admin_views.py
+++ b/springfield/cms/routing/admin_views.py
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Admin views for the "User Routing" submenu."""
+
+from django.views.generic import TemplateView
+
+from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
+
+from springfield.cms.routing.admin import build_signal_reference
+from springfield.cms.routing.models import RoutingRule
+from springfield.cms.routing.resolver import rule_problems
+
+
+class RoutingRulesIndexView(WagtailAdminTemplateMixin, TemplateView):
+    """A read/browse aggregation of routing rules across pages.
+
+    Purely a listing: rules are only ever authored inline on their canonical page, so
+    there is deliberately **no add affordance** here.
+    """
+
+    template_name = "wagtailadmin/routing/rules_index.html"
+    page_title = "User Routing rules"
+    header_icon = "list-ul"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        rules = RoutingRule.objects.select_related("page", "target").prefetch_related("conditions").order_by("page_id", "sort_order", "pk")
+        context["rows"] = _rows_with_status(rules)
+        return context
+
+
+def _rows_with_status(rules):
+    """Pair each rule with why it cannot route anyone, or ``None`` if it can.
+
+    A rule that is dropped at serve time looks completely healthy in a plain listing: the
+    target column shows a real page, the condition count looks right, and nothing says the
+    rule is inert. Several of the ways that happens are invisible in the row itself — the
+    target belongs to a different page's subtree, or has no version in this page's language.
+
+    Rules arrive ordered by page, so the per-page lookup runs once per page rather than once
+    per rule.
+    """
+    rows = []
+    problems = {}
+    current_page_id = None
+    for rule in rules:
+        if rule.page_id != current_page_id:
+            current_page_id = rule.page_id
+            problems = rule_problems(rule.page)
+        rows.append({"rule": rule, "problem": problems.get(rule.pk)})
+    return rows
+
+
+class RoutingSignalsReferenceView(WagtailAdminTemplateMixin, TemplateView):
+    """The auto-generated Signals reference page.
+
+    Renders the whole registry as a table, generated from the registry so it never
+    drifts from what the evaluator reads.
+    """
+
+    template_name = "wagtailadmin/routing/signals_reference.html"
+    page_title = "Routing signals reference"
+    header_icon = "help"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["signals"] = build_signal_reference()
+        return context

--- a/springfield/cms/routing/mixins.py
+++ b/springfield/cms/routing/mixins.py
@@ -42,32 +42,9 @@ ROUTING_TAB_HELP = _(
 
 
 class RoutingPageForm(WagtailAdminPageForm):
-    """Page form owning the admin-side routing validation.
-
-    Two things live here rather than on the models, both because of *when* Wagtail runs
-    things during a save:
-
-    * **Condition-floor.** A rule with no conditions matches every triggered
-      visitor, so it must opt in via ``match_all``. ``RoutingRule.clean()`` can't enforce
-      this — modelcluster attaches a rule's nested conditions to the instance only at
-      *save* time, after validation, so a model-level count check sees zero conditions
-      and rejects valid rules. The floor is checked here, where the nested ``conditions``
-      formset is inspectable, and the error lands on the rule's ``match_all`` field.
-
-    * **Hidden-tab formsets.** The routing tab is hidden on non-canonical
-      instances (``RoutingObjectList.is_shown``), so its ``routing_rules`` /
-      ``routing_config`` formsets aren't rendered there — nor on the *add* form, where a
-      new page isn't yet canonical. Their management forms are therefore absent from the
-      POST, and validating/saving them would block the page entirely with ManagementForm
-      errors. So they are excluded from validation/save on non-canonical instances.
-      ``self.formsets`` is left intact outside that window so panel binding (which reads
-      ``self.form.formsets[name]``) still works when the form re-renders.
-
-    * **Kill-switch record.** ``__init__`` auto-creates the ``RoutingConfig`` for
-      canonical instances so the pause checkbox always renders (no "Add" step) — see
-      ``__init__``; this replaces a panel ``min_num``, which can't be satisfied by an
-      unchanged empty form.
-    """
+    """Page form owning admin-side routing validation: the condition floor, target/signal
+    scope guards, hidden-formset scoping on non-canonical instances, and kill-switch
+    auto-create — see each method for why it can't live on the model or a panel."""
 
     # Formsets owned by the routing tab (hidden on non-canonical instances).
     ROUTING_FORMSETS = ("routing_rules", "routing_config")

--- a/springfield/cms/routing/mixins.py
+++ b/springfield/cms/routing/mixins.py
@@ -4,20 +4,222 @@
 
 """The routing adoption mixin.
 
-The whole surface a consumer page type touches: two overridable hooks — a **trigger** and
-an **eligibility predicate** — and the serve path adapted onto them. It adds no database
-fields, so adopting it produces no migration.
-
-The "User Routing" edit tab and its page form reopen this class in a later change.
+``RoutingMixin`` is the whole adoption surface a consumer page type touches. It
+declares exactly two overridable hooks — a **trigger** and an **eligibility predicate**
+— adapts the serve path onto them, and wires a "User Routing" edit tab holding the
+rules and kill-switch panels. The tab's condition signals are narrowed from the trigger
+itself, so nothing extra is declared for that. It adds **no database fields** (all state
+lives in the routing tables keyed to ``wagtailcore.Page``), so adopting it produces **no
+migration**.
 """
 
+from contextlib import contextmanager
+
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 import waffle
+from wagtail.admin.forms import WagtailAdminPageForm
+from wagtail.admin.panels import HelpPanel, InlinePanel, MultiFieldPanel, ObjectList, TabbedInterface
+from wagtail.utils.decorators import cached_classmethod
 
 from springfield.cms.routing.dispatch import SERVE_PREVIEW, SERVE_RESOLVER, USER_ROUTING_SWITCH, decide_routing
-from springfield.cms.routing.models import RoutingConfig
+from springfield.cms.routing.models import RoutingConfig, localized_target, rule_panels
 from springfield.cms.routing.params import LOOP_BREAKER_PARAM
+from springfield.cms.routing.signals import registry
+
+# Consumer-agnostic guidance shown at the top of the "User Routing" tab. Kept
+# generic (no per-consumer specifics) and localized; HTML is allowed in a HelpPanel.
+ROUTING_TAB_HELP = _(
+    "<p>Rules are checked <strong>top to bottom, first match wins</strong> — drag to reorder. "
+    "A visitor is routed to the first rule whose conditions all match; if none match, they stay "
+    "on this page.</p>"
+    "<p>Each rule needs at least one condition, or “Match all triggered visitors” to route everyone. "
+    "The <strong>kill switch</strong> in Options pauses routing without deleting any rules — "
+    "it takes effect when you <strong>publish</strong>, like every other change on this page, "
+    "and reaches already-cached pages shortly after.</p>"
+)
+
+
+class RoutingPageForm(WagtailAdminPageForm):
+    """Page form owning the admin-side routing validation.
+
+    Two things live here rather than on the models, both because of *when* Wagtail runs
+    things during a save:
+
+    * **Condition-floor.** A rule with no conditions matches every triggered
+      visitor, so it must opt in via ``match_all``. ``RoutingRule.clean()`` can't enforce
+      this — modelcluster attaches a rule's nested conditions to the instance only at
+      *save* time, after validation, so a model-level count check sees zero conditions
+      and rejects valid rules. The floor is checked here, where the nested ``conditions``
+      formset is inspectable, and the error lands on the rule's ``match_all`` field.
+
+    * **Hidden-tab formsets.** The routing tab is hidden on non-canonical
+      instances (``RoutingObjectList.is_shown``), so its ``routing_rules`` /
+      ``routing_config`` formsets aren't rendered there — nor on the *add* form, where a
+      new page isn't yet canonical. Their management forms are therefore absent from the
+      POST, and validating/saving them would block the page entirely with ManagementForm
+      errors. So they are excluded from validation/save on non-canonical instances.
+      ``self.formsets`` is left intact outside that window so panel binding (which reads
+      ``self.form.formsets[name]``) still works when the form re-renders.
+
+    * **Kill-switch record.** ``__init__`` auto-creates the ``RoutingConfig`` for
+      canonical instances so the pause checkbox always renders (no "Add" step) — see
+      ``__init__``; this replaces a panel ``min_num``, which can't be satisfied by an
+      unchanged empty form.
+    """
+
+    # Formsets owned by the routing tab (hidden on non-canonical instances).
+    ROUTING_FORMSETS = ("routing_rules", "routing_config")
+
+    def __init__(self, *args, **kwargs):
+        # Ensure a canonical page always shows its kill-switch checkbox with no "Add" step.
+        # Add an (unsaved) RoutingConfig to the instance's in-memory cluster BEFORE
+        # the formsets are built, so the checkbox renders on the very first load and the
+        # record is persisted only when the page is saved. Done here rather than via a
+        # panel ``min_num`` (an unchanged empty form can't satisfy ``validate_min``) and via
+        # the cluster rather than a DB write (which a same-request formset can miss).
+        instance = kwargs.get("instance")
+        if instance is not None and getattr(instance, "pk", None):
+            predicate = getattr(instance, "is_routing_canonical", None)
+            if callable(predicate) and predicate() and not instance.routing_config.all():
+                instance.routing_config.add(RoutingConfig())
+        super().__init__(*args, **kwargs)
+
+    def _is_routing_canonical(self):
+        predicate = getattr(self.instance, "is_routing_canonical", None)
+        return bool(callable(predicate) and predicate())
+
+    @contextmanager
+    def _routing_formsets_scoped(self):
+        """Temporarily drop the routing formsets on non-canonical instances."""
+        if self._is_routing_canonical():
+            yield
+            return
+        original = self.formsets
+        self.formsets = {name: formset for name, formset in original.items() if name not in self.ROUTING_FORMSETS}
+        try:
+            yield
+        finally:
+            self.formsets = original
+
+    def is_valid(self):
+        with self._routing_formsets_scoped():
+            return super().is_valid()
+
+    def save(self, commit=True):
+        with self._routing_formsets_scoped():
+            return super().save(commit=commit)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        # On non-canonical instances the routing formsets are scoped out (above), so this
+        # is a no-op there; on canonical instances it enforces the condition-floor.
+        rules_formset = self.formsets.get("routing_rules")
+        if rules_formset is not None:
+            # Force nested validation now: ClusterForm validates child formsets only
+            # after this form's clean() runs, so the conditions aren't populated yet.
+            rules_formset.is_valid()
+            for rule_form in rules_formset.forms:
+                self._enforce_condition_floor(rule_form)
+                self._enforce_target_scope(rule_form)
+                self._enforce_signal_scope(rule_form)
+        return cleaned_data
+
+    def _enforce_signal_scope(self, rule_form):
+        # A condition on the surface's own arming param can never be useful: the
+        # resolver only runs once that param already holds its arming value, so the
+        # condition is always true (or, for any other value, always false). The narrowed
+        # dropdown keeps authors away from it; this makes it an actual rejection rather
+        # than a hidden <option>, and also covers the ORM/API path into the admin.
+        param = type(self.instance).get_routing_arming_param()
+        if not param:
+            return
+        conditions_formset = rule_form.formsets.get("conditions")
+        if conditions_formset is None:
+            return
+        for condition_form in conditions_formset.forms:
+            data = getattr(condition_form, "cleaned_data", None)
+            if not data or data.get("DELETE") or data.get("signal") != param:
+                continue
+            condition_form.add_error(
+                "signal",
+                _("“%(name)s” is what triggers routing on this page, so a condition on it always matches.") % {"name": param},
+            )
+
+    @staticmethod
+    def _enforce_condition_floor(rule_form):
+        data = getattr(rule_form, "cleaned_data", None)
+        # Skip blank extra rows, rows marked for deletion, and explicit match-all rules.
+        if not data or data.get("DELETE") or data.get("match_all"):
+            return
+        conditions_formset = rule_form.formsets.get("conditions")
+        condition_forms = conditions_formset.forms if conditions_formset is not None else []
+        has_condition = any(
+            getattr(condition_form, "cleaned_data", None) and not condition_form.cleaned_data.get("DELETE") for condition_form in condition_forms
+        )
+        if not has_condition:
+            rule_form.add_error("match_all", _("Add at least one condition, or enable “Match all triggered visitors”."))
+
+    def _enforce_target_scope(self, rule_form):
+        # Admin-side counterpart of RoutingRule.clean()'s target guards. A rule the author is
+        # *adding* has no ``page`` set when the model cleans (modelcluster attaches it on
+        # save), so the model guards cannot see the hosting page for new rules — they do run
+        # for a rule that already exists, and for the ORM path. Enforcing them here catches a
+        # bad target inline however the rule arrived (the type-scoped chooser narrows the
+        # choices; this guarantees correctness).
+        data = getattr(rule_form, "cleaned_data", None)
+        if not data or data.get("DELETE"):
+            return
+        if data.get("target") is None:
+            return
+        # Resolve into this page's locale first, so the guards judge the page a visitor here
+        # would actually be sent to.
+        target = localized_target(data.get("target"), self.instance)
+        if target is None:
+            # The chosen page exists only in another language. Two very different situations
+            # produce this, and only one is a mistake:
+            #
+            # * a rule copied here when the page was translated still stores the source
+            #   locale's target. The author never chose it and may not even have opened the
+            #   routing tab; the rule stays inert until the target is translated, then starts
+            #   working on its own. Erroring would block saves for unrelated edits.
+            # * the author just picked this page. It can never route anyone from here, so
+            #   telling them now is the whole point — after saving, nothing would ever say so.
+            #
+            # An untouched page chooser does not appear in ``changed_data``, and Django's
+            # ModelChoiceField compares initial and submitted values as strings, so the stored
+            # id coming back as "5" against an initial 5 is correctly read as unchanged.
+            if "target" in rule_form.changed_data:
+                rule_form.add_error("target", _("That page has no version in this page's language, so this rule could never fire."))
+            return
+        # A resolved target is in this page's language by construction, so the self-target and
+        # descendant checks below are the only ones that can still apply.
+        if target.pk == self.instance.pk:
+            rule_form.add_error("target", _("A rule cannot target its own page."))
+        elif not target.is_descendant_of(self.instance):
+            rule_form.add_error("target", _("The target page must be a descendant of the page this rule is attached to."))
+
+
+def routing_tab_is_shown(instance):
+    """Whether the "User Routing" tab should render for ``instance``.
+
+    The tab is shown only on canonical instances: a routing-enabled page
+    *type* can have non-canonical instances (e.g. a variant nested under a canonical)
+    whose rules would never fire at dispatch, so presenting a fully-functional-looking
+    routing tab there would be dead config. Evaluated from the page's own eligibility
+    predicate, which reads its tree position.
+    """
+    predicate = getattr(instance, "is_routing_canonical", None)
+    return bool(instance is not None and callable(predicate) and predicate())
+
+
+class RoutingObjectList(ObjectList):
+    """An edit-tab that renders only on canonical instances."""
+
+    class BoundPanel(ObjectList.BoundPanel):
+        def is_shown(self):
+            return routing_tab_is_shown(self.instance)
 
 
 class RoutingMixin(models.Model):
@@ -50,6 +252,87 @@ class RoutingMixin(models.Model):
         this with a predicate over its own tree.
         """
         return False
+
+    @classmethod
+    def get_routing_arming_param(cls):
+        """The query param this surface arms on, if it is also a registry signal.
+
+        Derived from the trigger rather than declared separately, so it can never drift
+        from what actually arms the surface. Read from a bare instance because the panels
+        are built per class: a trigger describes the *surface*, so it must not depend on
+        one page's saved state. Returns ``None`` for a surface with no trigger, a
+        non-param trigger, or a param that isn't a signal — in every case there is
+        nothing to withhold.
+        """
+        # The mixin itself is abstract and so can't be instantiated; it also declares no
+        # trigger, so there is nothing to derive until a concrete consumer adopts it.
+        if cls._meta.abstract:
+            return None
+        trigger = cls().get_routing_trigger()
+        param = getattr(trigger, "param_name", None)
+        return param if param in registry else None
+
+    # -- Admin wiring: the framework-owned "User Routing" tab --
+
+    # The condition-floor validation lives on the page form, not the rule
+    # model, because modelcluster only attaches nested conditions at save time — see
+    # RoutingPageForm. Consumers inherit this; one with its own base_form_class should
+    # subclass RoutingPageForm to keep the floor.
+    base_form_class = RoutingPageForm
+
+    # Page type(s) a rule's target chooser is scoped to. ``None`` = any page; a
+    # consumer sets this to its own type(s) — model class(es) or "app.Model" string(s) —
+    # so authors aren't offered unrelated pages. Correctness is still enforced by the
+    # descendant/self-target guards, so this is a usability narrowing, not the guard.
+    routing_target_page_types = None
+
+    @classmethod
+    def get_routing_tab(cls):
+        """The "User Routing" tab: guidance, page-level options, then the rules."""
+        panels = [
+            # Consumer-agnostic guidance on how matching works.
+            HelpPanel(content=ROUTING_TAB_HELP),
+            # Page-level routing options, grouped so future per-page settings nest here.
+            # For now it holds the kill switch (0-or-1 per page); its pause checkbox always
+            # renders with no "Add" step because RoutingPageForm auto-adds the record
+            # for canonical pages — not via min_num, which would block saving a page with no
+            # record yet.
+            MultiFieldPanel(
+                [InlinePanel("routing_config", label=_("Kill switch"), max_num=1)],
+                heading=_("Options"),
+            ),
+            # Rules, with the target chooser scoped to the consumer's page type(s) and
+            # the condition signals narrowed by the consumer's own trigger.
+            InlinePanel(
+                "routing_rules",
+                panels=rule_panels(cls.routing_target_page_types, cls.get_routing_arming_param()),
+                label=_("Rules"),
+            ),
+        ]
+        return RoutingObjectList(panels, heading=_("User Routing"))
+
+    @cached_classmethod
+    def get_edit_handler(cls):
+        """Extend Wagtail's default page tabs with the "User Routing" tab.
+
+        Mirrors Wagtail's default ``TabbedInterface`` (Content / Promote / Settings)
+        and appends the routing tab. A consumer that defines its own ``edit_handler``
+        is left untouched (it can add the tab itself).
+        """
+        if hasattr(cls, "edit_handler"):
+            return cls.edit_handler.bind_to_model(cls)
+
+        tabs = []
+        if cls.content_panels:
+            tabs.append(ObjectList(cls.content_panels, heading=_("Content")))
+        if cls.promote_panels:
+            tabs.append(ObjectList(cls.promote_panels, heading=_("Promote")))
+        if cls.settings_panels:
+            tabs.append(ObjectList(cls.settings_panels, heading=_("Settings")))
+        tabs.append(cls.get_routing_tab())
+
+        edit_handler = TabbedInterface(tabs, base_form_class=cls.base_form_class)
+        return edit_handler.bind_to_model(cls)
 
     # -- Serve-path dispatch --
 

--- a/springfield/cms/routing/resolver.py
+++ b/springfield/cms/routing/resolver.py
@@ -108,9 +108,13 @@ def usable_rules(page):
         return cached
 
     usable = []
-    # Pull targets in the same query and conditions in one more, so the loop below adds no
-    # query per rule. The locale lookup inside localized_target is the residual.
-    rules = page.routing_rules.select_related("target").prefetch_related("conditions")
+    # Reuse an already-prefetched relation if the caller set one up (e.g. the admin listing,
+    # which prefetches target/conditions once for many pages up front) — chaining
+    # select_related/prefetch_related onto the manager below always issues a fresh query,
+    # bypassing that cache, so check for it first. Otherwise pull targets in the same query
+    # and conditions in one more, so the loop below adds no query per rule.
+    prefetched = getattr(page, "_prefetched_objects_cache", {}).get("routing_rules")
+    rules = prefetched if prefetched is not None else page.routing_rules.select_related("target").prefetch_related("conditions")
     for rule in rules:
         target = localized_target(rule.target, page)
         if not target or not target.live:

--- a/springfield/cms/routing/tests/conftest.py
+++ b/springfield/cms/routing/tests/conftest.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission
 from django.test import override_settings
 
 import pytest
@@ -153,3 +154,23 @@ def admin_client(client, db):
         admin = User.objects.create_superuser(username="routing-admin", email="routing-admin@example.com", password="adminpass")
         client.force_login(admin, backend="django.contrib.auth.backends.ModelBackend")
         yield client
+
+
+@pytest.fixture
+def restricted_client(client, db):
+    """A logged-in staff client with admin access but no page permissions yet.
+
+    A test grants ``GroupPagePermission`` on ``.group`` for whichever pages it wants
+    visible, then everything else stays invisible — proving the listing is actually
+    scoped rather than open to any staff user.
+    """
+    with override_settings(
+        AUTHENTICATION_BACKENDS=("django.contrib.auth.backends.ModelBackend",),
+        USE_SSO_AUTH=False,
+    ):
+        user = User.objects.create_user(username="restricted-editor", email="restricted@example.com", password="pass", is_staff=True)
+        group = Group.objects.create(name="Restricted editors")
+        group.permissions.add(Permission.objects.get(content_type__app_label="wagtailadmin", codename="access_admin"))
+        user.groups.add(group)
+        client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")
+        yield SimpleNamespace(client=client, group=group)

--- a/springfield/cms/routing/tests/test_admin.py
+++ b/springfield/cms/routing/tests/test_admin.py
@@ -50,7 +50,7 @@ def test_version_signal_payload_has_operator_meanings_and_a_hint():
     version = build_signal_payload()["firefox_version"]
     assert version["enumValues"] == []
     operator_values = {operator["value"] for operator in version["operators"]}
-    assert {"gte", "lt", "not_gte"} <= operator_values
+    assert {"gte", "lt"} <= operator_values
     assert version["hint"] == str(VALUE_TYPE_HINTS[ValueType.VERSION])
 
 
@@ -232,5 +232,5 @@ def test_reference_rows_carry_a_value_example_per_type():
     rows = {row["name"]: row for row in build_signal_reference()}
     assert str(rows["is_firefox"]["value_example"]) == "true or false"
     assert "129" in str(rows["firefox_version"]["value_example"])
-    assert "30" in str(rows["profile_age"]["value_example"])
+    assert "30" in str(rows["profile_age_weeks"]["value_example"])
     assert str(rows["utm_source"]["value_example"]) == "Free text"

--- a/springfield/cms/routing/tests/test_admin.py
+++ b/springfield/cms/routing/tests/test_admin.py
@@ -1,0 +1,236 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the admin signal payload feeding the dynamic condition help."""
+
+from unittest.mock import patch
+
+from django.conf import settings
+from django.utils.functional import Promise
+
+import pytest
+
+from springfield.cms.routing import value_lists
+from springfield.cms.routing.admin import VALUE_LIST_HINT, VALUE_TYPE_HINTS, build_signal_payload, build_signal_reference
+from springfield.cms.routing.signals import ValueType, registry
+
+# The closed value lists are derived from ambient data — `settings.LANGUAGES` (itself filtered
+# through product-details) and the product-details region list. An environment without
+# product-details data loaded has empty lists, which is exactly what CI has: a fresh test
+# database. These tests are about the *derivation*, not the data, so they supply their own.
+SERVED_LOCALES = [("en-US", "English (US)"), ("en-CA", "English (Canada)"), ("de", "Deutsch"), ("fr", "Français"), ("es-MX", "Español")]
+CMS_CONTENT_LOCALES = [("en-US", "English (US)"), ("de", "Deutsch")]
+REGIONS = {"us": "United States", "de": "Germany", "gb": "United Kingdom"}
+
+
+@pytest.fixture
+def served_locales_and_regions(settings):
+    """Pin the two ambient sources the closed value lists are built from."""
+    settings.LANGUAGES = SERVED_LOCALES
+    settings.WAGTAIL_CONTENT_LANGUAGES = CMS_CONTENT_LOCALES
+    with patch.object(value_lists.product_details, "get_regions", return_value=REGIONS):
+        yield
+
+
+def test_payload_covers_every_registered_signal():
+    assert set(build_signal_payload()) == set(registry.names())
+
+
+def test_enum_signal_payload_lists_the_enumerated_set():
+    platform = build_signal_payload()["platform"]
+    assert platform["valueType"] == "enum"
+    assert {value["value"] for value in platform["enumValues"]} == {"windows", "osx", "linux", "android", "ios", "other"}
+    # Labels are the registry's own (localized) labels, not fresh literals.
+    registry_labels = {str(enum_value.label) for enum_value in registry.get("platform").enum_values}
+    assert {value["label"] for value in platform["enumValues"]} == registry_labels
+
+
+def test_version_signal_payload_has_operator_meanings_and_a_hint():
+    version = build_signal_payload()["firefox_version"]
+    assert version["enumValues"] == []
+    operator_values = {operator["value"] for operator in version["operators"]}
+    assert {"gte", "lt", "not_gte"} <= operator_values
+    assert version["hint"] == str(VALUE_TYPE_HINTS[ValueType.VERSION])
+
+
+def test_payload_carries_description_and_comma_hint():
+    # The dynamic help leads with the (short) description and appends a comma-separated
+    # hint only for set-membership operators — both delivered per signal in the payload.
+    platform = build_signal_payload()["platform"]
+    assert "operating system" in platform["description"]
+    assert platform["commaHint"]  # non-empty, localized
+
+
+# ---------------------------------------------------------------------------
+# Request-time value lists for locale / country string signals.
+# ---------------------------------------------------------------------------
+
+
+def test_payload_attaches_value_lists_for_locale_and_country(served_locales_and_regions):
+    payload = build_signal_payload()
+    # Regions arrive lowercase and are upper-cased to match what the geo reader produces.
+    assert "US" in payload["country"]["values"]
+    assert "en-US" in payload["locale"]["values"]
+    # These use the values-oriented lead-in, not the generic STRING operators hint.
+    assert payload["country"]["hint"] == str(VALUE_LIST_HINT)
+    assert payload["locale"]["hint"] == str(VALUE_LIST_HINT)
+
+
+def test_payload_attaches_the_region_free_value_list_for_language(served_locales_and_regions):
+    # `language` had no payload coverage at all, and its list is derived from the served
+    # locales by dropping the region — so a break in that derivation would silently reach
+    # authors as an empty help line.
+    payload = build_signal_payload()
+    values = payload["language"]["values"]
+
+    assert "de" in values
+    assert "en" in values
+    # Region-free by construction: every regional locale collapses to its base language.
+    assert not [value for value in values if "-" in value]
+    assert payload["language"]["hint"] == str(VALUE_LIST_HINT)
+
+
+def test_every_closed_set_signal_gets_its_values_from_the_expected_source(served_locales_and_regions):
+    # Deliberately not "every list is non-empty": that asserts a property of the *environment*
+    # (product-details data being loaded), which is false on a fresh database — CI included.
+    # What is worth pinning is that each signal draws from the source it should.
+    payload = build_signal_payload()
+    assert set(payload["locale"]["values"]) == {code for code, _label in SERVED_LOCALES}
+    assert set(payload["language"]["values"]) == {code.split("-")[0] for code, _label in SERVED_LOCALES}
+    assert set(payload["country"]["values"]) == {code.upper() for code in REGIONS}
+    # browser_language is the one deliberately wider than what we serve.
+    assert set(payload["browser_language"]["values"]) > set(payload["language"]["values"])
+
+
+def test_browser_language_accepts_languages_we_do_not_serve(served_locales_and_regions):
+    # The signal exists to reveal visitors whose language we DON'T publish in — a Norwegian
+    # served English, say. Restricting it to served languages would leave it unable to say
+    # anything `locale` doesn't already say. Validated against CLDR instead.
+    values = set(build_signal_payload()["browser_language"]["values"])
+    served = {code.split("-")[0] for code, _label in settings.LANGUAGES}
+
+    # Real languages Springfield publishes nothing in, all of which browsers can report.
+    assert {"mt", "yo", "dz", "no"} <= values
+    # ...and our own base languages are still in there, including any CLDR lacks.
+    assert served <= values
+    assert len(values) > len(served)
+
+
+def test_browser_language_still_rejects_typos():
+    values = set(build_signal_payload()["browser_language"]["values"])
+    # A closed set beats a shape check here: "xx" is well-formed but not a language.
+    for typo in ("english", "en_US", "en-au", "xx", "e", "123", ""):
+        assert typo not in values
+
+
+def test_browser_language_shows_served_languages_as_examples(served_locales_and_regions):
+    # 600-odd CLDR codes would be noise as guidance, so the help shows what we publish in
+    # while validation stays permissive.
+    entry = build_signal_payload()["browser_language"]
+    served = sorted({code.split("-")[0] for code, _label in settings.LANGUAGES})
+
+    assert entry["exampleValues"] == served
+    assert len(entry["values"]) > len(entry["exampleValues"])
+    # The lead-in must not imply the shown list is exhaustive.
+    assert "include" in entry["hint"]
+
+
+def test_closed_set_signals_carry_no_example_list():
+    # locale/country show their real values; only browser_language needs the distinction.
+    payload = build_signal_payload()
+    assert payload["locale"]["exampleValues"] == []
+    assert payload["country"]["exampleValues"] == []
+
+
+def test_locale_values_are_every_served_locale_not_just_cms_content_languages(served_locales_and_regions):
+    # The signal reads the *visitor's* page locale, so the offerable set is every locale
+    # the site serves — not WAGTAIL_CONTENT_LANGUAGES, which is the far smaller set of
+    # locales CMS content is translated into. Using the latter would tell authors that
+    # dozens of perfectly targetable locales are invalid.
+    values = build_signal_payload()["locale"]["values"]
+    served = {code for code, _label in settings.LANGUAGES}
+    cms_content = {code for code, _label in settings.WAGTAIL_CONTENT_LANGUAGES}
+
+    assert set(values) == served
+    assert len(served) > len(cms_content)
+    # A locale the site serves but has no CMS content for must still be offerable.
+    outside_cms = sorted(served - cms_content)
+    assert outside_cms and outside_cms[0] in values
+
+
+def test_free_text_url_signal_carries_no_value_list():
+    # utm_* are genuinely free text — no known option set, so no values list.
+    assert build_signal_payload()["utm_source"]["values"] == []
+
+
+# ---------------------------------------------------------------------------
+# The payload is the only source of truth and carries no raw English.
+# ---------------------------------------------------------------------------
+
+
+def test_value_type_hints_are_lazy_translated():
+    # Every hint is a gettext_lazy source, so nothing bypasses localization.
+    assert set(VALUE_TYPE_HINTS) == set(ValueType)
+    for hint in VALUE_TYPE_HINTS.values():
+        assert isinstance(hint, Promise)
+
+
+def test_operator_labels_trace_to_the_registry():
+    payload = build_signal_payload()
+    for name, entry in payload.items():
+        registry_labels = {operator.value: str(operator.label) for operator in registry.get(name).operators}
+        for operator in entry["operators"]:
+            assert operator["label"] == registry_labels[operator["value"]]
+
+
+# ---------------------------------------------------------------------------
+# Signals reference rows are generated straight from the registry.
+# ---------------------------------------------------------------------------
+
+
+def test_reference_has_one_row_per_registered_signal():
+    rows = build_signal_reference()
+    assert {row["name"] for row in rows} == set(registry.names())
+
+
+def test_reference_row_carries_source_type_operators_and_enum():
+    rows = {row["name"]: row for row in build_signal_reference()}
+    platform = rows["platform"]
+    assert str(platform["source"]) == "User-Agent"
+    assert platform["value_type"] == "enum"
+    assert {str(label) for label in platform["operators"]} >= {"is", "in"}
+    assert {value["value"] for value in platform["enum_values"]} == {"windows", "osx", "linux", "android", "ios", "other"}
+
+
+def test_reference_includes_the_honesty_notes():
+    rows = {row["name"]: row for row in build_signal_reference()}
+    # is_firefox still warns about the Firefox-for-iOS edge case, in plain language.
+    assert "iOS" in str(rows["is_firefox"]["description"])
+
+
+def test_reference_rows_carry_a_source_key_and_uitour_flag():
+    # source_key drives the per-source badge class; is_uitour drives the delay note.
+    rows = {row["name"]: row for row in build_signal_reference()}
+    assert rows["platform"]["source_key"] == "user_agent"
+    assert rows["country"]["source_key"] == "cdn_geo"
+    assert rows["is_default_browser"]["is_uitour"] is True
+    assert rows["utm_source"]["is_uitour"] is False
+
+
+def test_reference_rows_carry_value_lists_for_known_set_string_signals(served_locales_and_regions):
+    # locale/country expose their value lists (shown collapsed); free text has none.
+    rows = {row["name"]: row for row in build_signal_reference()}
+    assert "US" in rows["country"]["values"]
+    assert "en-US" in rows["locale"]["values"]
+    assert rows["utm_source"]["values"] == []  # genuinely free text
+
+
+def test_reference_rows_carry_a_value_example_per_type():
+    # The Values column shows a "what to type" hint for signals with no fixed set —
+    # true/false for booleans, version examples, a number example, "Free text" for strings.
+    rows = {row["name"]: row for row in build_signal_reference()}
+    assert str(rows["is_firefox"]["value_example"]) == "true or false"
+    assert "129" in str(rows["firefox_version"]["value_example"])
+    assert "30" in str(rows["profile_age"]["value_example"])
+    assert str(rows["utm_source"]["value_example"]) == "Free text"

--- a/springfield/cms/routing/tests/test_admin_views.py
+++ b/springfield/cms/routing/tests/test_admin_views.py
@@ -1,0 +1,233 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the browse-only User Routing rules listing."""
+
+from django.urls import NoReverseMatch, reverse
+
+import pytest
+from bs4 import BeautifulSoup
+from wagtail.models import Site
+
+from springfield.cms import wagtail_hooks
+from springfield.cms.routing.models import RoutingCondition, RoutingRule
+from springfield.cms.routing.signals import registry
+from springfield.cms.tests.factories import SimpleRichTextPageFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _rule_on(slug, title):
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug=slug, title=title, parent=site_root)
+    target = SimpleRichTextPageFactory(slug=f"{slug}-t", title=f"{title} target", parent=canonical, live=True)
+    return RoutingRule.objects.create(page=canonical, target=target)
+
+
+def test_listing_renders_rules_from_multiple_pages(admin_client):
+    _rule_on("canonical-alpha", "Canonical Alpha")
+    _rule_on("canonical-beta", "Canonical Beta")
+
+    response = admin_client.get(reverse("cms_routing_rules"))
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "Canonical Alpha" in content
+    assert "Canonical Beta" in content
+
+
+def test_listing_handles_no_rules(admin_client):
+    response = admin_client.get(reverse("cms_routing_rules"))
+    assert response.status_code == 200
+    assert "No routing rules" in response.content.decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Status column: a rule the serve path drops looks perfectly healthy in a plain
+# listing, so each way that happens has to be named here.
+# ---------------------------------------------------------------------------
+
+
+def _matchable(rule):
+    """Give a rule a condition so the status column reports its target, not its emptiness."""
+    RoutingCondition.objects.create(rule=rule, signal="platform", operator="is", expected_value="windows", sort_order=0)
+    return rule
+
+
+def _status_cell(content, rule_name):
+    """The status text for the row carrying ``rule_name``."""
+    row = next(tr for tr in BeautifulSoup(content, "html.parser").select("table.listing tbody tr") if rule_name in tr.get_text())
+    return " ".join(row.select("td")[-1].get_text(" ", strip=True).split())
+
+
+def test_listing_marks_a_healthy_rule_as_firing(admin_client):
+    rule = _matchable(_rule_on("healthy-canonical", "Healthy"))
+    rule.name = "Healthy rule"
+    rule.save()
+
+    content = admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8")
+    assert "Will fire" in _status_cell(content, "Healthy rule")
+
+
+def test_listing_flags_an_unpublished_target_as_waiting(admin_client):
+    # Publishing the variant is work already in flight, so this must not read as an error.
+    rule = _matchable(_rule_on("draft-target-canonical", "Draft target"))
+    rule.name = "Awaiting publish"
+    rule.save()
+    rule.target.unpublish()
+
+    status = _status_cell(admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8"), "Awaiting publish")
+    assert "Waiting" in status
+    assert "not published" in status
+    assert "Won" not in status  # not the won't-fire treatment
+
+
+def test_listing_flags_an_untranslated_target_as_waiting(admin_client, translated_wnp):
+    # The ordinary state of a staged translation: the German page's rule points at a variant
+    # that has not been translated yet.
+    translated_wnp.de_variant.delete()
+    rule = translated_wnp.de_canonical.routing_rules.first()
+    rule.name = "Awaiting translation"
+    rule.save()
+
+    status = _status_cell(admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8"), "Awaiting translation")
+    assert "Waiting" in status
+    assert "not translated" in status
+
+
+def test_listing_flags_a_target_outside_the_page_as_wont_fire(admin_client):
+    # A page-copy artefact: nothing in the row itself reveals that the target belongs to a
+    # different page's subtree. This one stays broken until an author fixes it.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="stray-host", title="Stray host", parent=site_root)
+    unrelated = SimpleRichTextPageFactory(slug="unrelated-host", title="Unrelated", parent=site_root)
+    stray = SimpleRichTextPageFactory(slug="stray-target", title="Stray target", parent=unrelated, live=True)
+    rule = _matchable(RoutingRule.objects.create(page=canonical, target=stray, name="Cross subtree"))
+
+    status = _status_cell(admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8"), "Cross subtree")
+    assert "Won" in status  # won't fire
+    assert "not part of this page" in status
+    assert "Waiting" not in status
+    assert rule.target_id == stray.pk
+
+
+def test_listing_flags_a_deleted_target_as_wont_fire(admin_client):
+    # The listing is what makes deleting a target a discoverable mistake rather than an
+    # invisible one — the whole reason blocking the delete was judged unnecessary.
+    rule = _matchable(_rule_on("deleted-target-canonical", "Deleted target"))
+    rule.name = "Target deleted"
+    rule.save()
+    rule.target.delete()
+
+    status = _status_cell(admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8"), "Target deleted")
+    assert "Won" in status
+    assert "No target page" in status
+    assert "Waiting" not in status
+
+
+def test_listing_flags_a_rule_that_can_never_match_as_wont_fire(admin_client):
+    rule = _rule_on("conditionless-host", "Conditionless host")
+    rule.name = "No conditions"
+    rule.save()
+
+    status = _status_cell(admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8"), "No conditions")
+    assert "Won" in status
+    assert "No conditions" in status
+
+
+def test_listing_shows_the_rule_name(admin_client):
+    # Display: an author-given rule name appears in the browse listing.
+    rule = _rule_on("canonical-named", "Canonical Named")
+    rule.name = "Windows updaters"
+    rule.save()
+
+    content = admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8")
+    assert "Rule" in content  # the new column header
+    assert "Windows updaters" in content
+
+
+# ---------------------------------------------------------------------------
+# The listing is browse-only: no add affordance.
+# ---------------------------------------------------------------------------
+
+
+def test_no_add_route_is_registered():
+    with pytest.raises(NoReverseMatch):
+        reverse("cms_routing_rules_add")
+
+
+def test_listing_has_no_add_form_or_button(admin_client):
+    content = admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8").lower()
+    # A read/browse aggregation: no create form, no "add rule" affordance.
+    assert "<form" not in content
+    assert "add rule" not in content
+
+
+# ---------------------------------------------------------------------------
+# The "User Routing" submenu is registered with the Rules item.
+# ---------------------------------------------------------------------------
+
+
+def test_user_routing_submenu_is_registered():
+    submenu = wagtail_hooks.register_user_routing_menu()
+    assert str(submenu.label) == "User Routing"
+    assert submenu.menu is wagtail_hooks.user_routing_menu
+
+
+def test_rules_item_is_in_the_submenu():
+    labels = [str(item.label) for item in wagtail_hooks.user_routing_menu.registered_menu_items]
+    assert "Rules" in labels
+
+
+# ---------------------------------------------------------------------------
+# Signals reference page — generated from the registry, never drifts.
+# ---------------------------------------------------------------------------
+
+
+def test_signals_reference_lists_every_registered_signal(admin_client):
+    response = admin_client.get(reverse("cms_routing_signals"))
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    for name in registry.names():
+        assert name in content
+
+
+def test_signals_reference_shows_source_type_and_enum_values(admin_client):
+    content = admin_client.get(reverse("cms_routing_signals")).content.decode("utf-8")
+    assert "User-Agent" in content  # a source label
+    assert "enum" in content  # a value type
+    assert "windows" in content  # an enum value
+
+
+def test_signals_reference_renders_source_badges(admin_client):
+    # Each source gets a per-source badge class (drives the accent + dark-mode styling).
+    content = admin_client.get(reverse("cms_routing_signals")).content.decode("utf-8")
+    for source_key in ("cdn_geo", "user_agent", "uitour", "url"):
+        assert f"routing-badge--{source_key}" in content
+
+
+def test_signals_reference_shows_the_uitour_delay_note(admin_client):
+    # The ~500 ms UITour note is real authoring guidance and must be present.
+    content = admin_client.get(reverse("cms_routing_signals")).content.decode("utf-8")
+    assert "UITour" in content
+    assert "500" in content
+
+
+def test_signals_reference_shows_type_aware_value_hints(admin_client):
+    # Booleans read "true or false" (not "Free text"); version shows examples; the
+    # long country list is available behind a collapsible disclosure.
+    content = admin_client.get(reverse("cms_routing_signals")).content.decode("utf-8")
+    assert "true or false" in content  # boolean signals
+    assert "130.0.1" in content  # version example
+    assert "<details" in content  # collapsible locale/country value list
+    assert ">US<" in content or "US" in content  # a country code inside the disclosure
+
+
+def test_adding_a_signal_makes_it_appear_with_no_page_edit(admin_client, temp_signal):
+    content = admin_client.get(reverse("cms_routing_signals")).content.decode("utf-8")
+    assert temp_signal.name in content
+
+
+def test_signals_reference_item_is_in_the_submenu():
+    labels = [str(item.label) for item in wagtail_hooks.user_routing_menu.registered_menu_items]
+    assert "Signals reference" in labels

--- a/springfield/cms/routing/tests/test_admin_views.py
+++ b/springfield/cms/routing/tests/test_admin_views.py
@@ -4,15 +4,17 @@
 
 """Tests for the browse-only User Routing rules listing."""
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import NoReverseMatch, reverse
 
 import pytest
 from bs4 import BeautifulSoup
-from wagtail.models import Site
+from wagtail.models import GroupPagePermission, Site
 
 from springfield.cms import wagtail_hooks
 from springfield.cms.routing.models import RoutingCondition, RoutingRule
-from springfield.cms.routing.signals import registry
+from springfield.cms.routing.signals import RoutingSignal, Source, ValueType, registry
 from springfield.cms.tests.factories import SimpleRichTextPageFactory
 
 pytestmark = [pytest.mark.django_db]
@@ -40,6 +42,35 @@ def test_listing_handles_no_rules(admin_client):
     response = admin_client.get(reverse("cms_routing_rules"))
     assert response.status_code == 200
     assert "No routing rules" in response.content.decode("utf-8")
+
+
+def test_listing_hides_pages_the_user_cannot_edit(restricted_client):
+    visible = _rule_on("visible-canonical", "Visible page")
+    _rule_on("hidden-canonical", "Hidden page")
+    GroupPagePermission.objects.create(group=restricted_client.group, page=visible.page, permission_type="change")
+
+    content = restricted_client.client.get(reverse("cms_routing_rules")).content.decode("utf-8")
+    assert "Visible page" in content
+    assert "Hidden page" not in content
+
+
+def test_listing_query_count_does_not_scale_with_page_count(admin_client):
+    # Compares query counts at two page counts rather than asserting a fixed number, since
+    # Wagtail's own admin chrome (menus, permissions, session) adds queries unrelated to
+    # this view. What matters is that the *listing's own* query count is flat — the N+1
+    # this guards against would add one query per additional page.
+    def query_count():
+        with CaptureQueriesContext(connection) as context:
+            admin_client.get(reverse("cms_routing_rules"))
+        return len(context)
+
+    _matchable(_rule_on("scaling-canonical-a", "Scaling A"))
+    _matchable(_rule_on("scaling-canonical-b", "Scaling B"))
+    baseline = query_count()
+
+    for i in range(8):
+        _matchable(_rule_on(f"scaling-canonical-extra-{i}", f"Scaling extra {i}"))
+    assert query_count() == baseline
 
 
 # ---------------------------------------------------------------------------
@@ -231,3 +262,28 @@ def test_adding_a_signal_makes_it_appear_with_no_page_edit(admin_client, temp_si
 def test_signals_reference_item_is_in_the_submenu():
     labels = [str(item.label) for item in wagtail_hooks.user_routing_menu.registered_menu_items]
     assert "Signals reference" in labels
+
+
+# ---------------------------------------------------------------------------
+# The condition-help payload injected into the page editor: must not let a signal
+# description break out of its <script> tag.
+# ---------------------------------------------------------------------------
+
+
+def test_condition_help_payload_escapes_a_closing_script_tag():
+    # A translated description is the realistic vector — this proves the escaping
+    # rather than trusting that translators (or a future signal) never write "</script>".
+    signal = RoutingSignal(
+        name="temp_script_break_signal",
+        description="</script><script>alert(1)</script>",
+        source=Source.URL,
+        value_type=ValueType.STRING,
+    )
+    registry.register(signal)
+    try:
+        html = str(wagtail_hooks.routing_condition_help_js())
+    finally:
+        registry._signals.pop(signal.name, None)
+
+    assert "</script><script>alert" not in html
+    assert "\\u003c/script>\\u003cscript>alert(1)\\u003c/script>" in html

--- a/springfield/cms/routing/tests/test_mixins.py
+++ b/springfield/cms/routing/tests/test_mixins.py
@@ -5,8 +5,9 @@
 """Tests for the routing adoption mixin.
 
 Method-level tests only: no test-harness page type is introduced, so the
-full serve integration lands with the first real consumer. Here we prove the
-adoption-surface defaults and the serve-path flag adapter.
+full serve/edit-view integration lands with the first real consumer. Here we
+prove the adoption-surface defaults, the tab's panel structure, and the per-instance
+tab-visibility decision.
 """
 
 from types import SimpleNamespace
@@ -14,11 +15,12 @@ from types import SimpleNamespace
 from django.test import RequestFactory
 
 import pytest
+from wagtail.admin.panels import HelpPanel, InlinePanel, MultiFieldPanel
 from wagtail.models import Site
 
 from springfield.cms.models import SimpleRichTextPage
 from springfield.cms.routing.arming import QueryParamArmingCondition
-from springfield.cms.routing.mixins import RoutingMixin
+from springfield.cms.routing.mixins import RoutingMixin, RoutingObjectList, routing_tab_is_shown
 from springfield.cms.routing.models import RoutingRule
 from springfield.cms.tests.factories import SimpleRichTextPageFactory
 
@@ -38,6 +40,12 @@ def test_routing_trigger_is_unset_by_default():
     assert RoutingMixin.get_routing_trigger(SimpleNamespace()) is None
 
 
+def test_arming_param_is_none_without_a_trigger():
+    # Derived from the trigger, so an unadopted surface withholds nothing. The mixin is
+    # abstract and cannot be instantiated, so this also pins that it never tries.
+    assert RoutingMixin.get_routing_arming_param() is None
+
+
 # ---------------------------------------------------------------------------
 # The mixin adds no database fields, so adoption produces no migration.
 # ---------------------------------------------------------------------------
@@ -46,6 +54,73 @@ def test_routing_trigger_is_unset_by_default():
 def test_mixin_declares_no_database_fields():
     assert list(RoutingMixin._meta.local_fields) == []
     assert RoutingMixin._meta.abstract is True
+
+
+# ---------------------------------------------------------------------------
+# The "User Routing" tab wires both panels via Wagtail's inline-panel pattern.
+# ---------------------------------------------------------------------------
+
+
+def _inline_panels(panel):
+    """Every InlinePanel in a panel tree (the kill switch is nested under a group)."""
+    found = []
+    for child in getattr(panel, "children", []):
+        if isinstance(child, InlinePanel):
+            found.append(child)
+        found.extend(_inline_panels(child))
+    return found
+
+
+def test_routing_tab_holds_rules_and_kill_switch_panels():
+    tab = RoutingMixin.get_routing_tab()
+    assert isinstance(tab, RoutingObjectList)
+    assert str(tab.heading) == "User Routing"
+
+    # A generic guidance panel leads the tab.
+    assert any(isinstance(child, HelpPanel) for child in tab.children)
+
+    # Page-level settings sit under an "Options" group so more can nest there later.
+    groups = [child for child in tab.children if isinstance(child, MultiFieldPanel)]
+    assert any(str(group.heading) == "Options" for group in groups)
+
+    panels = {panel.relation_name: panel for panel in _inline_panels(tab)}
+    assert set(panels) == {"routing_rules", "routing_config"}
+
+    # The kill switch is a single-item panel over RoutingConfig (0-or-1 per page). The
+    # checkbox always renders with no "Add" step via RoutingPageForm auto-creating
+    # the record, not via min_num — so no min_num here (it can't be met by an empty form).
+    assert panels["routing_config"].max_num == 1
+    assert panels["routing_config"].min_num is None
+    assert str(panels["routing_config"].label) == "Kill switch"
+
+
+# ---------------------------------------------------------------------------
+# Tab visibility keys off eligibility: shown only on canonical instances.
+# ---------------------------------------------------------------------------
+
+
+def test_tab_shown_on_canonical_instance():
+    canonical = SimpleNamespace(is_routing_canonical=lambda: True)
+    assert routing_tab_is_shown(canonical) is True
+
+
+def test_tab_suppressed_on_non_canonical_instance():
+    non_canonical = SimpleNamespace(is_routing_canonical=lambda: False)
+    assert routing_tab_is_shown(non_canonical) is False
+
+
+def test_tab_suppressed_when_predicate_absent_or_none():
+    assert routing_tab_is_shown(None) is False
+    assert routing_tab_is_shown(SimpleNamespace()) is False
+
+
+def test_bound_panel_is_shown_delegates_to_eligibility():
+    # The RoutingObjectList tab's BoundPanel gates rendering on the instance predicate.
+    bound = RoutingObjectList.BoundPanel.__new__(RoutingObjectList.BoundPanel)
+    bound.instance = SimpleNamespace(is_routing_canonical=lambda: True)
+    assert bound.is_shown() is True
+    bound.instance = SimpleNamespace(is_routing_canonical=lambda: False)
+    assert bound.is_shown() is False
 
 
 # ---------------------------------------------------------------------------

--- a/springfield/cms/wagtail_hooks.py
+++ b/springfield/cms/wagtail_hooks.py
@@ -15,7 +15,7 @@ from django.utils.safestring import mark_safe
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from draftjs_exporter.dom import DOM
 from wagtail import hooks
-from wagtail.admin.menu import MenuItem
+from wagtail.admin.menu import Menu, MenuItem, SubmenuMenuItem
 from wagtail.admin.rich_text.converters.html_to_contentstate import (
     ExternalLinkElementHandler,
     InlineEntityElementHandler,
@@ -49,6 +49,8 @@ from springfield.cms.models import (
     SetAsDefaultSnippet,
     Tag,
 )
+from springfield.cms.routing.admin import build_signal_payload
+from springfield.cms.routing.admin_views import RoutingRulesIndexView, RoutingSignalsReferenceView
 
 
 @hooks.register("register_admin_urls")
@@ -119,6 +121,47 @@ def mark_locale_roles_in_admin():
     return mark_safe(
         f"<script>window.WAGTAIL_LOCALE_ALIAS_MAP = {json.dumps(alias_id_map)};</script>"
         f'<script src="{static("js/wagtailadmin-locale-badges.js")}"></script>'
+    )
+
+
+# The shared "User Routing" sidebar submenu. Items are contributed via the register
+# hook so later commits (the Signals reference page) can add to the same submenu.
+user_routing_menu = Menu(register_hook_name="register_user_routing_menu_item")
+
+
+@hooks.register("register_admin_urls")
+def register_routing_admin_urls():
+    return [
+        path("user-routing/rules/", RoutingRulesIndexView.as_view(), name="cms_routing_rules"),
+        path("user-routing/signals/", RoutingSignalsReferenceView.as_view(), name="cms_routing_signals"),
+    ]
+
+
+@hooks.register("register_admin_menu_item")
+def register_user_routing_menu():
+    return SubmenuMenuItem("User Routing", user_routing_menu, icon_name="list-ul", order=8000)
+
+
+@hooks.register("register_user_routing_menu_item")
+def register_routing_rules_menu_item():
+    return MenuItem("Rules", reverse("cms_routing_rules"), icon_name="list-ul")
+
+
+@hooks.register("register_user_routing_menu_item")
+def register_routing_signals_menu_item():
+    return MenuItem("Signals reference", reverse("cms_routing_signals"), icon_name="help")
+
+
+@hooks.register("insert_editor_js")
+def routing_condition_help_js():
+    """Deliver the registry payload + condition-help JS to the page editor.
+
+    Injects the localized signal payload as a global, then loads the static JS that
+    renders dynamic help beneath the expected-value field on signal selection.
+    """
+    payload = json.dumps(build_signal_payload())
+    return mark_safe(
+        f'<script>window.ROUTING_SIGNAL_PAYLOAD = {payload};</script><script src="{static("js/wagtailadmin-routing-help.js")}"></script>'
     )
 
 

--- a/springfield/cms/wagtail_hooks.py
+++ b/springfield/cms/wagtail_hooks.py
@@ -159,7 +159,9 @@ def routing_condition_help_js():
     Injects the localized signal payload as a global, then loads the static JS that
     renders dynamic help beneath the expected-value field on signal selection.
     """
-    payload = json.dumps(build_signal_payload())
+    # `<` is escaped so a translated signal description containing "</script>" can't break
+    # out of the tag — json.dumps() does not do this itself.
+    payload = json.dumps(build_signal_payload()).replace("<", "\\u003c")
     return mark_safe(
         f'<script>window.ROUTING_SIGNAL_PAYLOAD = {payload};</script><script src="{static("js/wagtailadmin-routing-help.js")}"></script>'
     )

--- a/tests/unit/spec/cms/routing/condition-help.js
+++ b/tests/unit/spec/cms/routing/condition-help.js
@@ -321,6 +321,36 @@ describe('cms/routing/condition-help.es6.js', function () {
             expect(help.textContent).toContain('Firefox version');
             expect(help.textContent).not.toContain('operating system');
         });
+
+        it('links the help text to the expected-value field via aria-describedby', function () {
+            const dom = makeConditionDOM('platform');
+            const input = dom.fieldWrap.querySelector('input');
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            const help = dom.fieldWrap.querySelector('.routing-condition-help');
+            expect(help.id).toBeTruthy();
+            expect(input.getAttribute('aria-describedby')).toContain(help.id);
+        });
+
+        it('does not duplicate the describedby id on repeated renders', function () {
+            const dom = makeConditionDOM('platform');
+            const input = dom.fieldWrap.querySelector('input');
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            const help = dom.fieldWrap.querySelector('.routing-condition-help');
+            const ids = input.getAttribute('aria-describedby').split(/\s+/);
+            expect(ids.filter((id) => id === help.id).length).toEqual(1);
+        });
+
+        it('preserves an existing aria-describedby value', function () {
+            const dom = makeConditionDOM('platform');
+            const input = dom.fieldWrap.querySelector('input');
+            input.setAttribute('aria-describedby', 'some-other-hint');
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            const help = dom.fieldWrap.querySelector('.routing-condition-help');
+            const ids = input.getAttribute('aria-describedby').split(/\s+/);
+            expect(ids).toContain('some-other-hint');
+            expect(ids).toContain(help.id);
+        });
     });
 
     describe('filterOperators', function () {
@@ -380,6 +410,39 @@ describe('cms/routing/condition-help.es6.js', function () {
             ]);
             // 'is' was selected and is now illegal -> reset to the first version operator.
             expect(dom.operatorSelect.value).toEqual('gte');
+        });
+
+        it('renders help for the post-filter operator, not the one about to be replaced', function () {
+            const dom = makeConditionDOM('platform');
+            dom.operatorSelect.value = 'in'; // membership operator -> comma hint shown
+            initConditionHelp({ payload: PAYLOAD, root: dom.container });
+            dom.select.value = 'firefox_version'; // 'in' is illegal here -> resets to 'gte'
+            dom.select.dispatchEvent(new Event('change'));
+            expect(dom.operatorSelect.value).toEqual('gte');
+            const help = dom.fieldWrap.querySelector('.routing-condition-help');
+            expect(help.textContent).toContain('Firefox version');
+            expect(help.textContent).not.toContain(COMMA_HINT);
+        });
+    });
+
+    describe('initConditionHelp — operator change revalidates the value', function () {
+        it('recomputes aria-invalid when the operator changes, not just the help text', function () {
+            const dom = makeConditionDOM('platform');
+            document.body.appendChild(dom.container);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: dom.container });
+                const input = dom.fieldWrap.querySelector('input');
+                // Valid set-membership under 'in', but not a single enum member under 'is'.
+                input.value = 'windows, osx';
+                input.dispatchEvent(new Event('change'));
+                expect(input.getAttribute('aria-invalid')).toEqual('true');
+
+                dom.operatorSelect.value = 'in';
+                dom.operatorSelect.dispatchEvent(new Event('change'));
+                expect(input.getAttribute('aria-invalid')).toBeNull();
+            } finally {
+                document.body.removeChild(dom.container);
+            }
         });
     });
 

--- a/tests/unit/spec/cms/routing/condition-help.js
+++ b/tests/unit/spec/cms/routing/condition-help.js
@@ -1,0 +1,800 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    buildHelpText,
+    renderConditionHelp,
+    filterOperators,
+    validateExpectedValue,
+    validateConditions,
+    initConditionHelp
+} from '../../../../../media/js/cms/routing/condition-help.es6.js';
+
+const COMMA_HINT = 'Separate multiple values with commas.';
+const INVALID_HINT = 'That value is not valid.';
+
+const PAYLOAD = {
+    platform: {
+        valueType: 'enum',
+        description: 'The visitor operating system.',
+        hint: 'Enter one of these values:',
+        commaHint: COMMA_HINT,
+        invalidHint: INVALID_HINT,
+        operators: [
+            { value: 'is', label: 'is' },
+            { value: 'is_not', label: 'is not' },
+            { value: 'in', label: 'in' },
+            { value: 'not_in', label: 'not in' }
+        ],
+        enumValues: [
+            { value: 'windows', label: 'Windows' },
+            { value: 'osx', label: 'macOS' }
+        ],
+        values: []
+    },
+    firefox_version: {
+        valueType: 'version',
+        description: 'The visitor Firefox version.',
+        hint: 'Enter a version, e.g. 129 or 130.0.1.',
+        commaHint: COMMA_HINT,
+        invalidHint: INVALID_HINT,
+        operators: [
+            { value: 'gte', label: 'is at least' },
+            { value: 'lt', label: 'is less than' }
+        ],
+        enumValues: [],
+        values: []
+    },
+    // A known-set STRING signal (locale/country): the values list is the signal's COMPLETE
+    // domain, so an off-list value can never match — enforced like an enum.
+    locale: {
+        valueType: 'string',
+        description: 'The visitor locale.',
+        hint: 'Enter one of these values:',
+        commaHint: COMMA_HINT,
+        invalidHint: INVALID_HINT,
+        operators: [
+            { value: 'is', label: 'is' },
+            { value: 'in', label: 'in' }
+        ],
+        enumValues: [],
+        values: ['en-US', 'de', 'fr']
+    },
+    // The region-free counterpart of `locale`: its set is derived by dropping the region
+    // from every served locale, so a regional tag can never be a member.
+    language: {
+        valueType: 'string',
+        description: 'The visitor page language.',
+        hint: 'Enter one of these values:',
+        commaHint: COMMA_HINT,
+        invalidHint: INVALID_HINT,
+        operators: [
+            { value: 'is', label: 'is' },
+            { value: 'in', label: 'in' }
+        ],
+        enumValues: [],
+        values: ['en', 'de', 'fr']
+    },
+    // A signal whose legal set is far larger than what is worth showing: validation runs
+    // against `values`, but the help displays the shorter `exampleValues`.
+    browser_language: {
+        valueType: 'string',
+        description: 'The visitor browser language.',
+        hint: 'Enter a language code. Languages we publish in include:',
+        commaHint: COMMA_HINT,
+        invalidHint: INVALID_HINT,
+        operators: [
+            { value: 'is', label: 'is' },
+            { value: 'in', label: 'in' }
+        ],
+        enumValues: [],
+        values: ['en', 'de', 'fr', 'no', 'dz', 'mt'],
+        exampleValues: ['en', 'de', 'fr']
+    },
+    // A boolean signal: a malformed value ("yess" → false) silently mis-routes, so it stays a
+    // hard block.
+    is_default_browser: {
+        valueType: 'boolean',
+        description: 'Whether Firefox is the default browser.',
+        hint: 'Enter true or false.',
+        commaHint: COMMA_HINT,
+        invalidHint: INVALID_HINT,
+        operators: [{ value: 'is', label: 'is' }],
+        enumValues: [],
+        values: []
+    }
+};
+
+// A representative subset of the operator dropdown (enum-legal is/in, version-legal gte/lt).
+const OPERATOR_OPTIONS = ['is', 'in', 'gte', 'lt'];
+
+function makeConditionDOM(signalValue) {
+    const container = document.createElement('div');
+    const select = document.createElement('select');
+    select.setAttribute('name', 'routing_rules-0-conditions-0-signal');
+    Object.keys(PAYLOAD).forEach(function (name) {
+        const option = document.createElement('option');
+        option.value = name;
+        select.appendChild(option);
+    });
+    select.value = signalValue;
+
+    const operatorSelect = document.createElement('select');
+    operatorSelect.setAttribute(
+        'name',
+        'routing_rules-0-conditions-0-operator'
+    );
+    OPERATOR_OPTIONS.forEach(function (value) {
+        const option = document.createElement('option');
+        option.value = value;
+        operatorSelect.appendChild(option);
+    });
+
+    const fieldWrap = document.createElement('div');
+    const input = document.createElement('input');
+    input.setAttribute('name', 'routing_rules-0-conditions-0-expected_value');
+    fieldWrap.appendChild(input);
+    container.appendChild(select);
+    container.appendChild(operatorSelect);
+    container.appendChild(fieldWrap);
+    return {
+        container: container,
+        select: select,
+        operatorSelect: operatorSelect,
+        fieldWrap: fieldWrap
+    };
+}
+
+// A rule row as the admin renders it: the "match all" checkbox, then the conditions in a
+// nested-InlinePanel wrapper around the formset's FORMS container. Both the id and the
+// wrapper class are what Wagtail actually emits (verified against a rendered edit page) —
+// the cue derives the panel from them, so the fixture has to carry them.
+function makeRuleDOM(options) {
+    const opts = options || {};
+    const index = opts.index === undefined ? 0 : opts.index;
+    const prefix = 'routing_rules-' + index;
+
+    const rule = document.createElement('div');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.setAttribute('name', prefix + '-match_all');
+    checkbox.checked = !!opts.matchAll;
+    rule.appendChild(checkbox);
+
+    const panel = document.createElement('div');
+    panel.className = 'w-panel__wrapper w-panel--nested';
+    const forms = document.createElement('div');
+    forms.id = 'id_' + prefix + '-conditions-FORMS';
+    panel.appendChild(forms);
+    rule.appendChild(panel);
+
+    const select = document.createElement('select');
+    select.setAttribute('name', prefix + '-conditions-0-signal');
+    Object.keys(PAYLOAD).forEach(function (name) {
+        const option = document.createElement('option');
+        option.value = name;
+        select.appendChild(option);
+    });
+    select.value = opts.signal || 'platform';
+
+    const operatorSelect = document.createElement('select');
+    operatorSelect.setAttribute('name', prefix + '-conditions-0-operator');
+    OPERATOR_OPTIONS.forEach(function (value) {
+        const option = document.createElement('option');
+        option.value = value;
+        operatorSelect.appendChild(option);
+    });
+    operatorSelect.value = 'is';
+
+    const fieldWrap = document.createElement('div');
+    const input = document.createElement('input');
+    input.setAttribute('name', prefix + '-conditions-0-expected_value');
+    input.value = opts.value === undefined ? 'windows' : opts.value;
+    fieldWrap.appendChild(input);
+
+    forms.appendChild(select);
+    forms.appendChild(operatorSelect);
+    forms.appendChild(fieldWrap);
+
+    return {
+        rule: rule,
+        checkbox: checkbox,
+        panel: panel,
+        select: select,
+        input: input,
+        fieldWrap: fieldWrap
+    };
+}
+
+const IGNORED_CLASS = 'routing-conditions--ignored';
+
+function hiddenValues(operatorSelect) {
+    const hidden = [];
+    Array.prototype.forEach.call(operatorSelect.options, function (option) {
+        if (option.hidden) {
+            hidden.push(option.value);
+        }
+    });
+    return hidden;
+}
+
+describe('cms/routing/condition-help.es6.js', function () {
+    describe('buildHelpText', function () {
+        it('leads with the description and lists enum value codes (no label parens)', function () {
+            const text = buildHelpText(PAYLOAD.platform, 'is');
+            expect(text).toContain('The visitor operating system.');
+            expect(text).toContain('Enter one of these values:');
+            expect(text).toContain('windows');
+            expect(text).toContain('osx');
+            expect(text).not.toContain('(windows)'); // codes only, no label parens
+        });
+
+        it('does not restate operators in the help', function () {
+            const text = buildHelpText(PAYLOAD.platform, 'is');
+            expect(text).not.toContain('is not');
+            const version = buildHelpText(PAYLOAD.firefox_version, 'gte');
+            expect(version).toContain('The visitor Firefox version.');
+            expect(version).toContain('130.0.1');
+            expect(version).not.toContain('is at least');
+        });
+
+        it('adds a comma-separated hint only for set-membership operators', function () {
+            expect(buildHelpText(PAYLOAD.platform, 'is')).not.toContain(
+                COMMA_HINT
+            );
+            expect(buildHelpText(PAYLOAD.platform, 'in')).toContain(COMMA_HINT);
+            expect(buildHelpText(PAYLOAD.platform, 'not_in')).toContain(
+                COMMA_HINT
+            );
+        });
+
+        it('leads with the value list for a string signal with a known set', function () {
+            const meta = {
+                valueType: 'string',
+                description: 'The visitor locale.',
+                hint: 'Enter one of these values:',
+                commaHint: COMMA_HINT,
+                operators: [],
+                enumValues: [],
+                values: ['US', 'GB', 'DE']
+            };
+            const text = buildHelpText(meta, 'is');
+            expect(text).toContain('The visitor locale.');
+            expect(text).toContain('US');
+            expect(text).toContain('DE');
+        });
+
+        it('shows exampleValues instead of the full legal set when present', function () {
+            const text = buildHelpText(PAYLOAD.browser_language, 'is');
+            expect(text).toContain('en');
+            expect(text).toContain('de');
+            // Valid, but not worth listing as guidance — the hint says these are examples.
+            expect(text).not.toContain('dz');
+            expect(text).toContain('include');
+        });
+
+        it('caps a long value list and reports the total', function () {
+            const values = [];
+            for (let i = 0; i < 40; i++) {
+                values.push('v' + i);
+            }
+            const text = buildHelpText(
+                {
+                    valueType: 'string',
+                    hint: 'Enter one of these values:',
+                    commaHint: COMMA_HINT,
+                    operators: [],
+                    enumValues: [],
+                    values: values
+                },
+                'in'
+            );
+            expect(text).toContain('v0');
+            expect(text).not.toContain('v39'); // beyond the cap
+            expect(text).toContain('(40 total)');
+        });
+
+        it('is empty for an unknown signal', function () {
+            expect(buildHelpText(undefined, 'is')).toEqual('');
+        });
+    });
+
+    describe('renderConditionHelp', function () {
+        it('inserts help beneath the expected-value field', function () {
+            const dom = makeConditionDOM('platform');
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            const help = dom.fieldWrap.querySelector('.routing-condition-help');
+            expect(help).not.toBeNull();
+            expect(help.textContent).toContain('operating system');
+            expect(help.textContent).toContain('windows');
+        });
+
+        it('updates the help when the signal changes', function () {
+            const dom = makeConditionDOM('platform');
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            dom.select.value = 'firefox_version';
+            renderConditionHelp(dom.select, PAYLOAD, dom.container);
+            const help = dom.fieldWrap.querySelector('.routing-condition-help');
+            expect(help.textContent).toContain('Firefox version');
+            expect(help.textContent).not.toContain('operating system');
+        });
+    });
+
+    describe('filterOperators', function () {
+        it('restricts the operator dropdown to the signal legal operators', function () {
+            const dom = makeConditionDOM('platform');
+            filterOperators(dom.select, PAYLOAD, dom.container);
+            // Enum signal: is/in legal; version-only gte/lt hidden.
+            expect(hiddenValues(dom.operatorSelect).sort()).toEqual([
+                'gte',
+                'lt'
+            ]);
+        });
+
+        it('resets a now-illegal operator selection to the first legal one', function () {
+            const dom = makeConditionDOM('platform');
+            dom.operatorSelect.value = 'gte'; // illegal for an enum signal
+            filterOperators(dom.select, PAYLOAD, dom.container);
+            expect(dom.operatorSelect.value).toEqual('is');
+        });
+
+        it('keeps a still-legal operator selection', function () {
+            const dom = makeConditionDOM('platform');
+            dom.operatorSelect.value = 'in';
+            filterOperators(dom.select, PAYLOAD, dom.container);
+            expect(dom.operatorSelect.value).toEqual('in');
+        });
+
+        it('leaves every operator available for an unknown/blank signal', function () {
+            const dom = makeConditionDOM('platform');
+            dom.select.value = ''; // no payload entry
+            filterOperators(dom.select, PAYLOAD, dom.container);
+            expect(hiddenValues(dom.operatorSelect)).toEqual([]);
+        });
+    });
+
+    describe('initConditionHelp — operator filtering', function () {
+        it('filters operators on initial wiring, preserving a saved legal operator', function () {
+            // An existing rule: version signal with a saved, legal operator.
+            const dom = makeConditionDOM('firefox_version');
+            dom.operatorSelect.value = 'gte';
+            initConditionHelp({ payload: PAYLOAD, root: dom.container });
+            expect(hiddenValues(dom.operatorSelect).sort()).toEqual([
+                'in',
+                'is'
+            ]);
+            expect(dom.operatorSelect.value).toEqual('gte'); // preserved
+        });
+
+        it('re-filters operators when the signal changes', function () {
+            const dom = makeConditionDOM('platform');
+            initConditionHelp({ payload: PAYLOAD, root: dom.container });
+            dom.select.value = 'firefox_version';
+            dom.select.dispatchEvent(new Event('change'));
+            expect(hiddenValues(dom.operatorSelect).sort()).toEqual([
+                'in',
+                'is'
+            ]);
+            // 'is' was selected and is now illegal -> reset to the first version operator.
+            expect(dom.operatorSelect.value).toEqual('gte');
+        });
+    });
+
+    describe('validateExpectedValue', function () {
+        const enumMeta = PAYLOAD.platform;
+        const versionMeta = PAYLOAD.firefox_version;
+
+        it('validates against the full legal set, not the shown examples', function () {
+            const meta = PAYLOAD.browser_language;
+            // Not in exampleValues, but legal — targeting a language we don't publish in
+            // is the entire point of the signal.
+            expect(validateExpectedValue(meta, 'is', 'dz')).toBe(true);
+            expect(validateExpectedValue(meta, 'is', 'no')).toBe(true);
+            expect(validateExpectedValue(meta, 'is', 'en')).toBe(true);
+            // Well-formed but not a language, and a regional tag the reader could never
+            // produce — both rejected rather than silently never matching.
+            expect(validateExpectedValue(meta, 'is', 'xx')).toBe(false);
+            expect(validateExpectedValue(meta, 'is', 'en-au')).toBe(false);
+        });
+
+        it('accepts an enum member and rejects a non-member', function () {
+            expect(validateExpectedValue(enumMeta, 'is', 'windows')).toBe(true);
+            expect(validateExpectedValue(enumMeta, 'is', 'beos')).toBe(false);
+        });
+
+        it('checks every value in a set-membership list', function () {
+            expect(validateExpectedValue(enumMeta, 'in', 'windows, osx')).toBe(
+                true
+            );
+            expect(validateExpectedValue(enumMeta, 'in', 'windows, beos')).toBe(
+                false
+            );
+        });
+
+        it('splits a set-membership list on newlines as well as commas', function () {
+            // One-per-line textarea entry validates the same as comma-separated.
+            expect(validateExpectedValue(enumMeta, 'in', 'windows\nosx')).toBe(
+                true
+            );
+            expect(validateExpectedValue(enumMeta, 'in', 'windows\nbeos')).toBe(
+                false
+            );
+        });
+
+        it('rejects an empty value', function () {
+            expect(validateExpectedValue(enumMeta, 'is', '   ')).toBe(false);
+        });
+
+        it('rejects an operator illegal for the signal', function () {
+            expect(validateExpectedValue(enumMeta, 'gte', 'windows')).toBe(
+                false
+            );
+        });
+
+        it('validates version format (bare, rv-prefixed, dotted)', function () {
+            expect(validateExpectedValue(versionMeta, 'gte', '129.0.1')).toBe(
+                true
+            );
+            expect(validateExpectedValue(versionMeta, 'gte', 'rv:129')).toBe(
+                true
+            );
+            expect(validateExpectedValue(versionMeta, 'gte', 'abc')).toBe(
+                false
+            );
+        });
+
+        it('validates integer and boolean values', function () {
+            const intMeta = {
+                valueType: 'integer',
+                operators: [{ value: 'gte', label: 'x' }],
+                enumValues: []
+            };
+            expect(validateExpectedValue(intMeta, 'gte', '30')).toBe(true);
+            expect(validateExpectedValue(intMeta, 'gte', '3.5')).toBe(false);
+            const boolMeta = {
+                valueType: 'boolean',
+                operators: [{ value: 'is', label: 'x' }],
+                enumValues: []
+            };
+            expect(validateExpectedValue(boolMeta, 'is', 'true')).toBe(true);
+            expect(validateExpectedValue(boolMeta, 'is', 'yes')).toBe(false);
+        });
+
+        it('checks membership for a known-set string signal (locale/country)', function () {
+            const localeMeta = {
+                valueType: 'string',
+                operators: [
+                    { value: 'is', label: 'x' },
+                    { value: 'in', label: 'y' }
+                ],
+                enumValues: [],
+                values: ['en-US', 'de']
+            };
+            expect(validateExpectedValue(localeMeta, 'is', 'de')).toBe(true);
+            expect(validateExpectedValue(localeMeta, 'is', 'zz')).toBe(false);
+        });
+
+        it('checks membership for language, where a regional tag is never a member', function () {
+            // `language` drops the region on purpose, so en-US can only ever be a typo here
+            // even though it is a perfectly valid `locale` value.
+            expect(validateExpectedValue(PAYLOAD.language, 'is', 'de')).toBe(
+                true
+            );
+            expect(
+                validateExpectedValue(PAYLOAD.language, 'in', 'de, fr')
+            ).toBe(true);
+            expect(validateExpectedValue(PAYLOAD.language, 'is', 'en-US')).toBe(
+                false
+            );
+            expect(validateExpectedValue(PAYLOAD.language, 'is', 'zz')).toBe(
+                false
+            );
+        });
+
+        it('accepts any non-empty free-text string', function () {
+            const strMeta = {
+                valueType: 'string',
+                operators: [{ value: 'is', label: 'x' }],
+                enumValues: [],
+                values: []
+            };
+            expect(validateExpectedValue(strMeta, 'is', 'anything')).toBe(true);
+        });
+
+        it('is valid for an unknown signal (server backstop)', function () {
+            expect(validateExpectedValue(undefined, 'is', 'x')).toBe(true);
+        });
+    });
+
+    describe('validateConditions', function () {
+        it('returns false and flags the row for an invalid value', function () {
+            const dom = makeConditionDOM('platform');
+            dom.operatorSelect.value = 'is'; // value left empty -> invalid
+            document.body.appendChild(dom.container);
+            try {
+                expect(validateConditions(dom.container, PAYLOAD)).toBe(false);
+                const expected = dom.fieldWrap.querySelector('input');
+                expect(expected.getAttribute('aria-invalid')).toEqual('true');
+                const help = dom.fieldWrap.querySelector(
+                    '.routing-condition-help'
+                );
+                expect(
+                    help.classList.contains('routing-condition-help--invalid')
+                ).toBe(true);
+                // An explicit message, not just a red outline.
+                expect(help.textContent).toContain(INVALID_HINT);
+            } finally {
+                document.body.removeChild(dom.container);
+            }
+        });
+
+        it('returns true and clears flags for valid values', function () {
+            const dom = makeConditionDOM('platform');
+            dom.operatorSelect.value = 'is';
+            dom.fieldWrap.querySelector('input').value = 'windows';
+            expect(validateConditions(dom.container, PAYLOAD)).toBe(true);
+            expect(
+                dom.fieldWrap
+                    .querySelector('input')
+                    .getAttribute('aria-invalid')
+            ).toBeNull();
+        });
+
+        it('blocks an off-list locale/country value and shows the valid values', function () {
+            const dom = makeConditionDOM('locale');
+            dom.operatorSelect.value = 'is';
+            // 'zz' is not a locale the site serves, so the condition could never match.
+            dom.fieldWrap.querySelector('input').value = 'zz';
+            document.body.appendChild(dom.container);
+            try {
+                // The set is the signal's complete domain, so this is a hard block...
+                expect(validateConditions(dom.container, PAYLOAD)).toBe(false);
+                // ...with the red hint listing what is actually valid.
+                const help = dom.fieldWrap.querySelector(
+                    '.routing-condition-help'
+                );
+                expect(
+                    help.classList.contains('routing-condition-help--invalid')
+                ).toBe(true);
+                expect(help.textContent).toContain('en-US');
+            } finally {
+                document.body.removeChild(dom.container);
+            }
+        });
+
+        it('still blocks a visible hard-invalid value (malformed boolean)', function () {
+            const dom = makeConditionDOM('is_default_browser');
+            dom.operatorSelect.value = 'is';
+            dom.fieldWrap.querySelector('input').value = 'yess'; // silently → false
+            document.body.appendChild(dom.container);
+            try {
+                expect(validateConditions(dom.container, PAYLOAD)).toBe(false);
+                expect(
+                    dom.fieldWrap
+                        .querySelector('input')
+                        .getAttribute('aria-invalid')
+                ).toEqual('true');
+            } finally {
+                document.body.removeChild(dom.container);
+            }
+        });
+
+        it('does not block a hard-invalid row that is hidden (on another tab)', function () {
+            const dom = makeConditionDOM('platform');
+            dom.operatorSelect.value = 'is';
+            dom.fieldWrap.querySelector('input').value = ''; // empty ⇒ hard-invalid
+            // An inactive Wagtail tab panel is display:none — the field isn't laid out.
+            dom.container.style.display = 'none';
+            document.body.appendChild(dom.container);
+            try {
+                // The field isn't visible, so the save reaches the server and Wagtail surfaces
+                // the error on the right tab natively — the client doesn't silently block it.
+                expect(validateConditions(dom.container, PAYLOAD)).toBe(true);
+            } finally {
+                document.body.removeChild(dom.container);
+            }
+        });
+    });
+
+    describe('initConditionHelp — pre-submit guard', function () {
+        // The form is left DETACHED from the document on purpose: a synthetic submit that
+        // the guard does NOT block would otherwise navigate the test runner away.
+        function formWith(signalValue, operator, expectedValue) {
+            const form = document.createElement('form');
+            const dom = makeConditionDOM(signalValue);
+            dom.operatorSelect.value = operator;
+            dom.fieldWrap.querySelector('input').value = expectedValue;
+            form.appendChild(dom.container);
+            return { form: form, dom: dom };
+        }
+
+        function submit(form) {
+            const event = new Event('submit', {
+                cancelable: true,
+                bubbles: true
+            });
+            form.dispatchEvent(event);
+            return event;
+        }
+
+        it('blocks submit when a visible condition value is hard-invalid', function () {
+            // Attached (so the routing field is visible) — safe because the guard blocks the
+            // submit, so it never navigates the runner.
+            const { form, dom } = formWith('platform', 'is', 'beos');
+            document.body.appendChild(form);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: form });
+                const event = submit(form);
+                expect(event.defaultPrevented).toBe(true);
+                const help = dom.fieldWrap.querySelector(
+                    '.routing-condition-help'
+                );
+                expect(
+                    help.classList.contains('routing-condition-help--invalid')
+                ).toBe(true);
+            } finally {
+                document.body.removeChild(form);
+            }
+        });
+
+        it('allows submit when every condition value is valid', function () {
+            const { form } = formWith('platform', 'is', 'windows');
+            initConditionHelp({ payload: PAYLOAD, root: form });
+            expect(submit(form).defaultPrevented).toBe(false);
+        });
+
+        it('blocks submit for an off-list locale value', function () {
+            // The locale list is the complete set of locales the site serves, so 'zz' can
+            // never match — the rule would be silently dead. Attached (see above): safe
+            // because the guard blocks, so the runner is never navigated.
+            const { form } = formWith('locale', 'is', 'zz');
+            document.body.appendChild(form);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: form });
+                expect(submit(form).defaultPrevented).toBe(true);
+            } finally {
+                document.body.removeChild(form);
+            }
+        });
+    });
+
+    describe('initConditionHelp', function () {
+        it('wires a change handler that refreshes the help', function () {
+            const dom = makeConditionDOM('platform');
+            initConditionHelp({ payload: PAYLOAD, root: dom.container });
+            expect(
+                dom.fieldWrap.querySelector('.routing-condition-help')
+                    .textContent
+            ).toContain('operating system');
+
+            dom.select.value = 'firefox_version';
+            dom.select.dispatchEvent(new Event('change'));
+            expect(
+                dom.fieldWrap.querySelector('.routing-condition-help')
+                    .textContent
+            ).toContain('Firefox version');
+        });
+
+        it('wires a row inserted AFTER init (regression guard for the missing observer)', async function () {
+            const root = document.createElement('div');
+            document.body.appendChild(root);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: root });
+                // A condition row Wagtail adds after load — the one-shot scan never saw it.
+                const dom = makeConditionDOM('platform');
+                root.appendChild(dom.container);
+                // Let the MutationObserver callback run.
+                await new Promise(function (resolve) {
+                    setTimeout(resolve, 0);
+                });
+                const help = dom.fieldWrap.querySelector(
+                    '.routing-condition-help'
+                );
+                expect(help).not.toBeNull();
+                expect(help.textContent).toContain('operating system');
+            } finally {
+                document.body.removeChild(root);
+            }
+        });
+
+        it('flags a bad value inline on edit (change), before any save', function () {
+            const dom = makeConditionDOM('platform');
+            document.body.appendChild(dom.container);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: dom.container });
+                const input = dom.fieldWrap.querySelector('input');
+                input.value = 'beos'; // not an enum member
+                input.dispatchEvent(new Event('change'));
+                const help = dom.fieldWrap.querySelector(
+                    '.routing-condition-help'
+                );
+                expect(
+                    help.classList.contains('routing-condition-help--invalid')
+                ).toBe(true);
+            } finally {
+                document.body.removeChild(dom.container);
+            }
+        });
+
+        // A match-all rule routes the whole triggered audience, so the server drops its
+        // conditions. The editor has to show that, or the author is looking at conditions
+        // they wrote that will never be consulted.
+        it('dims the conditions of a rule that is already set to match all', function () {
+            const dom = makeRuleDOM({ matchAll: true });
+            initConditionHelp({ payload: PAYLOAD, root: dom.rule });
+            expect(dom.panel.classList.contains(IGNORED_CLASS)).toBe(true);
+        });
+
+        it('dims and undims the conditions as the box is ticked and unticked', function () {
+            const dom = makeRuleDOM();
+            initConditionHelp({ payload: PAYLOAD, root: dom.rule });
+            expect(dom.panel.classList.contains(IGNORED_CLASS)).toBe(false);
+
+            dom.checkbox.checked = true;
+            dom.checkbox.dispatchEvent(new Event('change'));
+            expect(dom.panel.classList.contains(IGNORED_CLASS)).toBe(true);
+
+            dom.checkbox.checked = false;
+            dom.checkbox.dispatchEvent(new Event('change'));
+            expect(dom.panel.classList.contains(IGNORED_CLASS)).toBe(false);
+        });
+
+        it('dims a rule row inserted AFTER init', async function () {
+            const root = document.createElement('div');
+            document.body.appendChild(root);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: root });
+                // "Add rule" inserts a row the one-shot scan never saw.
+                const dom = makeRuleDOM({ index: 1, matchAll: true });
+                root.appendChild(dom.rule);
+                await new Promise(function (resolve) {
+                    setTimeout(resolve, 0);
+                });
+                expect(dom.panel.classList.contains(IGNORED_CLASS)).toBe(true);
+            } finally {
+                document.body.removeChild(root);
+            }
+        });
+
+        it('does not block a save on a bad value in an ignored condition', function () {
+            // The value is invalid, but the rule matches all triggered visitors so the
+            // server never reads it. Blocking the save would be the editor insisting on a
+            // value it has just told the author is ignored.
+            const dom = makeRuleDOM({ matchAll: true, value: 'beos' });
+            document.body.appendChild(dom.rule);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: dom.rule });
+                expect(validateConditions(dom.rule, PAYLOAD)).toBe(true);
+            } finally {
+                document.body.removeChild(dom.rule);
+            }
+        });
+
+        it('still blocks a save on a bad value once match-all is unticked', function () {
+            const dom = makeRuleDOM({ matchAll: true, value: 'beos' });
+            document.body.appendChild(dom.rule);
+            try {
+                initConditionHelp({ payload: PAYLOAD, root: dom.rule });
+                dom.checkbox.checked = false;
+                dom.checkbox.dispatchEvent(new Event('change'));
+                expect(validateConditions(dom.rule, PAYLOAD)).toBe(false);
+            } finally {
+                document.body.removeChild(dom.rule);
+            }
+        });
+
+        it('does not double-bind a select on repeated scans', function () {
+            const dom = makeConditionDOM('platform');
+            initConditionHelp({ payload: PAYLOAD, root: dom.container });
+            // Re-initialising must be a no-op for an already-wired select.
+            initConditionHelp({ payload: PAYLOAD, root: dom.container });
+            const helps = dom.fieldWrap.querySelectorAll(
+                '.routing-condition-help'
+            );
+            expect(helps.length).toEqual(1);
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Add the User Routing authoring surface — the editor tab, its validation, and the admin reference pages — layer 3 of 4, still dark behind the `user_routing` waffle switch.

**Layer 3 of 4**, based on `stack/2-runtime`. This layer **reopens `RoutingMixin`**, which layer 2
introduced, to add the edit tab. Editing one class across two layers is deliberate: the serve path and the
admin form genuinely share it, and splitting the file would be worse than splitting it by concern.

## Significant changes and points to review

- **`RoutingPageForm` is the most important thing to review**, and the least obvious. Two pieces of
  validation live on the form rather than on the models, both because of *when* Wagtail runs things
  during a save:
  - **The condition-floor.** A rule with no conditions matches every triggered visitor, so it has to opt
    in via `match_all`. `RoutingRule.clean()` cannot enforce this — modelcluster attaches a rule's nested
    conditions to the instance only at *save* time, after validation, so a model-level count check sees
    zero conditions and would reject valid rules. It is checked here, where the nested formset is
    inspectable.
  - **Hidden-tab formsets.** The routing tab is hidden on non-canonical instances, so its formsets are not
    rendered there — nor on the *add* form, where a new page is not yet canonical. Their management forms
    are therefore absent from the POST, and validating or saving them would block the page entirely with
    `ManagementForm` errors. They are scoped out on non-canonical instances, and `self.formsets` is
    restored outside that window so panel binding still works when the form re-renders.

- **The tab renders only on canonical instances** (`RoutingObjectList.is_shown` → `routing_tab_is_shown`).
  A routing-enabled page *type* can have non-canonical instances — a variant nested under a canonical —
  whose rules would never fire at dispatch. Showing a fully-functional-looking routing tab there would
  invite dead config.

- **`get_routing_arming_param()` lands here rather than with the mixin in layer 2.** Only the form and the
  tab consult it; the serve path never does. It is derived from the trigger rather than declared
  separately so it cannot drift from what actually arms the surface. A condition on the surface's own
  arming param can never be useful — the resolver only runs once that param already holds its arming value
  — so it is withheld from the dropdown *and* rejected on save, which also covers the ORM/API path.

- **Admin-side target guards duplicate the model's on purpose.** A rule the author is *adding* has no
  `page` set when the model cleans (modelcluster attaches it on save), so the model guards cannot see the
  hosting page for new rules. `_enforce_target_scope` catches a bad target inline however the rule
  arrived. Note the deliberate asymmetry for a target with no version in this locale: it errors only if
  the author actually *changed* the field, because a rule copied here by a translation still stores the
  source locale's target and erroring would block saves for unrelated edits.

- **The kill switch always renders with no "Add" step.** `RoutingPageForm.__init__` adds an unsaved
  `RoutingConfig` to the in-memory cluster for canonical instances. Done this way rather than via a panel
  `min_num` (an unchanged empty form cannot satisfy `validate_min`) and via the cluster rather than a DB
  write (which a same-request formset can miss).

- **Mechanical, skim these:** the sidebar submenu and admin URL registrations in `wagtail_hooks.py`, the
  rules index and the generated signals reference page (built from the registry, so it cannot drift), the
  per-signal dynamic help JS, and the status-badge CSS.

## Testing

```bash
python -m pytest springfield/cms/routing/tests/ -q
npm run build && npm run jasmine
```

Expected: **343 routing tests** and the full **600 JS specs** pass on this layer.

**Run `npm run build` before clicking through the admin** — `static/` is gitignored build output, so
without it the admin JS 404s and the dynamic condition help looks broken rather than missing.

To see the admin surface: **User Routing → Signals reference** and **User Routing → Rules** in the sidebar
both work now. The *edit tab* still has nothing to appear on until layer 4, since no page type adopts the
mixin yet — the end-to-end authoring round-trip is tested there for the same reason.
