### PR TITLE
User Routing 2/4: resolver page and client-side evaluation

### DIFF
--- a/l10n/en/cms-routing-resolver.ftl
+++ b/l10n/en/cms-routing-resolver.ftl
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### User Routing — client resolver page strings.
+
+# Shown briefly while the client evaluates routing rules and redirects.
+routing-resolver-preparing = Preparing your page…
+
+# Link to the canonical page, used in two places: the always-present escape hatch for a
+# visitor whose redirect never happens, and the no-JavaScript fallback.
+routing-resolver-continue = Continue to the page

--- a/media/css/cms/routing/resolver.scss
+++ b/media/css/cms/routing/resolver.scss
@@ -29,6 +29,16 @@
     animation: routing-resolver-escape-in 300ms ease-in 1600ms both;
 }
 
+// A keyboard user can reach the link on their first Tab, long before the delay is up, and
+// `both` holds it at opacity 0 until then — focus with nothing to see. Anyone who has
+// focused it is by definition not waiting for a redirect, so drop the animation entirely
+// and show it. Pointer users keep the delayed reveal.
+.routing-resolver-escape:focus,
+.routing-resolver-escape:focus-visible {
+    animation: none;
+    opacity: 1;
+}
+
 @keyframes routing-resolver-escape-in {
     from {
         opacity: 0;

--- a/media/css/cms/routing/resolver.scss
+++ b/media/css/cms/routing/resolver.scss
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Minimal styles for the lightweight client resolver bounce page.
+
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+
+.routing-resolver {
+    @include text-body-lg;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-block-size: 100vh;
+    padding: $spacing-lg;
+    text-align: center;
+}
+
+// The escape hatch is in the markup from the start — it has to work with no JS and no
+// stylesheet — but a visitor whose redirect is working should never see it. Fade it in once
+// the client evaluator's own budget has passed, so it only surfaces to someone actually
+// stranded. Opacity, not visibility or display: the link stays focusable and available to
+// screen readers throughout, and it is visible for anyone who gets no CSS at all.
+// The 1600ms delay sits just past the evaluator's global cap (GLOBAL_TIMEOUT_MS, 1500ms in
+// evaluator.es6.js). If that cap changes, raise this with it — too early and the link flashes
+// up for visitors who are about to be redirected anyway.
+.routing-resolver-escape {
+    animation: routing-resolver-escape-in 300ms ease-in 1600ms both;
+}
+
+@keyframes routing-resolver-escape-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+// Reduced motion (and any engine that skips animations): show it immediately rather than
+// leaving the only way off the page permanently transparent.
+@media (prefers-reduced-motion: reduce) {
+    .routing-resolver-escape {
+        animation: none;
+    }
+}

--- a/media/js/cms/routing/evaluator.es6.js
+++ b/media/js/cms/routing/evaluator.es6.js
@@ -85,18 +85,19 @@ function toNumber(value) {
     return Number.isNaN(number) ? null : number;
 }
 
+// Bare (129), rv-prefixed (rv:129) and dotted (129.0.1) — and nothing else. Matching the
+// whole string matters: stripping leading non-digits alone accepted `garbage129`, and
+// allowing a trailing remainder accepted `129beta`, both of which then compared as 129.
+// Anything unparseable must carry no version instead, so the comparison fails closed.
+// `oldversion=unknown`, which Firefox sends when it has no prior version, is the common case.
+const VERSION_RE = /^(?:rv:)?(\d+(?:\.\d+)*)$/;
+
 export function normalizeVersion(value) {
-    // Accept bare (129), prefixed (rv:129) and fully-qualified (129.0.1) forms by
-    // stripping any leading non-digits, then comparing dot-separated numbers. A value
-    // with no digits at all carries no version — `oldversion=unknown`, which Firefox
-    // sends when it has no prior version to report, is the common one.
     if (value === null || value === undefined) {
         return null;
     }
-    const stripped = String(value)
-        .trim()
-        .replace(/^[^\d]*/, '');
-    return stripped === '' ? null : stripped;
+    const match = VERSION_RE.exec(String(value).trim());
+    return match ? match[1] : null;
 }
 
 /**

--- a/media/js/cms/routing/evaluator.es6.js
+++ b/media/js/cms/routing/evaluator.es6.js
@@ -1,0 +1,438 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * User Routing — client-side tri-state rule evaluator.
+ *
+ * Pure, dependency-free logic: it knows nothing about Firefox, Mozilla.Client, or
+ * UITour. Signal values arrive through an injected `provider` (the readers),
+ * which is the extractability seam.
+ *
+ * Provider contract:
+ *   read(signalName)        -> Promise resolving to the signal's value; a rejection
+ *                              or a timeout is treated as the signal being unavailable.
+ *   getBudgetMs(signalName) -> optional per-signal read budget in ms (defaults to
+ *                              PER_SIGNAL_TIMEOUT_MS; UITour signals use the longer
+ *                              PER_UITOUR_KEY_TIMEOUT_MS).
+ */
+
+// The tri-state a condition or rule resolves to.
+export const MATCHED = 'matched';
+export const NOT_MATCHED = 'not_matched';
+export const PENDING = 'pending';
+
+// The state of a single signal read, as seen by the evaluator.
+export const SIGNAL_PENDING = 'pending';
+export const SIGNAL_AVAILABLE = 'available';
+export const SIGNAL_UNAVAILABLE = 'unavailable';
+
+// Timeout envelope. The evaluator owns the global cap; per-signal budgets
+// are supplied by the provider (UITour reads get the longer per-key budget).
+export const PER_SIGNAL_TIMEOUT_MS = 500;
+export const PER_UITOUR_KEY_TIMEOUT_MS = 800;
+export const GLOBAL_TIMEOUT_MS = 1500;
+
+// Operator semantics, mirroring the Python registry operators. `compare` is the
+// positive comparison kind; `negated` flips the positive result.
+export const OPERATORS = {
+    is: { compare: 'eq', negated: false },
+    is_not: { compare: 'eq', negated: true },
+    in: { compare: 'in', negated: false },
+    not_in: { compare: 'in', negated: true },
+    equals: { compare: 'eq', negated: false },
+    not_equals: { compare: 'eq', negated: true },
+    lt: { compare: 'lt', negated: false },
+    not_lt: { compare: 'lt', negated: true },
+    lte: { compare: 'lte', negated: false },
+    not_lte: { compare: 'lte', negated: true },
+    gt: { compare: 'gt', negated: false },
+    not_gt: { compare: 'gt', negated: true },
+    gte: { compare: 'gte', negated: false },
+    not_gte: { compare: 'gte', negated: true }
+};
+
+function splitList(expected) {
+    // Set-membership operators carry a list entered one-per-line and/or comma-separated,
+    // so split on both newlines and commas (matches the Python
+    // RoutingCondition.expected_values() convention).
+    if (expected === null || expected === undefined) {
+        return [];
+    }
+    return String(expected)
+        .split(/[\n,]/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+}
+
+function toBoolean(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    return normalized === 'true' || normalized === '1';
+}
+
+// `null` is the "no parseable value here" sentinel, shared by the parsers and the
+// comparisons below. It has to be distinct from every real answer: 0 is a valid number
+// and an "equal" comparison result, so returning either for a garbage value makes the
+// ordered operators read it as equal and match on it.
+function toNumber(value) {
+    const text = String(value).trim();
+    if (text === '') {
+        return null;
+    }
+    const number = Number(text);
+    return Number.isNaN(number) ? null : number;
+}
+
+export function normalizeVersion(value) {
+    // Accept bare (129), prefixed (rv:129) and fully-qualified (129.0.1) forms by
+    // stripping any leading non-digits, then comparing dot-separated numbers. A value
+    // with no digits at all carries no version — `oldversion=unknown`, which Firefox
+    // sends when it has no prior version to report, is the common one.
+    if (value === null || value === undefined) {
+        return null;
+    }
+    const stripped = String(value)
+        .trim()
+        .replace(/^[^\d]*/, '');
+    return stripped === '' ? null : stripped;
+}
+
+/**
+ * Version-aware comparison. Returns -1, 0 or 1, or `null` when either side carries no
+ * version to compare.
+ */
+export function compareVersions(a, b) {
+    const normalizedA = normalizeVersion(a);
+    const normalizedB = normalizeVersion(b);
+    if (normalizedA === null || normalizedB === null) {
+        return null;
+    }
+    const partsA = normalizedA.split('.');
+    const partsB = normalizedB.split('.');
+    const length = Math.max(partsA.length, partsB.length);
+    for (let i = 0; i < length; i++) {
+        const numA = parseInt(partsA[i], 10) || 0;
+        const numB = parseInt(partsB[i], 10) || 0;
+        if (numA < numB) {
+            return -1;
+        }
+        if (numA > numB) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+// The comparisons below return true, false, or `null` for "cannot be compared".
+function valuesEqual(valueType, value, expected) {
+    if (valueType === 'version') {
+        const comparison = compareVersions(value, expected);
+        return comparison === null ? null : comparison === 0;
+    }
+    if (valueType === 'integer') {
+        const number = toNumber(value);
+        const expectedNumber = toNumber(expected);
+        return number === null || expectedNumber === null
+            ? null
+            : number === expectedNumber;
+    }
+    if (valueType === 'boolean') {
+        return toBoolean(value) === toBoolean(expected);
+    }
+    return String(value) === String(expected);
+}
+
+function compareOrdered(valueType, value, expected) {
+    if (valueType === 'version') {
+        return compareVersions(value, expected);
+    }
+    const number = toNumber(value);
+    const expectedNumber = toNumber(expected);
+    if (number === null || expectedNumber === null) {
+        return null;
+    }
+    if (number < expectedNumber) {
+        return -1;
+    }
+    if (number > expectedNumber) {
+        return 1;
+    }
+    return 0;
+}
+
+function membership(valueType, value, expected) {
+    // A single match settles it. Otherwise, if any member could not be compared at all,
+    // the answer is unknown rather than "no" — the alternative lets a negated operator
+    // claim the value differs from a list it was never actually compared against.
+    let unknown = false;
+    const members = splitList(expected);
+    for (let i = 0; i < members.length; i++) {
+        const equal = valuesEqual(valueType, value, members[i]);
+        if (equal === true) {
+            return true;
+        }
+        if (equal === null) {
+            unknown = true;
+        }
+    }
+    return unknown ? null : false;
+}
+
+function ordered(valueType, value, expected, test) {
+    const comparison = compareOrdered(valueType, value, expected);
+    return comparison === null ? null : test(comparison);
+}
+
+function comparePositive(kind, valueType, value, expected) {
+    switch (kind) {
+        case 'eq':
+            return valuesEqual(valueType, value, expected);
+        case 'in':
+            return membership(valueType, value, expected);
+        case 'lt':
+            return ordered(valueType, value, expected, (c) => c < 0);
+        case 'lte':
+            return ordered(valueType, value, expected, (c) => c <= 0);
+        case 'gt':
+            return ordered(valueType, value, expected, (c) => c > 0);
+        case 'gte':
+            return ordered(valueType, value, expected, (c) => c >= 0);
+        default:
+            return false;
+    }
+}
+
+/**
+ * Resolve a single condition against a signal's current state.
+ *
+ * A pending signal leaves the condition PENDING (negation never touches pending). An
+ * unavailable/timed-out signal makes the condition NOT_MATCHED with no negation flip —
+ * a negated *unknown* must never become a match. Only a resolved (available) value is
+ * operator-evaluated and then negation-flipped.
+ *
+ * A value that arrived but cannot be compared — a version with no digits in it, an
+ * integer that isn't a number — is unknown for the same reason and takes the same exit.
+ * It is not a comparison that happens to be false: reporting false here would let the
+ * negated form of every operator match on it.
+ *
+ * @param state {status, value?} — a signal state, or undefined (treated as pending).
+ */
+export function evaluateCondition(condition, state) {
+    if (!state || state.status === SIGNAL_PENDING) {
+        return PENDING;
+    }
+    if (state.status === SIGNAL_UNAVAILABLE) {
+        return NOT_MATCHED;
+    }
+    const operator = OPERATORS[condition.operator];
+    if (!operator) {
+        // Unknown operator: fail safe — never match.
+        return NOT_MATCHED;
+    }
+    const positive = comparePositive(
+        operator.compare,
+        condition.valueType,
+        state.value,
+        condition.expected
+    );
+    if (positive === null) {
+        return NOT_MATCHED;
+    }
+    const matched = operator.negated ? !positive : positive;
+    return matched ? MATCHED : NOT_MATCHED;
+}
+
+/**
+ * Resolve a rule (an ordered conjunction of conditions) against signal states.
+ *
+ * A `matchAll` rule matches the whole triggered audience immediately.
+ * Otherwise: NOT_MATCHED as soon as any one condition is not-matched (short-circuit,
+ * even while siblings are pending); MATCHED only when all conditions match; PENDING
+ * otherwise. An empty, non-matchAll rule is NOT_MATCHED (defensive — the serializer
+ * already drops it), never the old match-everyone footgun.
+ */
+export function evaluateRule(rule, signalStates) {
+    if (rule.matchAll) {
+        return MATCHED;
+    }
+    let anyPending = false;
+    const conditions = rule.conditions || [];
+    if (conditions.length === 0) {
+        return NOT_MATCHED;
+    }
+    for (let i = 0; i < conditions.length; i++) {
+        const condition = conditions[i];
+        const result = evaluateCondition(
+            condition,
+            signalStates.get(condition.signal)
+        );
+        if (result === NOT_MATCHED) {
+            return NOT_MATCHED;
+        }
+        if (result === PENDING) {
+            anyPending = true;
+        }
+    }
+    return anyPending ? PENDING : MATCHED;
+}
+
+/**
+ * Priority-strict decision across all rules.
+ *
+ * Walking rules in priority order, the first MATCHED rule wins — but a PENDING
+ * higher-priority rule blocks every lower-priority rule (returns pending), so a slow
+ * signal can never let a lower-priority rule jump the queue.
+ */
+export function decideOutcome(rules, signalStates) {
+    for (let i = 0; i < rules.length; i++) {
+        const rule = rules[i];
+        const result = evaluateRule(rule, signalStates);
+        if (result === MATCHED) {
+            return { status: MATCHED, rule: rule, target: rule.target };
+        }
+        if (result === PENDING) {
+            return { status: PENDING };
+        }
+        // NOT_MATCHED: this rule is ruled out; consider the next one.
+    }
+    return { status: NOT_MATCHED };
+}
+
+function budgetFor(provider, signalName) {
+    if (provider && typeof provider.getBudgetMs === 'function') {
+        const budget = provider.getBudgetMs(signalName);
+        if (typeof budget === 'number' && budget > 0) {
+            return budget;
+        }
+    }
+    return PER_SIGNAL_TIMEOUT_MS;
+}
+
+function collectSignalNames(rules) {
+    const names = [];
+    const seen = {};
+    rules.forEach((rule) => {
+        (rule.conditions || []).forEach((condition) => {
+            if (!seen[condition.signal]) {
+                seen[condition.signal] = true;
+                names.push(condition.signal);
+            }
+        });
+    });
+    return names;
+}
+
+/**
+ * Evaluate rules against live signals, under the timeout envelope.
+ *
+ * Resolves as soon as a decision is reachable, or when the global cap forces closure
+ * (unresolved signals become unavailable ⇒ not-matched). Never rejects, never hangs.
+ *
+ * @returns Promise resolving to one of:
+ *   { status: 'matched', target, rule, timedOut }
+ *   { status: 'not_matched', timedOut }
+ */
+export function evaluateRules(rules, provider, options) {
+    const opts = options || {};
+    const globalTimeoutMs =
+        opts.globalTimeoutMs === null || opts.globalTimeoutMs === undefined
+            ? GLOBAL_TIMEOUT_MS
+            : opts.globalTimeoutMs;
+
+    return new Promise((resolve) => {
+        const states = new Map();
+        const timers = [];
+        let settled = false;
+
+        const signalNames = collectSignalNames(rules);
+        signalNames.forEach((name) =>
+            states.set(name, { status: SIGNAL_PENDING })
+        );
+
+        function finish(outcome) {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            timers.forEach((timer) => window.clearTimeout(timer));
+            resolve(outcome);
+        }
+
+        function markUnavailable(name) {
+            const state = states.get(name);
+            if (state && state.status === SIGNAL_PENDING) {
+                states.set(name, { status: SIGNAL_UNAVAILABLE });
+            }
+        }
+
+        function reevaluate(timedOut) {
+            if (settled) {
+                return;
+            }
+            const decision = decideOutcome(rules, states);
+            if (decision.status === PENDING && !timedOut) {
+                return; // still resolvable — keep waiting within the budget
+            }
+            if (decision.status === MATCHED) {
+                finish({
+                    status: MATCHED,
+                    target: decision.target,
+                    rule: decision.rule,
+                    timedOut: !!timedOut
+                });
+            } else {
+                // Genuine no-match, or the budget forced pending to close out.
+                finish({ status: NOT_MATCHED, timedOut: !!timedOut });
+            }
+        }
+
+        // Global hard cap: force any still-pending signal to unavailable and close.
+        timers.push(
+            window.setTimeout(function () {
+                signalNames.forEach(markUnavailable);
+                reevaluate(true);
+            }, globalTimeoutMs)
+        );
+
+        // Kick off each signal read under its own per-signal budget.
+        signalNames.forEach((name) => {
+            const perTimer = window.setTimeout(
+                function () {
+                    markUnavailable(name);
+                    reevaluate(false);
+                },
+                budgetFor(provider, name)
+            );
+            timers.push(perTimer);
+
+            Promise.resolve()
+                .then(() => provider.read(name))
+                .then(
+                    (value) => {
+                        window.clearTimeout(perTimer);
+                        const state = states.get(name);
+                        if (state && state.status === SIGNAL_PENDING) {
+                            states.set(name, {
+                                status: SIGNAL_AVAILABLE,
+                                value: value
+                            });
+                        }
+                        reevaluate(false);
+                    },
+                    () => {
+                        window.clearTimeout(perTimer);
+                        markUnavailable(name);
+                        reevaluate(false);
+                    }
+                );
+        });
+
+        // Handle the degenerate cases (no rules / no signals) synchronously.
+        reevaluate(false);
+    });
+}

--- a/media/js/cms/routing/evaluator.es6.js
+++ b/media/js/cms/routing/evaluator.es6.js
@@ -36,7 +36,8 @@ export const PER_UITOUR_KEY_TIMEOUT_MS = 800;
 export const GLOBAL_TIMEOUT_MS = 1500;
 
 // Operator semantics, mirroring the Python registry operators. `compare` is the
-// positive comparison kind; `negated` flips the positive result.
+// positive comparison kind; `negated` flips the positive result. Ordered comparisons have
+// no negated forms — the opposite of `lt` is `gte`, which is already here.
 export const OPERATORS = {
     is: { compare: 'eq', negated: false },
     is_not: { compare: 'eq', negated: true },
@@ -45,13 +46,9 @@ export const OPERATORS = {
     equals: { compare: 'eq', negated: false },
     not_equals: { compare: 'eq', negated: true },
     lt: { compare: 'lt', negated: false },
-    not_lt: { compare: 'lt', negated: true },
     lte: { compare: 'lte', negated: false },
-    not_lte: { compare: 'lte', negated: true },
     gt: { compare: 'gt', negated: false },
-    not_gt: { compare: 'gt', negated: true },
-    gte: { compare: 'gte', negated: false },
-    not_gte: { compare: 'gte', negated: true }
+    gte: { compare: 'gte', negated: false }
 };
 
 function splitList(expected) {

--- a/media/js/cms/routing/readers.es6.js
+++ b/media/js/cms/routing/readers.es6.js
@@ -140,24 +140,63 @@ export function createUserAgentReader(options) {
     };
 }
 
+/**
+ * Collapse UITour's per-feature AI control states into one posture.
+ *
+ * `aiControls` reports a state per AI feature (`translations`, `sidebarChatbot`, …) plus a
+ * `default` master, with no overall summary. Iterating whatever keys arrive — rather than
+ * naming features — means a new Firefox AI feature folds in without a change here.
+ *
+ * `available` counts as no choice: per Firefox's own wording it means "you'll see the
+ * feature and can use it", where `enabled` means "you've opted in". Blocking globally also
+ * writes `blocked` to every feature, so the master and per-feature views agree.
+ *
+ * Order matters — the cases overlap, and the global switch outranks per-feature noise.
+ */
+export function aiControlsPosture(config) {
+    if (!config || typeof config !== 'object') {
+        return undefined;
+    }
+    const features = Object.keys(config).filter((key) => key !== 'default');
+    if (config.default === 'blocked') {
+        return 'blocked_all';
+    }
+    const enabled = features.filter((key) => config[key] === 'enabled').length;
+    const blocked = features.filter((key) => config[key] === 'blocked').length;
+    if (enabled && blocked) {
+        return 'mixed';
+    }
+    if (blocked) {
+        return features.length && blocked === features.length
+            ? 'blocked_all'
+            : 'blocked_some';
+    }
+    if (enabled) {
+        return 'enabled_some';
+    }
+    return 'neutral';
+}
+
 // Per-signal extraction from a UITour getConfiguration() payload. Firefox-specific and
-// therefore quarantined here. NOTE: the exact fields for `profile_age` and
-// `ai_controls` are provisional and need validating against a real Firefox UITour.
+// therefore quarantined here. Field names verified against UITour.sys.mjs in
+// mozilla-central.
 const UITOUR_EXTRACTORS = {
     is_default_browser: function (config) {
         return config.defaultBrowser;
     },
+    // `sync.setup` is prefHasUserValue("services.sync.username") — it reports that sync is
+    // configured, which is close to but not the same as being signed in to a Firefox Account.
     fxa_signed_in: function (config) {
         return config.setup;
     },
-    profile_age: function (config) {
-        return typeof config.profileCreatedWeeks === 'number'
-            ? config.profileCreatedWeeks * 7
+    // Whole weeks, reported directly. Not converted to days: UITour only exposes weeks, so
+    // multiplying would imply a precision that is not there.
+    profile_age_weeks: function (config) {
+        return typeof config.profileCreatedWeeksAgo === 'number'
+            ? config.profileCreatedWeeksAgo
             : undefined;
     },
-    ai_controls: function (config) {
-        return config.state;
-    }
+    ai_controls: aiControlsPosture
 };
 
 /**

--- a/media/js/cms/routing/readers.es6.js
+++ b/media/js/cms/routing/readers.es6.js
@@ -1,0 +1,354 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * User Routing — client signal-reader adapters.
+ *
+ * This is the reader seam: every Firefox/Mozilla-specific read —
+ * Mozilla.Client, UITour, the server-rendered geo attribute — lives here, so the
+ * evaluator core stays generic. Each adapter implements a `read(descriptor)`
+ * returning a Promise that resolves to the signal's value, or rejects when the value
+ * is unavailable (which the evaluator treats as not-matched).
+ *
+ * `createProvider(manifest, options)` composes the four adapters into the provider the
+ * evaluator consumes. The manifest (signal name -> {source, browserStateKey, valueType})
+ * is serialized server-side from the Python registry and delivered on the resolver
+ * page; all Firefox/Mozilla globals are injectable for testing.
+ */
+
+import {
+    PER_SIGNAL_TIMEOUT_MS,
+    PER_UITOUR_KEY_TIMEOUT_MS,
+    normalizeVersion
+} from './evaluator.es6';
+
+// Source identifiers, mirroring the Python Source enum values.
+export const SOURCE_CDN_GEO = 'cdn_geo';
+export const SOURCE_USER_AGENT = 'user_agent';
+export const SOURCE_UITOUR = 'uitour';
+export const SOURCE_URL = 'url';
+
+function mozillaGlobal() {
+    return typeof window !== 'undefined' && window.Mozilla
+        ? window.Mozilla
+        : null;
+}
+
+/**
+ * A locale/language tag reduced to its base language subtag: `en-US` -> `en`.
+ * Lowercased because browsers are inconsistent about tag casing, while the base
+ * subtag is always lowercase in the value list authors pick from.
+ */
+export function baseLanguage(tag) {
+    return String(tag || '')
+        .split('-')[0]
+        .toLowerCase();
+}
+
+/**
+ * CDN geo — country is server-rendered into `data-country-code` on <html>, since the
+ * client cannot read the CDN header directly. Injectable `root` element.
+ */
+export function createGeoReader(options) {
+    const opts = options || {};
+    const root =
+        opts.root ||
+        (typeof document !== 'undefined' ? document.documentElement : null);
+    return {
+        read: function () {
+            return new Promise(function (resolve, reject) {
+                if (!root || !root.dataset) {
+                    reject();
+                    return;
+                }
+                const value = root.dataset.countryCode;
+                if (value) {
+                    resolve(value);
+                } else {
+                    reject();
+                }
+            });
+        }
+    };
+}
+
+/**
+ * User-Agent — read via Mozilla.Client, the canonical UA parser. Its UA
+ * methods work in any browser (returning falsey off Firefox), so it is not Firefox-
+ * gated. Injectable `client`.
+ */
+export function createUserAgentReader(options) {
+    const opts = options || {};
+    const client =
+        opts.client || (mozillaGlobal() ? mozillaGlobal().Client : null);
+    const nav =
+        opts.navigator || (typeof navigator !== 'undefined' ? navigator : null);
+    return {
+        read: function (descriptor) {
+            return new Promise(function (resolve, reject) {
+                if (descriptor.name === 'browser_language') {
+                    // Checked before the Mozilla.Client guard below: this is a plain
+                    // browser API, available off Firefox too. Only the top preference is
+                    // read — the ordered list would need list-valued signal support the
+                    // evaluator does not have.
+                    const preferred =
+                        nav &&
+                        ((nav.languages && nav.languages[0]) || nav.language);
+                    if (preferred) {
+                        resolve(baseLanguage(preferred));
+                    } else {
+                        reject();
+                    }
+                    return;
+                }
+                if (!client) {
+                    reject();
+                    return;
+                }
+                if (descriptor.name === 'is_firefox') {
+                    // A real boolean — false off Firefox (still an available value).
+                    resolve(!!client.isFirefox);
+                    return;
+                }
+                if (descriptor.name === 'platform') {
+                    if (client.platform) {
+                        resolve(client.platform);
+                    } else {
+                        reject();
+                    }
+                    return;
+                }
+                if (descriptor.name === 'firefox_version') {
+                    const version =
+                        typeof client._getFirefoxVersion === 'function'
+                            ? client._getFirefoxVersion()
+                            : client.FirefoxVersion;
+                    // Empty off Firefox -> unavailable, so version rules don't misfire.
+                    if (version) {
+                        resolve(version);
+                    } else {
+                        reject();
+                    }
+                    return;
+                }
+                reject();
+            });
+        }
+    };
+}
+
+// Per-signal extraction from a UITour getConfiguration() payload. Firefox-specific and
+// therefore quarantined here. NOTE: the exact fields for `profile_age` and
+// `ai_controls` are provisional and need validating against a real Firefox UITour.
+const UITOUR_EXTRACTORS = {
+    is_default_browser: function (config) {
+        return config.defaultBrowser;
+    },
+    fxa_signed_in: function (config) {
+        return config.setup;
+    },
+    profile_age: function (config) {
+        return typeof config.profileCreatedWeeks === 'number'
+            ? config.profileCreatedWeeks * 7
+            : undefined;
+    },
+    ai_controls: function (config) {
+        return config.state;
+    }
+};
+
+/**
+ * UITour — Firefox-only browser state, read via a ping-gated getConfiguration under a
+ * per-key budget. A ping or getConfiguration that never answers
+ * leaves the read pending until the budget expires, then rejects (⇒ not-matched).
+ * Injectable `uiTour` and `timeout`.
+ */
+export function createUITourReader(options) {
+    const opts = options || {};
+    const uiTour =
+        opts.uiTour || (mozillaGlobal() ? mozillaGlobal().UITour : null);
+    const timeout = opts.timeout || PER_UITOUR_KEY_TIMEOUT_MS;
+    return {
+        read: function (descriptor) {
+            return new Promise(function (resolve, reject) {
+                const extractor = UITOUR_EXTRACTORS[descriptor.name];
+                if (
+                    !uiTour ||
+                    typeof uiTour.getConfiguration !== 'function' ||
+                    typeof uiTour.ping !== 'function' ||
+                    !descriptor.browserStateKey ||
+                    !extractor
+                ) {
+                    reject();
+                    return;
+                }
+                let settled = false;
+                const timer = window.setTimeout(function () {
+                    if (!settled) {
+                        settled = true;
+                        reject();
+                    }
+                }, timeout);
+                uiTour.ping(function () {
+                    if (settled) {
+                        return;
+                    }
+                    uiTour.getConfiguration(
+                        descriptor.browserStateKey,
+                        function (config) {
+                            if (settled) {
+                                return;
+                            }
+                            settled = true;
+                            window.clearTimeout(timer);
+                            const value = extractor(config || {});
+                            if (value === undefined || value === null) {
+                                reject();
+                            } else {
+                                resolve(value);
+                            }
+                        }
+                    );
+                });
+            });
+        }
+    };
+}
+
+/**
+ * URL — a signal read from the current URL. Most URL signals are named
+ * after a query param and read verbatim; two are special-cased:
+ *
+ *   - `oldversion` is a version signal (Firefox's just-updated flow sends it); its value
+ *     is normalized the same way `firefox_version` is (bare / rv: / fully-qualified).
+ *   - `locale` is the page locale, read from an explicit `?locale=` override and falling
+ *     back to the `<html lang>` attribute (server-rendered on the resolver page).
+ *   - `language` is that same locale with the region dropped, so one condition covers
+ *     every regional variant of a language.
+ *
+ * Injectable `search` string, `root` element, and `lang` override.
+ */
+export function createUrlReader(options) {
+    const opts = options || {};
+    const search =
+        opts.search === undefined
+            ? typeof window !== 'undefined'
+                ? window.location.search
+                : ''
+            : opts.search;
+    const params = new URLSearchParams(search);
+
+    const root =
+        opts.root ||
+        (typeof document !== 'undefined' ? document.documentElement : null);
+
+    function htmlLang() {
+        if (opts.lang !== undefined) {
+            return opts.lang;
+        }
+        return root && typeof root.getAttribute === 'function'
+            ? root.getAttribute('lang')
+            : null;
+    }
+
+    return {
+        read: function (descriptor) {
+            return new Promise(function (resolve, reject) {
+                if (descriptor.name === 'oldversion') {
+                    if (params.has('oldversion')) {
+                        resolve(normalizeVersion(params.get('oldversion')));
+                    } else {
+                        reject();
+                    }
+                    return;
+                }
+                if (
+                    descriptor.name === 'locale' ||
+                    descriptor.name === 'language'
+                ) {
+                    // Explicit ?locale= wins; otherwise fall back to <html lang>.
+                    const locale = params.has('locale')
+                        ? params.get('locale')
+                        : htmlLang();
+                    if (locale) {
+                        // `language` is the same value with the region dropped, so one
+                        // condition matches every regional variant.
+                        resolve(
+                            descriptor.name === 'language'
+                                ? baseLanguage(locale)
+                                : locale
+                        );
+                    } else {
+                        reject();
+                    }
+                    return;
+                }
+                if (params.has(descriptor.name)) {
+                    resolve(params.get(descriptor.name));
+                } else {
+                    reject();
+                }
+            });
+        }
+    };
+}
+
+/**
+ * Compose the four adapters into the provider the evaluator consumes.
+ *
+ * @param manifest signal name -> { source, browserStateKey?, valueType? }
+ * @param options  injected dependencies passed through to each adapter (root, client,
+ *                 uiTour, search, timeout).
+ */
+export function createProvider(manifest, options) {
+    const opts = options || {};
+    const signalManifest = manifest || {};
+    // Fake signal values (preview_signal) resolve immediately; everything else
+    // reads live through the source adapters.
+    const fakes = opts.fakes || {};
+    const readers = {};
+    readers[SOURCE_CDN_GEO] = createGeoReader(opts);
+    readers[SOURCE_USER_AGENT] = createUserAgentReader(opts);
+    readers[SOURCE_UITOUR] = createUITourReader(opts);
+    readers[SOURCE_URL] = createUrlReader(opts);
+
+    function descriptorFor(name) {
+        const entry = signalManifest[name];
+        if (!entry) {
+            return null;
+        }
+        return {
+            name: name,
+            source: entry.source,
+            browserStateKey: entry.browserStateKey,
+            valueType: entry.valueType
+        };
+    }
+
+    return {
+        read: function (name) {
+            if (Object.prototype.hasOwnProperty.call(fakes, name)) {
+                return Promise.resolve(fakes[name]);
+            }
+            const descriptor = descriptorFor(name);
+            if (!descriptor) {
+                return Promise.reject();
+            }
+            const reader = readers[descriptor.source];
+            if (!reader) {
+                return Promise.reject();
+            }
+            return reader.read(descriptor);
+        },
+        getBudgetMs: function (name) {
+            const descriptor = descriptorFor(name);
+            if (descriptor && descriptor.source === SOURCE_UITOUR) {
+                return PER_UITOUR_KEY_TIMEOUT_MS;
+            }
+            return PER_SIGNAL_TIMEOUT_MS;
+        }
+    };
+}

--- a/media/js/cms/routing/resolver.es6.js
+++ b/media/js/cms/routing/resolver.es6.js
@@ -1,0 +1,189 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * User Routing — client resolver entrypoint.
+ *
+ * Reads the rules and signal manifest the server rendered into data-* attributes,
+ * builds the signal provider, evaluates the rules, and navigates: to the
+ * matched rule's target on a match, or to the canonical URL with the loop-breaker
+ * marker appended on no-match / timeout. This is the bundled entrypoint
+ * that pulls in the evaluator and readers.
+ */
+
+import { evaluateRules } from './evaluator.es6';
+import { createProvider } from './readers.es6';
+
+/**
+ * No-op seam for the deferred telemetry follow-up. The resolver already computes
+ * the outcome (match / no-match / timeout); the follow-up attaches here without
+ * reopening the resolver. Ships empty in this PR.
+ */
+// eslint-disable-next-line no-unused-vars
+export function onResolveOutcome(outcome) {
+    // Intentionally empty — telemetry follow-up will populate this.
+}
+
+function parseJSONAttribute(element, attribute) {
+    try {
+        return JSON.parse(element.getAttribute(attribute) || 'null');
+    } catch (e) {
+        return null;
+    }
+}
+
+export function appendLoopBreaker(url, param) {
+    const separator = url.indexOf('?') === -1 ? '?' : '&';
+    return url + separator + encodeURIComponent(param) + '=1';
+}
+
+// Framework control params that must never be carried onto the destination — they
+// would re-arm routing, re-enter the loop, or leak preview state. Mirrors
+// RESERVED_ROUTING_PARAMS in springfield/cms/routing/params.py, which the server uses for
+// the same purpose on the no-JS paths; a change to either list needs the same change to the
+// other. The active loop-breaker param is added at runtime from the data attribute in case a
+// consumer overrode it.
+export const RESERVED_ROUTING_PARAMS = [
+    'routing',
+    'routed',
+    'preview_rule',
+    'preview_signal'
+];
+
+/**
+ * Merge inbound query params onto a destination URL so attribution (utm_*, oldversion,
+ * …) survives the redirect. Framework control params in `reservedParams`
+ * are dropped, and a key the destination already carries is never overwritten or
+ * duplicated (destination wins). Any existing query and fragment on `url` are kept.
+ *
+ * Client-side only — the server render stays per-request-free and CDN-cacheable.
+ */
+export function preserveQueryString(url, incomingSearch, reservedParams) {
+    const incoming = new URLSearchParams(incomingSearch || '');
+    if (Array.from(incoming.keys()).length === 0) {
+        return url;
+    }
+
+    const reserved = {};
+    (reservedParams || []).forEach((name) => {
+        reserved[name] = true;
+    });
+
+    const hashIndex = url.indexOf('#');
+    const fragment = hashIndex === -1 ? '' : url.slice(hashIndex);
+    const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+    const queryIndex = beforeHash.indexOf('?');
+    const path =
+        queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+    const existing = new URLSearchParams(
+        queryIndex === -1 ? '' : beforeHash.slice(queryIndex + 1)
+    );
+
+    incoming.forEach((value, key) => {
+        if (reserved[key] || existing.has(key)) {
+            return; // never carry control params; destination's own value wins
+        }
+        existing.append(key, value);
+    });
+
+    const query = existing.toString();
+    return path + (query ? '?' + query : '') + fragment;
+}
+
+/**
+ * Wire the resolver against the DOM. `options` allow injecting the root element, a
+ * navigate function, a location object, and provider options (used in tests).
+ */
+export function initResolver(options) {
+    const opts = options || {};
+    const root =
+        opts.root ||
+        (typeof document !== 'undefined'
+            ? document.querySelector('.routing-resolver')
+            : null);
+    if (!root) {
+        return null;
+    }
+
+    const windowLocation =
+        opts.windowLocation ||
+        (typeof window !== 'undefined' ? window.location : null);
+    const navigate =
+        opts.navigate ||
+        function (url) {
+            // replace(), not assign(): this page renders *at* the canonical URL, so
+            // pushing the destination would leave the interstitial one Back press away —
+            // where it either bounces the visitor forward again or, restored from the
+            // back/forward cache, shows a frozen holding message with nothing to click.
+            // The same applies to the canonical fallback, whose loop-breaker would
+            // otherwise accumulate in history.
+            windowLocation.replace(url);
+        };
+
+    const rules = parseJSONAttribute(root, 'data-routing-rules') || [];
+    const manifest = parseJSONAttribute(root, 'data-routing-manifest') || {};
+    // Preview fake signals, if any, resolve immediately on the client.
+    const fakes = parseJSONAttribute(root, 'data-routing-fake-signals') || {};
+    const canonicalUrl = root.getAttribute('data-canonical-url') || '/';
+    const loopBreakerParam =
+        root.getAttribute('data-loop-breaker-param') || 'routed';
+
+    const baseOptions = opts.providerOptions || {};
+    const providerOptions = {
+        root: baseOptions.root,
+        client: baseOptions.client,
+        uiTour: baseOptions.uiTour,
+        search: baseOptions.search,
+        timeout: baseOptions.timeout,
+        fakes: baseOptions.fakes || fakes
+    };
+    const provider = createProvider(manifest, providerOptions);
+
+    // The inbound query string to carry through. Same source the URL signal reader
+    // uses, so signals and preserved attribution stay consistent.
+    const incomingSearch =
+        baseOptions.search !== undefined
+            ? baseOptions.search
+            : typeof window !== 'undefined' && window.location
+              ? window.location.search
+              : '';
+    const reservedParams = RESERVED_ROUTING_PARAMS.concat(loopBreakerParam);
+
+    return evaluateRules(rules, provider, opts.evaluatorOptions).then(
+        function (outcome) {
+            onResolveOutcome(outcome);
+            if (outcome.status === 'matched' && outcome.target) {
+                navigate(
+                    preserveQueryString(
+                        outcome.target,
+                        incomingSearch,
+                        reservedParams
+                    )
+                );
+            } else {
+                const fallback = preserveQueryString(
+                    canonicalUrl,
+                    incomingSearch,
+                    reservedParams
+                );
+                navigate(appendLoopBreaker(fallback, loopBreakerParam));
+            }
+            return outcome;
+        }
+    );
+}
+
+// Auto-run when loaded as a page bundle. A no-op in contexts without the resolver
+// element (e.g. unit tests import initResolver and drive it explicitly).
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            initResolver();
+        });
+    } else {
+        initResolver();
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -463,6 +463,12 @@
         "css/cms/themes/enterprise.css"
       ],
       "name": "flare-theme-enterprise"
+    },
+    {
+      "files": [
+        "css/cms/routing/resolver.scss"
+      ],
+      "name": "cms_routing_resolver"
     }
   ],
   "js": [
@@ -846,6 +852,12 @@
         "js/cms/flare-docs.js"
       ],
       "name": "flare-docs"
+    },
+    {
+      "files": [
+        "js/cms/routing/resolver.es6.js"
+      ],
+      "name": "cms_routing_resolver"
     }
   ]
 }

--- a/springfield/cms/routing/arming.py
+++ b/springfield/cms/routing/arming.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""The consumer trigger, framed as an arming condition.
+
+A consumer's trigger is *the condition under which routing fires for its surface*.
+Framing it as an abstraction — rather than hardcoding "a query param" — keeps a future
+non-param trigger (referrer, cookie, path, always-on) a new realization of the same
+interface, not a framework change (deferred). v1 ships exactly one
+realization: query-param presence.
+"""
+
+from springfield.cms.routing.params import TRIGGER_PARAM
+
+
+class ArmingCondition:
+    """Abstract arming condition: does this request arm routing for the surface?
+
+    Callers (the dispatcher) depend only on ``is_satisfied(request)``; the concrete
+    realization is swappable without touching them.
+    """
+
+    def is_satisfied(self, request) -> bool:
+        raise NotImplementedError
+
+
+class QueryParamArmingCondition(ArmingCondition):
+    """v1 realization: armed iff a query param is present on the request.
+
+    Presence-based: any value — including an empty one — counts, so
+    ``?routing`` and ``?routing=1`` both arm routing.
+    """
+
+    def __init__(self, param_name: str = TRIGGER_PARAM):
+        self.param_name = param_name
+
+    def is_satisfied(self, request) -> bool:
+        return self.param_name in request.GET
+
+
+class QueryParamValueArmingCondition(ArmingCondition):
+    """Armed iff a query param is present *and* its value is one of ``values``.
+
+    Value-matching, not presence-based: when a surface arms on a shared query param
+    (e.g. one ``utm_source`` value among many), it must fire only for that value and
+    stay dark for every other value of the same param (an empty value counts as a
+    mismatch). Single-purpose alongside the presence-only condition — each arming
+    strategy stays its own class.
+    """
+
+    def __init__(self, param_name: str, values):
+        self.param_name = param_name
+        self.values = frozenset(values)
+
+    def is_satisfied(self, request) -> bool:
+        return request.GET.get(self.param_name) in self.values

--- a/springfield/cms/routing/arming.py
+++ b/springfield/cms/routing/arming.py
@@ -2,34 +2,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""The consumer trigger, framed as an arming condition.
+"""The consumer trigger — the condition under which routing fires for a surface.
 
-A consumer's trigger is *the condition under which routing fires for its surface*.
-Framing it as an abstraction — rather than hardcoding "a query param" — keeps a future
-non-param trigger (referrer, cookie, path, always-on) a new realization of the same
-interface, not a framework change (deferred). v1 ships exactly one
-realization: query-param presence.
+An abstraction rather than a hardcoded query param, so a future referrer, cookie or
+path trigger is a new subclass rather than a change to the serve path.
 """
 
 from springfield.cms.routing.params import TRIGGER_PARAM
 
 
 class ArmingCondition:
-    """Abstract arming condition: does this request arm routing for the surface?
-
-    Callers (the dispatcher) depend only on ``is_satisfied(request)``; the concrete
-    realization is swappable without touching them.
-    """
+    """Abstract arming condition. Callers depend only on ``is_satisfied(request)``."""
 
     def is_satisfied(self, request) -> bool:
         raise NotImplementedError
 
 
 class QueryParamArmingCondition(ArmingCondition):
-    """v1 realization: armed iff a query param is present on the request.
+    """Armed iff a query param is present, whatever its value.
 
-    Presence-based: any value — including an empty one — counts, so
-    ``?routing`` and ``?routing=1`` both arm routing.
+    ``?routing`` and ``?routing=1`` both arm; an empty value still counts.
     """
 
     def __init__(self, param_name: str = TRIGGER_PARAM):
@@ -40,13 +32,10 @@ class QueryParamArmingCondition(ArmingCondition):
 
 
 class QueryParamValueArmingCondition(ArmingCondition):
-    """Armed iff a query param is present *and* its value is one of ``values``.
+    """Armed iff a query param holds one of ``values``.
 
-    Value-matching, not presence-based: when a surface arms on a shared query param
-    (e.g. one ``utm_source`` value among many), it must fire only for that value and
-    stay dark for every other value of the same param (an empty value counts as a
-    mismatch). Single-purpose alongside the presence-only condition — each arming
-    strategy stays its own class.
+    For a surface arming on a shared param — one ``utm_source`` value among many — which
+    must stay dark for every other value of it. An empty value is a mismatch.
     """
 
     def __init__(self, param_name: str, values):

--- a/springfield/cms/routing/dispatch.py
+++ b/springfield/cms/routing/dispatch.py
@@ -4,27 +4,22 @@
 
 """The serve-path routing decision.
 
-The decision order is expressed as a **pure function** of boolean flags — no request,
-no page, no Wagtail. This is what makes the highest-risk logic exhaustively testable
-without a mixin-bearing page and keeps routing *policy* separate from
-Wagtail plumbing (the thin ``serve()`` adapter lives on ``RoutingMixin``).
+A pure function of flags — no request, no page, no Wagtail — so the highest-risk logic
+is exhaustively testable and policy stays out of the ``serve()`` adapter.
 
-The two database-backed flags arrive as zero-argument callables, consulted only if the
-order below actually reaches them. Passing them as values would run both on every request
-to an adopted page — including when the switch is off, which is the one case that must
-cost nothing at all.
+``is_paused`` and ``has_live_rules`` arrive as callables, consulted only if the order
+below reaches them. As values they would cost a query each on every request to an
+adopted page, including while the switch is off.
 
 The order is fixed and must not be reordered:
 
-0. Global ``user_routing`` switch off  → canonical  (outermost operational gate)
-1. Loop-breaker marker present         → canonical  (checked FIRST after the switch, so
-                                                      a fallen-through user can never
-                                                      re-enter routing)
-2. Preview param + admin               → preview flow
-3. Kill switch engaged                 → canonical
-4. Trigger satisfied AND live canonical
-   with >= 1 live rule                 → resolver page
-5. Otherwise                           → canonical
+0. Switch off              → canonical
+1. Loop-breaker present    → canonical  (before everything else, so a visitor who has
+                                         fallen through cannot re-enter)
+2. Preview param + admin   → preview
+3. Kill switch engaged     → canonical
+4. Triggered, canonical, ≥1 live rule → resolver
+5. Otherwise               → canonical
 """
 
 # The waffle switch name that gates the whole framework (ships off — dark).

--- a/springfield/cms/routing/dispatch.py
+++ b/springfield/cms/routing/dispatch.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""The serve-path routing decision.
+
+The decision order is expressed as a **pure function** of boolean flags — no request,
+no page, no Wagtail. This is what makes the highest-risk logic exhaustively testable
+without a mixin-bearing page and keeps routing *policy* separate from
+Wagtail plumbing (the thin ``serve()`` adapter lives on ``RoutingMixin``).
+
+The order is fixed and must not be reordered:
+
+0. Global ``user_routing`` switch off  → canonical  (outermost operational gate)
+1. Loop-breaker marker present         → canonical  (checked FIRST after the switch, so
+                                                      a fallen-through user can never
+                                                      re-enter routing)
+2. Preview param + admin               → preview flow
+3. Kill switch engaged                 → canonical
+4. Trigger satisfied AND live canonical
+   with >= 1 live rule                 → resolver page
+5. Otherwise                           → canonical
+"""
+
+# The waffle switch name that gates the whole framework (ships off — dark).
+USER_ROUTING_SWITCH = "user_routing"
+
+# Decision outcomes.
+SERVE_CANONICAL = "canonical"
+SERVE_PREVIEW = "preview"
+SERVE_RESOLVER = "resolver"
+
+
+def decide_routing(
+    *,
+    routing_enabled,
+    has_loop_breaker,
+    is_preview_admin,
+    is_paused,
+    trigger_satisfied,
+    is_canonical,
+    has_live_rules,
+):
+    """Return the serve-path branch for the given flags.
+
+    Keyword-only args so the flag mapping is always explicit at the call site.
+    """
+    if not routing_enabled:
+        return SERVE_CANONICAL
+    if has_loop_breaker:
+        return SERVE_CANONICAL
+    if is_preview_admin:
+        return SERVE_PREVIEW
+    if is_paused:
+        return SERVE_CANONICAL
+    if trigger_satisfied and is_canonical and has_live_rules:
+        return SERVE_RESOLVER
+    return SERVE_CANONICAL

--- a/springfield/cms/routing/dispatch.py
+++ b/springfield/cms/routing/dispatch.py
@@ -9,6 +9,11 @@ no page, no Wagtail. This is what makes the highest-risk logic exhaustively test
 without a mixin-bearing page and keeps routing *policy* separate from
 Wagtail plumbing (the thin ``serve()`` adapter lives on ``RoutingMixin``).
 
+The two database-backed flags arrive as zero-argument callables, consulted only if the
+order below actually reaches them. Passing them as values would run both on every request
+to an adopted page — including when the switch is off, which is the one case that must
+cost nothing at all.
+
 The order is fixed and must not be reordered:
 
 0. Global ``user_routing`` switch off  → canonical  (outermost operational gate)
@@ -44,6 +49,7 @@ def decide_routing(
     """Return the serve-path branch for the given flags.
 
     Keyword-only args so the flag mapping is always explicit at the call site.
+    ``is_paused`` and ``has_live_rules`` are callables — see the module docstring.
     """
     if not routing_enabled:
         return SERVE_CANONICAL
@@ -51,8 +57,10 @@ def decide_routing(
         return SERVE_CANONICAL
     if is_preview_admin:
         return SERVE_PREVIEW
-    if is_paused:
+    if is_paused():
         return SERVE_CANONICAL
-    if trigger_satisfied and is_canonical and has_live_rules:
+    # `and` short-circuits, so an untriggered or non-canonical page never reaches the
+    # rule scan — which is every organic request to an adopted page.
+    if trigger_satisfied and is_canonical and has_live_rules():
         return SERVE_RESOLVER
     return SERVE_CANONICAL

--- a/springfield/cms/routing/mixins.py
+++ b/springfield/cms/routing/mixins.py
@@ -1,0 +1,107 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""The routing adoption mixin.
+
+``RoutingMixin`` is the whole adoption surface a consumer page type touches. It
+declares exactly two overridable hooks — a **trigger** and an **eligibility predicate**
+— and adapts the serve path onto them. It adds **no database fields** (all state lives in
+the routing tables keyed to ``wagtailcore.Page``), so adopting it produces **no
+migration**.
+
+The admin authoring surface — the "User Routing" edit tab and its page form — reopens
+this class in a later change; this one owns the declaration surface and dispatch.
+"""
+
+from django.db import models
+
+import waffle
+
+from springfield.cms.routing.dispatch import SERVE_PREVIEW, SERVE_RESOLVER, USER_ROUTING_SWITCH, decide_routing
+from springfield.cms.routing.models import RoutingConfig
+from springfield.cms.routing.params import LOOP_BREAKER_PARAM
+
+
+class RoutingMixin(models.Model):
+    """Abstract mixin a Wagtail page type mixes in to adopt routing.
+
+    A consumer declares exactly two things by overriding the hooks below and adds
+    no view code, no framework code, and no schema. List this mixin **before** the
+    page base class so its ``get_edit_handler`` wins in the MRO.
+    """
+
+    class Meta:
+        abstract = True
+
+    # -- Adoption surface: the only two things a consumer declares --
+
+    def get_routing_trigger(self):
+        """This surface's trigger — the arming condition under which routing fires.
+
+        Default **unset** (``None``): absent a trigger, dispatch never fires and
+        organic traffic is untouched. A consumer overrides this to return its arming
+        condition.
+        """
+        return None
+
+    def is_routing_canonical(self):
+        """Whether this page may *host* rules — the consumer's notion of "canonical".
+
+        Framework default is **fail-closed** (``False``): a half-adopted
+        consumer never routes and never shows the routing tab. Each consumer overrides
+        this with a predicate over its own tree.
+        """
+        return False
+
+    # -- Serve-path dispatch --
+
+    def _routing_trigger_satisfied(self, request):
+        """Whether this request arms routing for the surface (consumer trigger)."""
+        trigger = self.get_routing_trigger()
+        return bool(trigger is not None and trigger.is_satisfied(request))
+
+    def _has_live_routing_rules(self):
+        """Whether the page hosts at least one rule that could route a visitor.
+
+        Asks the same question the serializer answers, through the same code, so the gate
+        can never let a page serve a resolver the serializer then empties — or withhold
+        one whose rules resolve perfectly well in this locale.
+        """
+        # Imported at call time for the same reason serve() does: keeps the resolver's
+        # l10n import chain out of model loading.
+        from springfield.cms.routing.resolver import usable_rules
+
+        return bool(usable_rules(self))
+
+    def serve(self, request, *args, **kwargs):
+        """Thin adapter: map request/page state onto flags, then act on the decision.
+
+        Routing *policy* lives in the pure ``decide_routing`` function; this method only
+        reads the flags off the request and page and performs the chosen branch. The
+        global ``user_routing`` waffle switch is the outermost gate — off ⇒ canonical
+        exactly as today (the framework ships dark).
+        """
+        # Imported here (request time) to keep the resolver/preview + l10n import chain
+        # out of model loading; dispatch only matters when a page is actually served.
+        from springfield.cms.routing.preview import get_preview_response, is_preview_admin, is_preview_request
+        from springfield.cms.routing.resolver import render_resolver
+
+        decision = decide_routing(
+            routing_enabled=waffle.switch_is_active(USER_ROUTING_SWITCH),
+            has_loop_breaker=bool(request.GET.get(LOOP_BREAKER_PARAM)),
+            is_preview_admin=is_preview_request(request) and is_preview_admin(request),
+            is_paused=RoutingConfig.is_paused_for(self),
+            trigger_satisfied=self._routing_trigger_satisfied(request),
+            is_canonical=self.is_routing_canonical(),
+            has_live_rules=self._has_live_routing_rules(),
+        )
+
+        if decision == SERVE_RESOLVER:
+            return render_resolver(request, self)
+        if decision == SERVE_PREVIEW:
+            preview_response = get_preview_response(request, self)
+            if preview_response is not None:
+                return preview_response
+        # SERVE_CANONICAL (and any preview that produced nothing) — serve as today.
+        return super().serve(request, *args, **kwargs)

--- a/springfield/cms/routing/mixins.py
+++ b/springfield/cms/routing/mixins.py
@@ -82,19 +82,28 @@ class RoutingMixin(models.Model):
         global ``user_routing`` waffle switch is the outermost gate — off ⇒ canonical
         exactly as today (the framework ships dark).
         """
+        # Raw switch_is_active, deliberately not springfield.base.waffle.switch, which
+        # treats a missing switch as settings.DEV — that would put every local dev on the
+        # routing path. Checked here as well as in decide_routing so a dark page returns
+        # before importing the resolver chain or touching the database.
+        if not waffle.switch_is_active(USER_ROUTING_SWITCH):
+            return super().serve(request, *args, **kwargs)
+
         # Imported here (request time) to keep the resolver/preview + l10n import chain
         # out of model loading; dispatch only matters when a page is actually served.
         from springfield.cms.routing.preview import get_preview_response, is_preview_admin, is_preview_request
         from springfield.cms.routing.resolver import render_resolver
 
+        # The two database-backed flags are passed unevaluated; decide_routing calls them
+        # only if its precedence reaches them.
         decision = decide_routing(
-            routing_enabled=waffle.switch_is_active(USER_ROUTING_SWITCH),
+            routing_enabled=True,
             has_loop_breaker=bool(request.GET.get(LOOP_BREAKER_PARAM)),
             is_preview_admin=is_preview_request(request) and is_preview_admin(request),
-            is_paused=RoutingConfig.is_paused_for(self),
+            is_paused=lambda: RoutingConfig.is_paused_for(self),
             trigger_satisfied=self._routing_trigger_satisfied(request),
             is_canonical=self.is_routing_canonical(),
-            has_live_rules=self._has_live_routing_rules(),
+            has_live_rules=self._has_live_routing_rules,
         )
 
         if decision == SERVE_RESOLVER:

--- a/springfield/cms/routing/mixins.py
+++ b/springfield/cms/routing/mixins.py
@@ -4,14 +4,11 @@
 
 """The routing adoption mixin.
 
-``RoutingMixin`` is the whole adoption surface a consumer page type touches. It
-declares exactly two overridable hooks — a **trigger** and an **eligibility predicate**
-— and adapts the serve path onto them. It adds **no database fields** (all state lives in
-the routing tables keyed to ``wagtailcore.Page``), so adopting it produces **no
-migration**.
+The whole surface a consumer page type touches: two overridable hooks — a **trigger** and
+an **eligibility predicate** — and the serve path adapted onto them. It adds no database
+fields, so adopting it produces no migration.
 
-The admin authoring surface — the "User Routing" edit tab and its page form — reopens
-this class in a later change; this one owns the declaration surface and dispatch.
+The "User Routing" edit tab and its page form reopen this class in a later change.
 """
 
 from django.db import models
@@ -75,12 +72,10 @@ class RoutingMixin(models.Model):
         return bool(usable_rules(self))
 
     def serve(self, request, *args, **kwargs):
-        """Thin adapter: map request/page state onto flags, then act on the decision.
+        """Thin adapter: read the flags, hand them to ``decide_routing``, act on the answer.
 
-        Routing *policy* lives in the pure ``decide_routing`` function; this method only
-        reads the flags off the request and page and performs the chosen branch. The
-        global ``user_routing`` waffle switch is the outermost gate — off ⇒ canonical
-        exactly as today (the framework ships dark).
+        Policy lives in that pure function, not here. The ``user_routing`` switch is the
+        outermost gate — off means canonical, exactly as today.
         """
         # Raw switch_is_active, deliberately not springfield.base.waffle.switch, which
         # treats a missing switch as settings.DEV — that would put every local dev on the

--- a/springfield/cms/routing/models.py
+++ b/springfield/cms/routing/models.py
@@ -41,8 +41,10 @@ _SET_MEMBERSHIP_OPERATORS = ("in", "not_in")
 # boolean to false rather than ignoring it, so "ture" would save and match the opposite audience.
 _BOOLEAN_LITERALS = frozenset({"true", "false", "1", "0"})
 _INTEGER_RE = re.compile(r"^[+-]?\d+$")
-# Bare (129), prefixed (rv:129) and dotted (129.0.1), mirroring normalizeVersion().
-_VERSION_RE = re.compile(r"^\D*\d+(?:\.\d+)*$")
+# Bare (129), rv-prefixed (rv:129) and dotted (129.0.1), and nothing else — the same
+# grammar as normalizeVersion() in evaluator.es6.js. Keep the two in step: a value this
+# accepts but the client cannot parse becomes a rule that never fires.
+_VERSION_RE = re.compile(r"^(?:rv:)?\d+(?:\.\d+)*$")
 
 
 def signal_choices():

--- a/springfield/cms/routing/params.py
+++ b/springfield/cms/routing/params.py
@@ -2,31 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Centralized routing query-param names.
+"""The query params routing reads, named in one place."""
 
-Single source of truth for the query params the framework reads across the serve-path
-dispatcher, the resolver, the loop-breaker, and the preview flows — so no later commit
-hardcodes these string literals.
-"""
-
-# Default trigger param whose presence arms routing for a surface. A
-# consumer supplies its own arming condition; this is the canonical param the
-# query-param realization uses unless a consumer overrides it.
+# The default arming param. A consumer can supply its own arming condition instead.
 TRIGGER_PARAM = "routing"
 
-# Loop-breaker marker. When the resolver falls through (no match / timeout)
-# it navigates to the canonical URL with this param appended; the dispatcher serves
-# canonical content on any non-empty value, so a fallen-through user cannot re-enter.
+# Appended to the canonical URL when the resolver falls through, so a visitor who has
+# already fallen through cannot re-enter routing. Any non-empty value counts.
 LOOP_BREAKER_PARAM = "routed"
 
 # Preview flow params, both admin-authenticated only.
 PREVIEW_RULE_PARAM = "preview_rule"
 PREVIEW_SIGNAL_PARAM = "preview_signal"
 
-# The framework's own control params, which must never be carried onto a destination: they
-# would re-arm routing, re-enter the loop, or leak preview state. Anything else a visitor
-# arrived with is attribution and rides along.
-#
-# ``RESERVED_ROUTING_PARAMS`` in ``resolver.es6.js`` mirrors this list by hand — the client
-# has no way to read it — so a change here needs the same change there.
+# Never carried onto a destination: they would re-arm routing, re-enter the loop, or leak
+# preview state. Anything else the visitor arrived with is attribution and rides along.
+# Mirrored by hand in resolver.es6.js, which cannot read this — change both together.
 RESERVED_ROUTING_PARAMS = (TRIGGER_PARAM, LOOP_BREAKER_PARAM, PREVIEW_RULE_PARAM, PREVIEW_SIGNAL_PARAM)

--- a/springfield/cms/routing/params.py
+++ b/springfield/cms/routing/params.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Centralized routing query-param names.
+
+Single source of truth for the query params the framework reads across the serve-path
+dispatcher, the resolver, the loop-breaker, and the preview flows — so no later commit
+hardcodes these string literals.
+"""
+
+# Default trigger param whose presence arms routing for a surface. A
+# consumer supplies its own arming condition; this is the canonical param the
+# query-param realization uses unless a consumer overrides it.
+TRIGGER_PARAM = "routing"
+
+# Loop-breaker marker. When the resolver falls through (no match / timeout)
+# it navigates to the canonical URL with this param appended; the dispatcher serves
+# canonical content on any non-empty value, so a fallen-through user cannot re-enter.
+LOOP_BREAKER_PARAM = "routed"
+
+# Preview flow params, both admin-authenticated only.
+PREVIEW_RULE_PARAM = "preview_rule"
+PREVIEW_SIGNAL_PARAM = "preview_signal"
+
+# The framework's own control params, which must never be carried onto a destination: they
+# would re-arm routing, re-enter the loop, or leak preview state. Anything else a visitor
+# arrived with is attribution and rides along.
+#
+# ``RESERVED_ROUTING_PARAMS`` in ``resolver.es6.js`` mirrors this list by hand — the client
+# has no way to read it — so a change here needs the same change there.
+RESERVED_ROUTING_PARAMS = (TRIGGER_PARAM, LOOP_BREAKER_PARAM, PREVIEW_RULE_PARAM, PREVIEW_SIGNAL_PARAM)

--- a/springfield/cms/routing/preview.py
+++ b/springfield/cms/routing/preview.py
@@ -1,0 +1,114 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Admin-only routing preview flows.
+
+Two flows let authors verify routing, including while a page is paused — both are
+**admin-authenticated only**, both respond ``Cache-Control: no-store``, and both
+**bypass the kill switch**:
+
+* ``preview_rule={id}`` — a server-side 302 straight to the rule's target, skipping
+  signal evaluation entirely. The target is resolved the way the serve path resolves it, and
+  a rule that could not route a visitor is *reported as such* rather than redirected to:
+  preview exists to say what visitors get, so it must never flatter a broken rule.
+* ``preview_signal=name:value`` (repeatable) — renders the resolver with *fake* signal
+  values injected via a ``data-*`` blob (the same attribute-on-the-page convention as
+  the rest of the resolver), so the author exercises the real client evaluation path:
+  faked signals resolve immediately, un-faked signals still read live.
+
+The serve-path dispatcher calls :func:`get_preview_response` before the kill
+switch and the trigger checks; a ``None`` return means "no preview — fall through".
+"""
+
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.utils.translation import gettext as _
+
+from springfield.cms.routing.models import localized_target
+from springfield.cms.routing.params import PREVIEW_RULE_PARAM, PREVIEW_SIGNAL_PARAM
+from springfield.cms.routing.resolver import (
+    render_resolver,
+    rule_problems,
+    url_in_requested_locale,
+)
+from springfield.cms.routing.signals import registry
+
+
+def is_preview_request(request) -> bool:
+    """Whether the request carries either preview param (regardless of auth)."""
+    return PREVIEW_RULE_PARAM in request.GET or PREVIEW_SIGNAL_PARAM in request.GET
+
+
+def is_preview_admin(request) -> bool:
+    """Whether the requester may use the preview flows (a signed-in staff user)."""
+    user = getattr(request, "user", None)
+    return bool(user and user.is_authenticated and user.is_staff)
+
+
+def parse_fake_signals(values):
+    """Parse repeated ``name:value`` preview params into a ``{name: value}`` map.
+
+    Unknown signal names and malformed items are ignored.
+    """
+    fakes = {}
+    for item in values:
+        name, separator, value = item.partition(":")
+        if separator and name in registry:
+            fakes[name] = value
+    return fakes
+
+
+def _no_store(response):
+    response["Cache-Control"] = "no-store"
+    return response
+
+
+def _inert(message):
+    """Report a rule that will not fire, instead of redirecting to a page visitors never see."""
+    return _no_store(HttpResponse(message, content_type="text/plain; charset=utf-8"))
+
+
+def _preview_rule(request, page):
+    rule_id = request.GET.get(PREVIEW_RULE_PARAM)
+    if not rule_id or not rule_id.isdigit():
+        return None
+    rule = page.routing_rules.filter(pk=int(rule_id)).first()
+    if not rule:
+        return None
+    # The same reason vocabulary the rules listing shows, so the two surfaces cannot describe
+    # one rule differently.
+    problem = rule_problems(page).get(rule.pk)
+    if problem:
+        return _inert(_("This rule never fires: %(reason)s.") % {"reason": problem.message})
+    # Resolved exactly as the resolver resolves it: this locale's version of the target,
+    # carrying the locale prefix the requester asked for.
+    url = url_in_requested_locale(localized_target(rule.target, page), request)
+    if not url:
+        # An unroutable page (no site) has no URL, and redirect(None) would 500.
+        return _inert(_("This rule's target has no URL, so it never fires."))
+    # Straight 302 to the target; signal evaluation is skipped entirely.
+    return _no_store(redirect(url))
+
+
+def _preview_signal(request, page):
+    fakes = parse_fake_signals(request.GET.getlist(PREVIEW_SIGNAL_PARAM))
+    # ``render_resolver`` patches the request itself, which matters here: this is a live
+    # request from an author, not a Wagtail preview, so it needs the page's locales like any
+    # other serve — otherwise the author is redirected out of the locale they are checking.
+    return _no_store(render_resolver(request, page, fake_signals=fakes))
+
+
+def get_preview_response(request, page):
+    """Return an admin preview response, or ``None`` to fall through to normal serve.
+
+    Non-admin requests carrying preview params fall through (the params are ignored).
+    Both flows bypass the page kill switch by construction — they never consult it.
+    """
+    if not is_preview_admin(request):
+        return None
+    if PREVIEW_RULE_PARAM in request.GET:
+        return _preview_rule(request, page)
+    if PREVIEW_SIGNAL_PARAM in request.GET:
+        return _preview_signal(request, page)
+    return None

--- a/springfield/cms/routing/resolver.py
+++ b/springfield/cms/routing/resolver.py
@@ -1,0 +1,265 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Server-side rendering of the client resolver page.
+
+When a triggered request reaches a live canonical with rules, the page
+serves this lightweight resolver instead of final content. The resolver ships the data
+the client needs — the page's rules and the metadata for the signals they test — as
+``data-*`` attributes (CSP-clean, no inline script), plus the server-rendered country
+attribute and localized status strings via Fluent. All rule evaluation happens on the
+client; the server does no matching.
+
+Resolver responses are CDN-cacheable, and state their own lifetime — see
+``ROUTING_RESOLVER_CACHE_SECONDS``, which is how long the frozen target URLs, pause state and
+country may be stale, since nothing purges this page. The preview flows add ``no-store``
+themselves.
+"""
+
+from collections import namedtuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
+
+from lib import l10n_utils
+from springfield.cms.routing.models import localized_target
+from springfield.cms.routing.params import LOOP_BREAKER_PARAM, RESERVED_ROUTING_PARAMS
+from springfield.cms.routing.signals import registry
+
+RESOLVER_TEMPLATE = "cms/routing/resolver.html"
+RESOLVER_FTL = "cms-routing-resolver"
+
+
+def url_in_requested_locale(page, request):
+    """The page's URL carrying the locale prefix the visitor actually asked for.
+
+    For an alias locale (es-AR served from es-MX, pt-PT from pt-BR, en-GB from en-US) the
+    content comes from the fallback locale while the URL keeps the requested one. Raw
+    ``get_url`` returns the *page's* prefix, which would move the visitor out of the locale
+    they asked for on the one navigation this page exists to perform.
+
+    Rule targets are stored as base ``Page``, so the specific instance is what carries the
+    helper. A target whose type isn't a springfield CMS page falls back to ``get_url``: the
+    ORM/API path can attach any page, and an un-rewritten prefix beats a 500 for a
+    triggered visitor.
+    """
+    specific = page.specific
+    active_locale_url = getattr(specific, "get_active_locale_url", None)
+    return active_locale_url(request) if active_locale_url else specific.get_url(request)
+
+
+def fallback_url(page, request):
+    """Where a visitor goes when the client never redirects them.
+
+    The canonical URL, keeping the visitor's own query string so their attribution survives —
+    minus the framework's control params, plus the loop-breaker. The loop-breaker is not
+    optional: this URL still carries whatever armed routing in the first place, so without it
+    the destination would serve the resolver again.
+
+    Mirrors what ``preserveQueryString`` plus ``appendLoopBreaker`` do on the client, for the
+    two paths the client never reaches — the ``<noscript>`` refresh and the escape link.
+
+    **Depends on the CDN keying on the full URL, query string included.** That is what makes it
+    safe to render per-request data into a cacheable body: the response can only ever be served
+    to a request whose query string is the one rendered into it. If that ever stops being true,
+    this has to go back to a bare canonical URL.
+    """
+    url = url_in_requested_locale(page, request)
+    parts = urlsplit(url)
+    kept = parse_qsl(parts.query, keep_blank_values=True)
+    seen = {name for name, _value in kept}
+    if request is not None:
+        for name, value in parse_qsl(request.META.get("QUERY_STRING", ""), keep_blank_values=True):
+            if name in RESERVED_ROUTING_PARAMS or name in seen:
+                continue
+            kept.append((name, value))
+    kept.append((LOOP_BREAKER_PARAM, "1"))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(kept), parts.fragment))
+
+
+UsableRule = namedtuple("UsableRule", ["rule", "target"])
+
+
+def usable_rules(page):
+    """The page's rules that could actually route a visitor, in priority order.
+
+    The single definition of "this page has routing", shared by the serve-path gate and
+    the serializer so the two can never disagree. When they did, a page either served a
+    resolver with no rules in it — a holding page and an immediate bounce back to where
+    the visitor already was — or refused to route on rules that would have worked.
+
+    Every floor lives here rather than at either caller:
+
+    * the target resolved into the page's own locale (see ``localized_target``), which
+      drops a rule whose target has no version in this locale
+    * that resolved target must be published — never route to an unpublished page
+    * the target must be a strict descendant of the hosting page. Copying a page copies
+      its rules, whose targets still point into the *source* page's subtree; and a target
+      that is the page itself would send the visitor to the URL they are already on,
+      re-rendering the resolver with no loop-breaker to stop the cycle.
+    * a rule with neither conditions nor ``match_all`` is dropped: it would match every
+      triggered visitor. Authoring one is blocked, but the ORM/API path has no such
+      floor, so this is the backstop.
+
+    Returns ``(rule, target)`` pairs in the model's position-then-id order; empty means
+    the page has nothing to route with. Evaluating each rule's conditions here caches
+    them on the rule instance, so the serializer's formatting pass is free.
+    """
+    usable = []
+    for rule in page.routing_rules.all():
+        target = localized_target(rule.target, page)
+        if not target or not target.live:
+            continue
+        # Strict descendant, so a rule targeting its own page is dropped here too — a page
+        # is not its own descendant.
+        if not target.is_descendant_of(page):
+            continue
+        if not rule.conditions.all() and not rule.match_all:
+            continue
+        usable.append(UsableRule(rule, target))
+    return usable
+
+
+RuleProblem = namedtuple("RuleProblem", ["message", "pending"])
+
+
+def rule_problems(page):
+    """Why each of ``page``'s rules cannot route a visitor: ``{rule pk: RuleProblem}``.
+
+    Rules that *can* route are absent from the map. Which rules are unusable is decided by
+    ``usable_rules`` — the same answer the serve path acts on — so an authoring surface can
+    report what visitors get without forming its own opinion. The checks below only choose
+    the wording.
+
+    ``pending`` separates the two states that clear themselves through work already under
+    way — the target is translated or published later — from the ones that stay broken until
+    somebody changes the rule. Without that distinction the whole report is noise: an
+    ordinary staged translation would light up exactly like a page-copy mistake, and authors
+    would learn to ignore both.
+    """
+    usable_ids = {usable.rule.pk for usable in usable_rules(page)}
+    problems = {}
+    for rule in page.routing_rules.all():
+        if rule.pk in usable_ids:
+            continue
+        problems[rule.pk] = _rule_problem(rule, page)
+    return problems
+
+
+def _rule_problem(rule, page):
+    if rule.target is None:
+        return RuleProblem(_("No target page"), pending=False)
+    target = localized_target(rule.target, page)
+    if target is None:
+        return RuleProblem(_("Target not translated into this language yet"), pending=True)
+    if not target.live:
+        return RuleProblem(_("Target not published yet"), pending=True)
+    if not target.is_descendant_of(page):
+        return RuleProblem(_("Target is not part of this page"), pending=False)
+    return RuleProblem(_("No conditions, and not set to match all"), pending=False)
+
+
+def serialize_rules(page, request=None):
+    """Format the page's usable rules into the shape the client evaluator consumes.
+
+    Pure formatting over ``usable_rules`` — every decision about which rules survive
+    belongs there. Each condition carries the signal's value type from the registry so
+    the evaluator can compare correctly, and a rule's ``matchAll`` flag is emitted so the
+    client can route the whole triggered audience for an intentional match-all rule.
+
+    A match-all rule is emitted **without** its conditions. The client matches such a rule
+    outright, so any conditions stored against it are inert; shipping them anyway would
+    make the payload contradict itself, and invite a later reader to "fix" the client into
+    honouring conditions the author was told were ignored. The editor says so too — see
+    ``match_all``'s help text and the conditions panel's.
+    """
+    serialized = []
+    for rule, target in usable_rules(page):
+        conditions = []
+        for condition in [] if rule.match_all else rule.conditions.all():
+            signal = registry.get(condition.signal) if condition.signal in registry else None
+            conditions.append(
+                {
+                    "signal": condition.signal,
+                    "operator": condition.operator,
+                    "expected": condition.expected_value,
+                    "valueType": signal.value_type.value if signal else None,
+                }
+            )
+        serialized.append({"target": url_in_requested_locale(target, request), "matchAll": rule.match_all, "conditions": conditions})
+    return serialized
+
+
+def serialize_manifest(rules):
+    """Signal metadata the client provider needs, for every signal the rules reference.
+
+    Maps signal name -> {source, browserStateKey, valueType}. Serialized from the
+    registry so the client reads each signal from the correct source with the correct
+    per-key budget.
+    """
+    manifest = {}
+    for rule in rules:
+        for condition in rule["conditions"]:
+            name = condition["signal"]
+            if name in manifest or name not in registry:
+                continue
+            signal = registry.get(name)
+            manifest[name] = {
+                "source": signal.source.value,
+                "browserStateKey": signal.browser_state_key,
+                "valueType": signal.value_type.value,
+            }
+    return manifest
+
+
+def patch_request_for_resolver(request, page):
+    """Apply the request setup a normal page serve does, for the resolver path.
+
+    Rendering the resolver skips ``AbstractSpringfieldCMSPage.serve()``, and with it both
+    the ``is_preview`` flag and the page's own list of available locales. Without that list
+    the Fluent render falls back to the resolver strings' activation state and redirects any
+    visitor whose locale is missing from it — a German visitor asking for the German
+    canonical is sent to ``/en-US/``. Every other CMS page resolves locales from the page
+    tree; the resolver must not be the one exception.
+
+    Called by ``render_resolver`` itself, deliberately: a caller that has to remember this
+    reintroduces that redirect the moment one forgets, and the failure is invisible — the
+    page renders, the suite stays green, and only non-English visitors are affected. Since
+    nothing renders the resolver without going through ``render_resolver``, the locale
+    queries land on the resolver path only, never on canonical traffic.
+    """
+    request.is_preview = False
+    return page._patch_request_for_springfield(request)
+
+
+def render_resolver(request, page, fake_signals=None):
+    """Render the resolver page for ``page`` and its live rules.
+
+    ``fake_signals`` (a ``{name: value}`` map, used by the preview_signal flow) is
+    serialized into a ``data-*`` blob so the client
+    resolves those signals immediately while reading the rest live.
+
+    States its own cache lifetime rather than inheriting the site-wide default, because this
+    page freezes state into a cacheable body that nothing purges — see
+    ``ROUTING_RESOLVER_CACHE_SECONDS``. The preview flows overwrite this with ``no-store``.
+    """
+    request = patch_request_for_resolver(request, page)
+    rules = serialize_rules(page, request)
+    context = {
+        "page": page,
+        "routing_rules": rules,
+        "routing_manifest": serialize_manifest(rules),
+        "canonical_url": url_in_requested_locale(page, request),
+        # Where a stranded visitor goes: canonical, attribution intact, loop-breaker attached.
+        "fallback_url": fallback_url(page, request),
+        "loop_breaker_param": LOOP_BREAKER_PARAM,
+        "routing_fake_signals": fake_signals or None,
+    }
+    response = l10n_utils.render(request, RESOLVER_TEMPLATE, context, ftl_files=[RESOLVER_FTL])
+    if response.status_code == 200:
+        # Setting this here also stops the site-wide cache middleware stamping its own value:
+        # it defers to any response that already carries Cache-Control.
+        response["Cache-Control"] = f"max-age={settings.ROUTING_RESOLVER_CACHE_SECONDS}"
+    return response

--- a/springfield/cms/routing/resolver.py
+++ b/springfield/cms/routing/resolver.py
@@ -4,17 +4,14 @@
 
 """Server-side rendering of the client resolver page.
 
-When a triggered request reaches a live canonical with rules, the page
-serves this lightweight resolver instead of final content. The resolver ships the data
-the client needs — the page's rules and the metadata for the signals they test — as
-``data-*`` attributes (CSP-clean, no inline script), plus the server-rendered country
-attribute and localized status strings via Fluent. All rule evaluation happens on the
-client; the server does no matching.
+A triggered request to a live canonical with rules gets this lightweight page instead of
+final content. It ships the rules and their signals' metadata as ``data-*`` attributes
+(CSP-clean, no inline script), plus the server-rendered country and localized strings.
+**All matching happens on the client** — the server never evaluates a rule.
 
-Resolver responses are CDN-cacheable, and state their own lifetime — see
-``ROUTING_RESOLVER_CACHE_SECONDS``, which is how long the frozen target URLs, pause state and
-country may be stale, since nothing purges this page. The preview flows add ``no-store``
-themselves.
+Responses are CDN-cacheable and state their own lifetime via
+``ROUTING_RESOLVER_CACHE_SECONDS``: how long frozen target URLs, pause state and country
+may be stale, since nothing purges this page. Preview flows send ``no-store`` instead.
 """
 
 from collections import namedtuple
@@ -86,26 +83,21 @@ def usable_rules(page):
     """The page's rules that could actually route a visitor, in priority order.
 
     The single definition of "this page has routing", shared by the serve-path gate and
-    the serializer so the two can never disagree. When they did, a page either served a
-    resolver with no rules in it — a holding page and an immediate bounce back to where
-    the visitor already was — or refused to route on rules that would have worked.
+    the serializer so the two cannot disagree — when they did, a page either served an
+    empty resolver (a holding page, then a bounce straight back) or refused to route on
+    rules that would have worked.
 
-    Every floor lives here rather than at either caller:
+    Every floor lives here rather than at either caller. A rule is dropped when:
 
-    * the target resolved into the page's own locale (see ``localized_target``), which
-      drops a rule whose target has no version in this locale
-    * that resolved target must be published — never route to an unpublished page
-    * the target must be a strict descendant of the hosting page. Copying a page copies
-      its rules, whose targets still point into the *source* page's subtree; and a target
-      that is the page itself would send the visitor to the URL they are already on,
-      re-rendering the resolver with no loop-breaker to stop the cycle.
-    * a rule with neither conditions nor ``match_all`` is dropped: it would match every
-      triggered visitor. Authoring one is blocked, but the ORM/API path has no such
-      floor, so this is the backstop.
+    * its target has no version in this page's locale (see ``localized_target``)
+    * that resolved target is unpublished
+    * the target is not a strict descendant of the hosting page — copying a page copies
+      its rules, whose targets still point into the source subtree, and a self-target
+      would re-render the resolver with no loop-breaker to stop the cycle
+    * it has neither conditions nor ``match_all``, which would match every triggered
+      visitor. Authoring one is blocked; this is the backstop for the ORM/API path.
 
-    Returns ``(rule, target)`` pairs in the model's position-then-id order; empty means
-    the page has nothing to route with. Evaluating each rule's conditions here caches
-    them on the rule instance, so the serializer's formatting pass is free.
+    Returns ``(rule, target)`` pairs in position-then-id order.
     """
     # Memoized for the life of this page *instance* — one request, where the gate asks and
     # then the serializer asks again. It makes the two share a single answer rather than two

--- a/springfield/cms/routing/resolver.py
+++ b/springfield/cms/routing/resolver.py
@@ -107,8 +107,19 @@ def usable_rules(page):
     the page has nothing to route with. Evaluating each rule's conditions here caches
     them on the rule instance, so the serializer's formatting pass is free.
     """
+    # Memoized for the life of this page *instance* — one request, where the gate asks and
+    # then the serializer asks again. It makes the two share a single answer rather than two
+    # that merely ought to agree. A caller that mutates rules and re-asks the same instance
+    # would see the stale list, so re-fetch the page instead (which is what a request does).
+    cached = getattr(page, "_usable_rules_cache", None)
+    if cached is not None:
+        return cached
+
     usable = []
-    for rule in page.routing_rules.all():
+    # Pull targets in the same query and conditions in one more, so the loop below adds no
+    # query per rule. The locale lookup inside localized_target is the residual.
+    rules = page.routing_rules.select_related("target").prefetch_related("conditions")
+    for rule in rules:
         target = localized_target(rule.target, page)
         if not target or not target.live:
             continue
@@ -119,6 +130,8 @@ def usable_rules(page):
         if not rule.conditions.all() and not rule.match_all:
             continue
         usable.append(UsableRule(rule, target))
+
+    page._usable_rules_cache = usable
     return usable
 
 

--- a/springfield/cms/routing/tests/test_arming.py
+++ b/springfield/cms/routing/tests/test_arming.py
@@ -1,0 +1,130 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the arming-condition abstraction and routing param constants."""
+
+from django.test import RequestFactory
+
+import pytest
+
+from springfield.cms.routing import params
+from springfield.cms.routing.arming import (
+    ArmingCondition,
+    QueryParamArmingCondition,
+    QueryParamValueArmingCondition,
+)
+
+rf = RequestFactory()
+
+
+# ---------------------------------------------------------------------------
+# Query-param arming condition (v1 realization).
+# ---------------------------------------------------------------------------
+
+
+def test_armed_when_trigger_param_present():
+    condition = QueryParamArmingCondition("routing")
+    assert condition.is_satisfied(rf.get("/whatsnew/?routing=1")) is True
+
+
+def test_not_armed_when_trigger_param_absent():
+    condition = QueryParamArmingCondition("routing")
+    assert condition.is_satisfied(rf.get("/whatsnew/")) is False
+    # A different, unrelated param does not arm routing.
+    assert condition.is_satisfied(rf.get("/whatsnew/?utm_source=x")) is False
+
+
+def test_presence_based_empty_value_still_arms():
+    condition = QueryParamArmingCondition("routing")
+    assert condition.is_satisfied(rf.get("/whatsnew/?routing=")) is True
+
+
+def test_defaults_to_the_framework_trigger_param():
+    condition = QueryParamArmingCondition()
+    assert condition.param_name == params.TRIGGER_PARAM
+    assert condition.is_satisfied(rf.get(f"/?{params.TRIGGER_PARAM}=1")) is True
+
+
+def test_each_consumer_can_use_its_own_param():
+    paid = QueryParamArmingCondition("r")
+    assert paid.is_satisfied(rf.get("/landing/?r=1")) is True
+    assert paid.is_satisfied(rf.get("/landing/?routing=1")) is False
+
+
+# ---------------------------------------------------------------------------
+# Value-matching arming condition: present AND value in the set.
+# ---------------------------------------------------------------------------
+
+
+def test_value_condition_armed_when_value_matches():
+    condition = QueryParamValueArmingCondition("utm_source", {"update"})
+    assert condition.is_satisfied(rf.get("/whatsnew/?utm_source=update")) is True
+
+
+def test_value_condition_not_armed_when_param_absent():
+    condition = QueryParamValueArmingCondition("utm_source", {"update"})
+    assert condition.is_satisfied(rf.get("/whatsnew/")) is False
+
+
+def test_value_condition_not_armed_on_value_mismatch():
+    condition = QueryParamValueArmingCondition("utm_source", {"update"})
+    assert condition.is_satisfied(rf.get("/whatsnew/?utm_source=newsletter")) is False
+
+
+def test_value_condition_empty_value_does_not_arm():
+    # Unlike the presence-only condition, an empty value is a mismatch.
+    condition = QueryParamValueArmingCondition("utm_source", {"update"})
+    assert condition.is_satisfied(rf.get("/whatsnew/?utm_source=")) is False
+
+
+def test_value_condition_accepts_any_of_several_values():
+    condition = QueryParamValueArmingCondition("utm_source", {"update", "upgrade"})
+    assert condition.is_satisfied(rf.get("/?utm_source=update")) is True
+    assert condition.is_satisfied(rf.get("/?utm_source=upgrade")) is True
+    assert condition.is_satisfied(rf.get("/?utm_source=other")) is False
+
+
+# ---------------------------------------------------------------------------
+# The abstraction is a real seam: callers depend only on is_satisfied().
+# ---------------------------------------------------------------------------
+
+
+def test_abstraction_is_swappable():
+    class AlwaysArmed(ArmingCondition):
+        def is_satisfied(self, request):
+            return True
+
+    # A caller that only knows the interface works with any realization.
+    def caller_arms(condition, request):
+        return condition.is_satisfied(request)
+
+    assert caller_arms(AlwaysArmed(), rf.get("/")) is True
+    assert caller_arms(QueryParamArmingCondition("routing"), rf.get("/")) is False
+
+
+def test_base_class_requires_a_realization():
+    with pytest.raises(NotImplementedError):
+        ArmingCondition().is_satisfied(rf.get("/"))
+
+
+# ---------------------------------------------------------------------------
+# Param constants are centralized.
+# ---------------------------------------------------------------------------
+
+
+def test_param_constants_are_defined():
+    assert params.TRIGGER_PARAM == "routing"
+    assert params.LOOP_BREAKER_PARAM == "routed"
+    assert params.PREVIEW_RULE_PARAM == "preview_rule"
+    assert params.PREVIEW_SIGNAL_PARAM == "preview_signal"
+
+
+def test_param_constants_are_distinct():
+    names = {
+        params.TRIGGER_PARAM,
+        params.LOOP_BREAKER_PARAM,
+        params.PREVIEW_RULE_PARAM,
+        params.PREVIEW_SIGNAL_PARAM,
+    }
+    assert len(names) == 4

--- a/springfield/cms/routing/tests/test_dispatch.py
+++ b/springfield/cms/routing/tests/test_dispatch.py
@@ -50,6 +50,18 @@ def expected_decision(flags):
     return SERVE_CANONICAL
 
 
+# The two database-backed flags are callables in the real signature. The truth table below
+# reasons in plain booleans, so wrap them at the call site.
+LAZY_FLAGS = ("is_paused", "has_live_rules")
+
+
+def decide(**flags):
+    kwargs = dict(flags)
+    for name in LAZY_FLAGS:
+        kwargs[name] = lambda value=kwargs[name]: value
+    return decide_routing(**kwargs)
+
+
 ALL_FLAG_COMBINATIONS = [dict(zip(FLAG_NAMES, values)) for values in itertools.product([False, True], repeat=len(FLAG_NAMES))]
 
 
@@ -64,7 +76,7 @@ def test_covers_every_flag_combination():
 
 @pytest.mark.parametrize("flags", ALL_FLAG_COMBINATIONS)
 def test_decision_matches_spec_order_for_every_combination(flags):
-    assert decide_routing(**flags) == expected_decision(flags)
+    assert decide(**flags) == expected_decision(flags)
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +92,7 @@ def _flags(**overrides):
 
 def test_switch_off_short_circuits_everything():
     # Every downstream flag set to "would route/preview", but the switch is off.
-    result = decide_routing(
+    result = decide(
         **_flags(
             routing_enabled=False,
             is_preview_admin=True,
@@ -95,7 +107,7 @@ def test_switch_off_short_circuits_everything():
 def test_loop_breaker_is_checked_before_everything_else():
     # A fallen-through user (loop-breaker present) who is also triggered on a live
     # canonical with rules — and even an admin preview — still gets canonical.
-    result = decide_routing(
+    result = decide(
         **_flags(
             routing_enabled=True,
             has_loop_breaker=True,
@@ -110,26 +122,82 @@ def test_loop_breaker_is_checked_before_everything_else():
 
 def test_preview_wins_over_pause_and_resolver_but_needs_the_flag():
     routed = _flags(routing_enabled=True, is_paused=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True)
-    assert decide_routing(**{**routed, "is_preview_admin": True}) == SERVE_PREVIEW
+    assert decide(**{**routed, "is_preview_admin": True}) == SERVE_PREVIEW
     # Without the preview-admin flag, the pause takes over -> canonical.
-    assert decide_routing(**{**routed, "is_preview_admin": False}) == SERVE_CANONICAL
+    assert decide(**{**routed, "is_preview_admin": False}) == SERVE_CANONICAL
 
 
 def test_pause_short_circuits_the_resolver():
-    result = decide_routing(**_flags(routing_enabled=True, is_paused=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True))
+    result = decide(**_flags(routing_enabled=True, is_paused=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True))
     assert result == SERVE_CANONICAL
 
 
 def test_resolver_requires_trigger_canonical_and_live_rules():
     routes = _flags(routing_enabled=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True)
-    assert decide_routing(**routes) == SERVE_RESOLVER
+    assert decide(**routes) == SERVE_RESOLVER
     # Dropping any one of the three falls back to canonical.
-    assert decide_routing(**{**routes, "trigger_satisfied": False}) == SERVE_CANONICAL
-    assert decide_routing(**{**routes, "is_canonical": False}) == SERVE_CANONICAL
-    assert decide_routing(**{**routes, "has_live_rules": False}) == SERVE_CANONICAL
+    assert decide(**{**routes, "trigger_satisfied": False}) == SERVE_CANONICAL
+    assert decide(**{**routes, "is_canonical": False}) == SERVE_CANONICAL
+    assert decide(**{**routes, "has_live_rules": False}) == SERVE_CANONICAL
 
 
 def test_untriggered_traffic_is_canonical():
     # The organic case: enabled, canonical, has rules, but no trigger -> canonical.
-    result = decide_routing(**_flags(routing_enabled=True, is_canonical=True, has_live_rules=True, trigger_satisfied=False))
+    result = decide(**_flags(routing_enabled=True, is_canonical=True, has_live_rules=True, trigger_satisfied=False))
     assert result == SERVE_CANONICAL
+
+
+# ---------------------------------------------------------------------------
+# The database-backed flags are only consulted if precedence reaches them. Passing
+# them as values instead would put a pause read and a rule scan on every request to
+# an adopted page — including while the switch is off, which must cost nothing.
+# ---------------------------------------------------------------------------
+
+
+class _Counter:
+    """A flag callable that records whether anything asked for its value."""
+
+    def __init__(self, value):
+        self.value = value
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return self.value
+
+
+def _decide_counting(**overrides):
+    flags = _flags(**overrides)
+    paused = _Counter(flags["is_paused"])
+    live = _Counter(flags["has_live_rules"])
+    flags["is_paused"] = paused
+    flags["has_live_rules"] = live
+    return decide_routing(**flags), paused, live
+
+
+@pytest.mark.parametrize(
+    ("label", "overrides"),
+    (
+        ("switch off", {"routing_enabled": False}),
+        ("loop breaker", {"routing_enabled": True, "has_loop_breaker": True}),
+        ("admin preview", {"routing_enabled": True, "is_preview_admin": True}),
+    ),
+)
+def test_neither_database_flag_is_read_before_its_gate(label, overrides):
+    # All three exit above the pause check, so neither flag may be touched.
+    _, paused, live = _decide_counting(**overrides, trigger_satisfied=True, is_canonical=True, has_live_rules=True)
+    assert paused.calls == 0, label
+    assert live.calls == 0, label
+
+
+def test_the_rule_scan_is_skipped_for_untriggered_traffic():
+    # The common case by volume: organic visitors to an adopted page. The pause is read,
+    # the rule scan is not.
+    _, paused, live = _decide_counting(routing_enabled=True, is_canonical=True, has_live_rules=True, trigger_satisfied=False)
+    assert paused.calls == 1
+    assert live.calls == 0
+
+
+def test_the_rule_scan_is_skipped_on_a_non_canonical_page():
+    _, _, live = _decide_counting(routing_enabled=True, trigger_satisfied=True, is_canonical=False, has_live_rules=True)
+    assert live.calls == 0

--- a/springfield/cms/routing/tests/test_dispatch.py
+++ b/springfield/cms/routing/tests/test_dispatch.py
@@ -1,0 +1,135 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Exhaustive tests for the pure serve-path decision.
+
+The decision function is the highest-blast-radius logic in the framework (a wrong
+answer silently mis-routes organic or crawler traffic). It is pure, so we exercise it
+over *every* combination of its flags and pin the critical orderings explicitly.
+"""
+
+import itertools
+
+import pytest
+
+from springfield.cms.routing.dispatch import (
+    SERVE_CANONICAL,
+    SERVE_PREVIEW,
+    SERVE_RESOLVER,
+    decide_routing,
+)
+
+FLAG_NAMES = (
+    "routing_enabled",
+    "has_loop_breaker",
+    "is_preview_admin",
+    "is_paused",
+    "trigger_satisfied",
+    "is_canonical",
+    "has_live_rules",
+)
+
+
+# An independent transcription of the serve-path decision plus the outermost switch, written as an
+# ordered priority scan rather than an if-chain, so it can disagree with a buggy
+# decide_routing (e.g. wrong order, OR instead of AND in the resolver clause).
+_ORDERED_RULES = (
+    (lambda f: not f["routing_enabled"], SERVE_CANONICAL),
+    (lambda f: f["has_loop_breaker"], SERVE_CANONICAL),
+    (lambda f: f["is_preview_admin"], SERVE_PREVIEW),
+    (lambda f: f["is_paused"], SERVE_CANONICAL),
+    (lambda f: f["trigger_satisfied"] and f["is_canonical"] and f["has_live_rules"], SERVE_RESOLVER),
+)
+
+
+def expected_decision(flags):
+    for predicate, outcome in _ORDERED_RULES:
+        if predicate(flags):
+            return outcome
+    return SERVE_CANONICAL
+
+
+ALL_FLAG_COMBINATIONS = [dict(zip(FLAG_NAMES, values)) for values in itertools.product([False, True], repeat=len(FLAG_NAMES))]
+
+
+# ---------------------------------------------------------------------------
+# Exhaustive truth table: all 2^7 = 128 flag combinations.
+# ---------------------------------------------------------------------------
+
+
+def test_covers_every_flag_combination():
+    assert len(ALL_FLAG_COMBINATIONS) == 128
+
+
+@pytest.mark.parametrize("flags", ALL_FLAG_COMBINATIONS)
+def test_decision_matches_spec_order_for_every_combination(flags):
+    assert decide_routing(**flags) == expected_decision(flags)
+
+
+# ---------------------------------------------------------------------------
+# Critical invariants, pinned to explicit expected values (not via the oracle).
+# ---------------------------------------------------------------------------
+
+
+def _flags(**overrides):
+    base = dict.fromkeys(FLAG_NAMES, False)
+    base.update(overrides)
+    return base
+
+
+def test_switch_off_short_circuits_everything():
+    # Every downstream flag set to "would route/preview", but the switch is off.
+    result = decide_routing(
+        **_flags(
+            routing_enabled=False,
+            is_preview_admin=True,
+            trigger_satisfied=True,
+            is_canonical=True,
+            has_live_rules=True,
+        )
+    )
+    assert result == SERVE_CANONICAL
+
+
+def test_loop_breaker_is_checked_before_everything_else():
+    # A fallen-through user (loop-breaker present) who is also triggered on a live
+    # canonical with rules — and even an admin preview — still gets canonical.
+    result = decide_routing(
+        **_flags(
+            routing_enabled=True,
+            has_loop_breaker=True,
+            is_preview_admin=True,
+            trigger_satisfied=True,
+            is_canonical=True,
+            has_live_rules=True,
+        )
+    )
+    assert result == SERVE_CANONICAL
+
+
+def test_preview_wins_over_pause_and_resolver_but_needs_the_flag():
+    routed = _flags(routing_enabled=True, is_paused=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True)
+    assert decide_routing(**{**routed, "is_preview_admin": True}) == SERVE_PREVIEW
+    # Without the preview-admin flag, the pause takes over -> canonical.
+    assert decide_routing(**{**routed, "is_preview_admin": False}) == SERVE_CANONICAL
+
+
+def test_pause_short_circuits_the_resolver():
+    result = decide_routing(**_flags(routing_enabled=True, is_paused=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True))
+    assert result == SERVE_CANONICAL
+
+
+def test_resolver_requires_trigger_canonical_and_live_rules():
+    routes = _flags(routing_enabled=True, trigger_satisfied=True, is_canonical=True, has_live_rules=True)
+    assert decide_routing(**routes) == SERVE_RESOLVER
+    # Dropping any one of the three falls back to canonical.
+    assert decide_routing(**{**routes, "trigger_satisfied": False}) == SERVE_CANONICAL
+    assert decide_routing(**{**routes, "is_canonical": False}) == SERVE_CANONICAL
+    assert decide_routing(**{**routes, "has_live_rules": False}) == SERVE_CANONICAL
+
+
+def test_untriggered_traffic_is_canonical():
+    # The organic case: enabled, canonical, has rules, but no trigger -> canonical.
+    result = decide_routing(**_flags(routing_enabled=True, is_canonical=True, has_live_rules=True, trigger_satisfied=False))
+    assert result == SERVE_CANONICAL

--- a/springfield/cms/routing/tests/test_mixins.py
+++ b/springfield/cms/routing/tests/test_mixins.py
@@ -16,6 +16,7 @@ from django.test import RequestFactory
 import pytest
 from wagtail.models import Site
 
+from springfield.cms.models import SimpleRichTextPage
 from springfield.cms.routing.arming import QueryParamArmingCondition
 from springfield.cms.routing.mixins import RoutingMixin
 from springfield.cms.routing.models import RoutingRule
@@ -72,6 +73,10 @@ def test_has_live_routing_rules_counts_only_live_targets():
     # match_all so the rule can route someone; a rule that cannot route is a separate
     # question, covered below.
     RoutingRule.objects.create(page=canonical, target=live_target, match_all=True)
+    # Re-fetched rather than reusing the instance above: usable_rules memoizes per page
+    # instance for the life of a request, and adding a rule mid-instance is not something
+    # a request does.
+    canonical = SimpleRichTextPage.objects.get(pk=canonical.pk)
     assert RoutingMixin._has_live_routing_rules(canonical) is True
 
     # A rule pointing only at an unpublished target does not count.

--- a/springfield/cms/routing/tests/test_mixins.py
+++ b/springfield/cms/routing/tests/test_mixins.py
@@ -1,0 +1,128 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the routing adoption mixin.
+
+Method-level tests only: no test-harness page type is introduced, so the
+full serve integration lands with the first real consumer. Here we prove the
+adoption-surface defaults and the serve-path flag adapter.
+"""
+
+from types import SimpleNamespace
+
+from django.test import RequestFactory
+
+import pytest
+from wagtail.models import Site
+
+from springfield.cms.routing.arming import QueryParamArmingCondition
+from springfield.cms.routing.mixins import RoutingMixin
+from springfield.cms.routing.models import RoutingRule
+from springfield.cms.tests.factories import SimpleRichTextPageFactory
+
+rf = RequestFactory()
+
+# ---------------------------------------------------------------------------
+# Adoption surface: the two hooks and their defaults.
+# ---------------------------------------------------------------------------
+
+
+def test_is_routing_canonical_defaults_to_false():
+    # Fail-closed: a half-adopted consumer never routes.
+    assert RoutingMixin.is_routing_canonical(SimpleNamespace()) is False
+
+
+def test_routing_trigger_is_unset_by_default():
+    assert RoutingMixin.get_routing_trigger(SimpleNamespace()) is None
+
+
+# ---------------------------------------------------------------------------
+# The mixin adds no database fields, so adoption produces no migration.
+# ---------------------------------------------------------------------------
+
+
+def test_mixin_declares_no_database_fields():
+    assert list(RoutingMixin._meta.local_fields) == []
+    assert RoutingMixin._meta.abstract is True
+
+
+# ---------------------------------------------------------------------------
+# Serve-path flag sources: the thin adapter maps these onto decide_routing.
+# Full request-level serve integration lands with the first consumer.
+# ---------------------------------------------------------------------------
+
+
+def test_routing_trigger_satisfied_maps_the_trigger_hook():
+    armed = SimpleNamespace(get_routing_trigger=lambda: QueryParamArmingCondition("routing"))
+    assert RoutingMixin._routing_trigger_satisfied(armed, rf.get("/?routing=1")) is True
+    assert RoutingMixin._routing_trigger_satisfied(armed, rf.get("/")) is False
+    # An unset trigger (the default) is never satisfied.
+    unset = SimpleNamespace(get_routing_trigger=lambda: None)
+    assert RoutingMixin._routing_trigger_satisfied(unset, rf.get("/?routing=1")) is False
+
+
+@pytest.mark.django_db
+def test_has_live_routing_rules_counts_only_live_targets():
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="live-rules-canonical", parent=site_root)
+    live_target = SimpleRichTextPageFactory(slug="live-target", parent=canonical, live=True)
+    # No rules yet.
+    assert RoutingMixin._has_live_routing_rules(canonical) is False
+    # match_all so the rule can route someone; a rule that cannot route is a separate
+    # question, covered below.
+    RoutingRule.objects.create(page=canonical, target=live_target, match_all=True)
+    assert RoutingMixin._has_live_routing_rules(canonical) is True
+
+    # A rule pointing only at an unpublished target does not count.
+    other = SimpleRichTextPageFactory(slug="other-canonical", parent=site_root)
+    dead_target = SimpleRichTextPageFactory(slug="draft-target", parent=other, live=False)
+    RoutingRule.objects.create(page=other, target=dead_target, match_all=True)
+    assert RoutingMixin._has_live_routing_rules(other) is False
+
+
+# ---------------------------------------------------------------------------
+# "This page has routing" and "these are the rules the client gets" must be the
+# same question. When they diverge, a page either serves a resolver with nothing
+# in it (holding page, then a bounce straight back) or refuses to route on rules
+# that would have worked.
+# ---------------------------------------------------------------------------
+
+
+def _assert_gate_agrees_with_the_serializer(page):
+    from springfield.cms.routing.resolver import serialize_rules
+
+    assert RoutingMixin._has_live_routing_rules(page) is bool(serialize_rules(page))
+
+
+@pytest.mark.django_db
+def test_a_conditionless_rule_neither_routes_nor_counts():
+    # No conditions and match_all off: the serializer drops it, so the gate must not
+    # count it. Built via the ORM because the page form blocks authoring one.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="conditionless-canonical", parent=site_root)
+    target = SimpleRichTextPageFactory(slug="conditionless-target", parent=canonical, live=True)
+    RoutingRule.objects.create(page=canonical, target=target, match_all=False)
+
+    _assert_gate_agrees_with_the_serializer(canonical)
+    assert RoutingMixin._has_live_routing_rules(canonical) is False
+
+
+@pytest.mark.django_db
+def test_a_target_with_no_version_in_this_locale_neither_routes_nor_counts(translated_wnp):
+    # The German page's rule points at a variant that exists only in English, so it can
+    # never route a German visitor.
+    translated_wnp.de_variant.delete()
+
+    _assert_gate_agrees_with_the_serializer(translated_wnp.de_canonical)
+    assert RoutingMixin._has_live_routing_rules(translated_wnp.de_canonical) is False
+
+
+@pytest.mark.django_db
+def test_routing_survives_the_source_locale_target_being_unpublished(translated_wnp):
+    # Only the English variant is a draft; the German one is live. The German page's rule
+    # resolves to the German variant, so it still routes.
+    translated_wnp.variant.unpublish()
+
+    _assert_gate_agrees_with_the_serializer(translated_wnp.de_canonical)
+    assert RoutingMixin._has_live_routing_rules(translated_wnp.de_canonical) is True

--- a/springfield/cms/routing/tests/test_models.py
+++ b/springfield/cms/routing/tests/test_models.py
@@ -348,7 +348,7 @@ def test_version_accepts_the_forms_the_client_normalizes(rule, value):
     condition.full_clean()  # does not raise
 
 
-@pytest.mark.parametrize("value", ["unknown", "", "beta", "145.x"])
+@pytest.mark.parametrize("value", ["unknown", "", "beta", "145.x", "garbage145", "145beta", "145.0.1-beta"])
 def test_version_rejects_values_carrying_no_version(rule, value):
     # These compare as "unknown" on the client, so the rule can never fire — dead config
     # that looks fine in the editor.

--- a/springfield/cms/routing/tests/test_preview.py
+++ b/springfield/cms/routing/tests/test_preview.py
@@ -1,0 +1,166 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the admin-only preview flows."""
+
+from types import SimpleNamespace
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+import pytest
+from wagtail.models import Site
+
+from springfield.cms.routing.models import RoutingCondition, RoutingConfig, RoutingRule
+from springfield.cms.routing.preview import get_preview_response, parse_fake_signals
+from springfield.cms.tests.factories import SimpleRichTextPageFactory
+
+pytestmark = [pytest.mark.django_db]
+
+rf = RequestFactory()
+User = get_user_model()
+
+
+@pytest.fixture
+def routed_page():
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="preview-canonical", parent=site_root)
+    target = SimpleRichTextPageFactory(slug="preview-variant", parent=canonical, live=True)
+    rule = RoutingRule.objects.create(page=canonical, target=target)
+    RoutingCondition.objects.create(rule=rule, signal="platform", operator="is", expected_value="windows", sort_order=0)
+    return SimpleNamespace(canonical=canonical, target=target, rule=rule)
+
+
+@pytest.fixture
+def staff_user():
+    return User.objects.create(username="staff", is_staff=True, is_active=True)
+
+
+def _request(path, user):
+    request = rf.get(path)
+    request.user = user
+    return request
+
+
+def _content(response):
+    if hasattr(response, "render"):
+        response.render()
+    return response.content.decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Auth gating — non-admins fall through to normal serve.
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_preview_params_are_ignored(routed_page):
+    request = _request(f"/?preview_rule={routed_page.rule.pk}", AnonymousUser())
+    assert get_preview_response(request, routed_page.canonical) is None
+
+
+def test_non_staff_user_is_ignored(routed_page):
+    user = User.objects.create(username="viewer", is_staff=False, is_active=True)
+    request = _request(f"/?preview_rule={routed_page.rule.pk}", user)
+    assert get_preview_response(request, routed_page.canonical) is None
+
+
+def test_admin_without_preview_params_gets_no_preview(routed_page, staff_user):
+    request = _request("/", staff_user)
+    assert get_preview_response(request, routed_page.canonical) is None
+
+
+# ---------------------------------------------------------------------------
+# preview_rule — server-side 302, no-store, bypasses the kill switch.
+# ---------------------------------------------------------------------------
+
+
+def test_preview_rule_302s_to_target(routed_page, staff_user):
+    request = _request(f"/?preview_rule={routed_page.rule.pk}", staff_user)
+    response = get_preview_response(request, routed_page.canonical)
+    assert response.status_code == 302
+    assert response["Location"] == routed_page.target.get_url(request)
+    assert response["Cache-Control"] == "no-store"
+
+
+def test_preview_rule_bypasses_kill_switch(routed_page, staff_user):
+    RoutingConfig.objects.create(page=routed_page.canonical, routing_paused=True)
+    request = _request(f"/?preview_rule={routed_page.rule.pk}", staff_user)
+    response = get_preview_response(request, routed_page.canonical)
+    # Previews deliberately ignore routing_paused.
+    assert response.status_code == 302
+
+
+def test_preview_rule_302s_to_the_variant_in_this_locale(translated_wnp, staff_user):
+    # Preview has to answer "where do visitors on *this* page end up", and on a translated
+    # page that is the translated variant. The stored target is still the English one.
+    rule = translated_wnp.de_canonical.routing_rules.first()
+    request = _request(f"/de/whatsnew/145/?preview_rule={rule.pk}", staff_user)
+
+    response = get_preview_response(request, translated_wnp.de_canonical)
+    assert response.status_code == 302
+    assert response["Location"] == translated_wnp.de_variant.get_url(request)
+    assert response["Location"].startswith("/de/")
+
+
+def test_preview_rule_reports_an_unpublished_target_rather_than_redirecting(routed_page, staff_user):
+    # Visitors are never routed to an unpublished page, so redirecting the author into a 404
+    # would misreport what the rule does.
+    routed_page.target.unpublish()
+    request = _request(f"/?preview_rule={routed_page.rule.pk}", staff_user)
+
+    response = get_preview_response(request, routed_page.canonical)
+    assert response.status_code == 200
+    assert "never fires" in _content(response)
+    assert "not published" in _content(response)
+    assert response["Cache-Control"] == "no-store"
+
+
+def test_preview_rule_reports_a_target_missing_from_this_locale(translated_wnp, staff_user):
+    # The German page's rule points at a variant that exists only in English.
+    translated_wnp.de_variant.delete()
+    rule = translated_wnp.de_canonical.routing_rules.first()
+    request = _request(f"/de/whatsnew/145/?preview_rule={rule.pk}", staff_user)
+
+    response = get_preview_response(request, translated_wnp.de_canonical)
+    assert response.status_code == 200
+    assert "never fires" in _content(response)
+    # Same wording the rules listing uses for this state — one vocabulary, two surfaces.
+    assert "not translated" in _content(response)
+
+
+def test_preview_rule_with_invalid_id_falls_through(routed_page, staff_user):
+    for value in ("99999", "not-a-number"):
+        request = _request(f"/?preview_rule={value}", staff_user)
+        assert get_preview_response(request, routed_page.canonical) is None
+
+
+# ---------------------------------------------------------------------------
+# preview_signal — fake-signal blob, real evaluation path, no-store.
+# ---------------------------------------------------------------------------
+
+
+def test_preview_signal_injects_fake_blob(routed_page, staff_user):
+    # The resolver renders under a locale prefix, as it does in production.
+    request = _request("/en-US/whatsnew/?preview_signal=platform:windows", staff_user)
+    response = get_preview_response(request, routed_page.canonical)
+    assert response["Cache-Control"] == "no-store"
+    html = _content(response)
+    # Faked signal rides the same data-* attribute convention.
+    assert "data-routing-fake-signals=" in html
+    assert "platform" in html
+    assert "windows" in html
+    # Un-faked signals still ship in the manifest so the client reads them live.
+    assert "data-routing-manifest=" in html
+
+
+def test_preview_signal_ignores_unknown_and_malformed(routed_page, staff_user):
+    request = _request("/?preview_signal=platform:windows&preview_signal=bogus:x&preview_signal=malformed", staff_user)
+    fakes = parse_fake_signals(request.GET.getlist("preview_signal"))
+    assert fakes == {"platform": "windows"}
+
+
+def test_parse_fake_signals_keeps_colons_in_value():
+    # Only the first colon separates name from value.
+    assert parse_fake_signals(["firefox_version:129:beta"]) == {"firefox_version": "129:beta"}

--- a/springfield/cms/routing/tests/test_resolver.py
+++ b/springfield/cms/routing/tests/test_resolver.py
@@ -1,0 +1,368 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the resolver page rendering and serialization."""
+
+from types import SimpleNamespace
+
+from django.conf import settings
+from django.test import RequestFactory, override_settings
+from django.utils import translation
+
+import pytest
+from bs4 import BeautifulSoup
+from wagtail.models import Locale, Page, Site
+
+from springfield.cms.routing.mixins import RoutingMixin
+from springfield.cms.routing.models import RoutingCondition, RoutingRule
+from springfield.cms.routing.resolver import render_resolver, serialize_manifest, serialize_rules
+from springfield.cms.tests.factories import SimpleRichTextPageFactory
+
+pytestmark = [pytest.mark.django_db]
+
+rf = RequestFactory()
+
+
+@pytest.fixture
+def routed_page():
+    # Build under the default site's root so pages have real URLs.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="resolver-canonical", parent=site_root)
+    target = SimpleRichTextPageFactory(slug="resolver-variant", parent=canonical, live=True)
+    rule = RoutingRule.objects.create(page=canonical, target=target)
+    RoutingCondition.objects.create(rule=rule, signal="platform", operator="is", expected_value="windows", sort_order=0)
+    RoutingCondition.objects.create(rule=rule, signal="country", operator="is", expected_value="US", sort_order=1)
+    return SimpleNamespace(canonical=canonical, target=target, rule=rule)
+
+
+# ---------------------------------------------------------------------------
+# Serialization (the data the client evaluator needs).
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_rules_carries_target_and_typed_conditions(routed_page):
+    rules = serialize_rules(routed_page.canonical)
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["target"] == routed_page.target.get_url()
+    assert [c["signal"] for c in rule["conditions"]] == ["platform", "country"]
+    # Value type is drawn from the registry so the evaluator compares correctly.
+    assert rule["conditions"][0]["valueType"] == "enum"
+    assert rule["conditions"][0]["operator"] == "is"
+    assert rule["conditions"][0]["expected"] == "windows"
+
+
+def test_serialize_rules_skips_unpublished_targets(routed_page):
+    routed_page.target.live = False
+    routed_page.target.save()
+    assert serialize_rules(routed_page.canonical) == []
+
+
+def test_serialize_rules_emits_match_all_flag(routed_page):
+    # A conditionful rule carries matchAll=False.
+    rules = serialize_rules(routed_page.canonical)
+    assert rules[0]["matchAll"] is False
+
+
+def test_serialize_rules_emits_match_all_rule_with_no_conditions(routed_page):
+    RoutingRule.objects.create(page=routed_page.canonical, target=routed_page.target, match_all=True, sort_order=1)
+    rules = serialize_rules(routed_page.canonical)
+    # The match-all rule is emitted with no conditions (and matchAll=True).
+    match_all_rules = [rule for rule in rules if rule["matchAll"]]
+    assert len(match_all_rules) == 1
+    assert match_all_rules[0]["conditions"] == []
+
+
+def test_serialize_rules_omits_conditions_from_a_match_all_rule(routed_page):
+    # match_all means "every triggered visitor", which is what the client already does with
+    # such a rule — so conditions on it are inert. Emitting them would make the payload
+    # contradict itself and invite a future reader to "fix" the client into honouring them.
+    rule = routed_page.rule
+    rule.match_all = True
+    rule.save()
+
+    rules = serialize_rules(routed_page.canonical)
+    assert rules[0]["matchAll"] is True
+    assert rules[0]["conditions"] == []
+
+
+def test_serialize_rules_skips_empty_non_match_all_rule(routed_page):
+    # A rule with neither conditions nor match_all is defensively dropped, never
+    # emitted as a match-everyone rule.
+    RoutingRule.objects.create(page=routed_page.canonical, target=routed_page.target, sort_order=1)
+    rules = serialize_rules(routed_page.canonical)
+    assert len(rules) == 1
+    assert rules[0]["conditions"] != []
+
+
+def test_serialize_rules_drops_a_lone_conditionless_non_match_all_rule():
+    # The page-form floor blocks *authoring* a conditionless, non-match-all rule (it would
+    # match the whole triggered audience), but the ORM/API path has no such floor and does not
+    # call clean(). serialize_rules is the runtime backstop, and it is the *only* guard on that
+    # path — so pin it directly: a lone ORM-created rule with no conditions and match_all=False
+    # is dropped entirely and never reaches the client, even with a perfectly live target.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="conditionless-canonical", parent=site_root)
+    target = SimpleRichTextPageFactory(slug="conditionless-variant", parent=canonical, live=True)
+    RoutingRule.objects.create(page=canonical, target=target, match_all=False)
+    assert serialize_rules(canonical) == []
+
+
+def test_serialize_rules_drops_a_target_under_a_different_page():
+    # Copying a page copies its rules, and the copies still point into the *source* page's
+    # subtree — so a visitor to the copy would be routed to content belonging to the page
+    # they didn't ask for. The page form blocks authoring this; the ORM/API path does not,
+    # and a copy arrives that way.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="hosting-canonical", parent=site_root)
+    unrelated = SimpleRichTextPageFactory(slug="unrelated-canonical", parent=site_root)
+    stray = SimpleRichTextPageFactory(slug="unrelated-variant", parent=unrelated, live=True)
+    rule = RoutingRule.objects.create(page=canonical, target=stray, match_all=True)
+    RoutingCondition.objects.create(rule=rule, signal="platform", operator="is", expected_value="windows", sort_order=0)
+
+    assert serialize_rules(canonical) == []
+    assert RoutingMixin._has_live_routing_rules(canonical) is False
+
+
+def test_serialize_rules_drops_a_rule_that_targets_its_own_page():
+    # Routing a visitor to the URL they are already on re-renders the resolver, which
+    # evaluates and navigates again: the loop-breaker only rides along on the *fallback*
+    # path, so nothing stops the cycle. The page form blocks it; the ORM/API path does not.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="self-targeting-canonical", parent=site_root, live=True)
+    rule = RoutingRule.objects.create(page=canonical, target=canonical, match_all=True)
+    RoutingCondition.objects.create(rule=rule, signal="platform", operator="is", expected_value="windows", sort_order=0)
+
+    assert serialize_rules(canonical) == []
+    assert RoutingMixin._has_live_routing_rules(canonical) is False
+
+
+def test_serialize_rules_drops_a_rule_whose_target_was_deleted(routed_page):
+    # Deleting the target nulls it rather than blocking the delete, so the serializer meets a
+    # rule with no target at all. It must drop it and carry on, not raise.
+    routed_page.target.delete()
+
+    assert serialize_rules(routed_page.canonical) == []
+    assert RoutingMixin._has_live_routing_rules(routed_page.canonical) is False
+
+
+def test_serialize_rules_keeps_the_alias_locale_the_visitor_asked_for(fallback_locale_wnp):
+    # es-AR has no pages of its own, so the es-MX page is served at the es-AR URL. A target
+    # URL carrying /es-MX/ would move the visitor out of the locale they asked for, on the
+    # one navigation the resolver exists to perform.
+    request = rf.get(fallback_locale_wnp.alias_url + "?utm_source=update")
+    with translation.override("es-AR"):
+        rules = serialize_rules(fallback_locale_wnp.canonical, request)
+
+    assert rules[0]["target"].startswith("/es-AR/")
+    assert "/es-MX/" not in rules[0]["target"]
+
+
+def test_serialize_rules_still_emits_a_url_for_a_plain_page_target():
+    # Only springfield CMS pages carry the alias-aware URL helper, and the ORM/API path can
+    # attach any page as a target. Such a rule must still serve — a triggered visitor
+    # getting a 500 would be worse than a URL with the un-rewritten locale prefix.
+    site_root = Site.objects.get(is_default_site=True).root_page
+    canonical = SimpleRichTextPageFactory(slug="plain-target-canonical", parent=site_root)
+    plain = Page(title="Plain target", slug="plain-target", live=True)
+    canonical.add_child(instance=plain)
+    RoutingRule.objects.create(page=canonical, target=plain, match_all=True)
+
+    rules = serialize_rules(canonical)
+    assert rules[0]["target"].endswith("/plain-target/")
+
+
+def test_serialize_manifest_maps_signals_to_source_metadata(routed_page):
+    manifest = serialize_manifest(serialize_rules(routed_page.canonical))
+    assert manifest["platform"] == {"source": "user_agent", "browserStateKey": None, "valueType": "enum"}
+    assert manifest["country"]["source"] == "cdn_geo"
+
+
+# ---------------------------------------------------------------------------
+# Rendering.
+# ---------------------------------------------------------------------------
+
+
+def _render(routed_page):
+    request = rf.get("/en-US/whatsnew/?routing=1")
+    response = render_resolver(request, routed_page.canonical)
+    if hasattr(response, "render"):
+        response.render()
+    return response, response.content.decode("utf-8")
+
+
+def test_resolver_renders_country_rules_and_manifest(routed_page):
+    _response, html = _render(routed_page)
+    assert "data-country-code=" in html
+    assert "data-routing-rules=" in html
+    assert "data-routing-manifest=" in html
+    # The serialized target and a signal name reach the client blob.
+    assert routed_page.target.get_url() in html
+    assert "platform" in html
+
+
+def test_resolver_renders_localized_status_and_noscript(routed_page):
+    _response, html = _render(routed_page)
+    assert "Preparing your page" in html
+    assert "<noscript>" in html
+
+
+def test_the_resolver_offers_a_way_out_that_does_not_depend_on_javascript(routed_page):
+    # <noscript> does not render when JS is *enabled* but the bundle fails to load or throws —
+    # and `static/` is build output, so a missing bundle is a realistic deploy failure. Without
+    # a link outside that block, such a visitor is stranded on a page with no heading, no link
+    # and no control. (CSS keeps it out of the way of visitors whose redirect works.)
+    _response, html = _render(routed_page)
+    soup = BeautifulSoup(html, "html.parser")
+
+    escape = soup.select_one(".routing-resolver-escape a")
+    assert escape is not None
+    assert escape["href"].startswith(routed_page.canonical.get_url())
+    # Outside <noscript>: nothing about JS being enabled may hide it.
+    assert not escape.find_parents("noscript")
+
+
+def _render_for(routed_page, request):
+    """Render the resolver for a specific request, so its query string reaches the template."""
+    response = render_resolver(request, routed_page.canonical)
+    if hasattr(response, "render"):
+        response.render()
+    return response.content.decode("utf-8")
+
+
+def _fallback_targets(html):
+    """Both server-rendered escape routes: the no-JS refresh and the visible link."""
+    soup = BeautifulSoup(html, "html.parser")
+    refresh = soup.select_one("noscript meta[http-equiv='refresh']")["content"]
+    return refresh.split("url=", 1)[1], soup.select_one(".routing-resolver-escape a")["href"]
+
+
+def test_the_no_js_paths_keep_the_visitors_attribution(routed_page):
+    # A visitor without JS keeps their content today but loses their utm_* entirely — silently,
+    # in exactly the population hardest to measure. Both server-rendered escape routes carry the
+    # inbound query string through, the way the client does for everyone else.
+    request = rf.get("/en-US/whatsnew/?utm_source=update&utm_campaign=spring&oldversion=143")
+    html = _render_for(routed_page, request)
+
+    for url in _fallback_targets(html):
+        assert "utm_campaign=spring" in url
+        assert "oldversion=143" in url
+
+
+def test_the_no_js_paths_drop_control_params_and_carry_the_loop_breaker(routed_page):
+    # utm_source is WNP's arming param, so it rides along as attribution — which means the
+    # destination would serve this page again without the loop-breaker. Framework control params
+    # are dropped instead of duplicated.
+    request = rf.get("/en-US/whatsnew/?utm_source=update&routing=1&routed=1&preview_rule=3")
+    html = _render_for(routed_page, request)
+
+    for url in _fallback_targets(html):
+        assert "routed=1" in url
+        assert url.count("routed=") == 1
+        assert "routing=1" not in url
+        assert "preview_rule" not in url
+        assert "utm_source=update" in url
+
+
+def test_resolver_response_is_cacheable(routed_page):
+    response, _html = _render(routed_page)
+    # The plain resolver must stay CDN-cacheable — no no-store (previews add it).
+    assert "no-store" not in response.get("Cache-Control", "")
+
+
+def test_render_resolver_patches_the_request_itself(routed_page):
+    # Not a caller's job to remember. Rendering the resolver bypasses the normal CMS page
+    # serve, so without this the Fluent render falls back to the resolver strings' activation
+    # state and redirects any visitor whose locale is missing from it. A caller that forgot
+    # would reintroduce that silently: the page still renders and the suite still passes, and
+    # only non-English visitors are affected. Pin it here so moving the call back out fails.
+    request = rf.get("/en-US/whatsnew/?utm_source=update")
+    assert not hasattr(request, "is_cms_page")
+
+    render_resolver(request, routed_page.canonical)
+
+    assert request.is_cms_page is True
+    assert hasattr(request, "_locales_available_via_cms")
+    assert request.is_preview is False
+
+
+def test_resolver_states_its_own_cache_lifetime(routed_page):
+    # The resolver freezes target URLs, the pause state and the visitor's country into a
+    # cacheable body, and nothing purges it — so how long it may be reused is a property of
+    # this page, not something to inherit from the site-wide default by accident.
+    response, _html = _render(routed_page)
+    assert response["Cache-Control"] == f"max-age={settings.ROUTING_RESOLVER_CACHE_SECONDS}"
+
+
+@override_settings(ROUTING_RESOLVER_CACHE_SECONDS=5)
+def test_the_cache_lifetime_is_configurable(routed_page):
+    # Tunable without a deploy: the right window depends on traffic and CDN shielding, which
+    # are only knowable when the switch is actually turned on.
+    response, _html = _render(routed_page)
+    assert response["Cache-Control"] == "max-age=5"
+
+
+def test_resolver_has_no_inline_script_or_style(routed_page):
+    _response, html = _render(routed_page)
+    soup = BeautifulSoup(html, "html.parser")
+    # CSP: every script is an external bundle (has src); no inline <script> blocks.
+    scripts = soup.find_all("script")
+    assert scripts, "expected bundled scripts"
+    assert all(script.get("src") for script in scripts)
+    # All CSS ships via <link> bundles; no inline <style>.
+    assert soup.find_all("style") == []
+
+
+# ---------------------------------------------------------------------------
+# Translated pages: rules are copied by Wagtail but their target FK is not remapped.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def translated_tree(routed_page):
+    """The routed page copied into a German locale, as copy_for_translation leaves it."""
+    german = Locale.objects.get_or_create(language_code="de")[0]
+    canonical_de = routed_page.canonical.copy_for_translation(german, copy_parents=True)
+    canonical_de.save()
+    canonical_de.refresh_from_db()
+    target_de = routed_page.target.copy_for_translation(german)
+    target_de.live = True
+    target_de.save()
+    return SimpleNamespace(canonical=canonical_de, target=target_de, source=routed_page)
+
+
+def test_translation_copies_rules_still_pointing_at_the_source_locale(translated_tree):
+    # Pins the Wagtail behaviour the fix exists for: the rule comes across, but its
+    # stored target is still the English variant. If Wagtail ever remaps this itself,
+    # this test fails and localized_target can be reconsidered.
+    rule = translated_tree.canonical.routing_rules.get()
+    assert rule.target_id == translated_tree.source.target.pk
+    assert not rule.target.is_descendant_of(translated_tree.canonical)
+
+
+def test_serialize_routes_a_translated_page_to_its_own_locale_target(translated_tree):
+    # The German page must route to the German variant, never the English one.
+    serialized = serialize_rules(translated_tree.canonical)
+    assert len(serialized) == 1
+    assert serialized[0]["target"] == translated_tree.target.get_url()
+    assert serialized[0]["target"] != translated_tree.source.target.get_url()
+
+
+def test_serialize_drops_a_rule_whose_target_is_not_translated(translated_tree):
+    # Fail safe the way the rest of the framework does: with no German variant, the
+    # visitor stays on the German canonical rather than being sent to English content.
+    translated_tree.target.delete()
+    assert serialize_rules(translated_tree.canonical) == []
+
+
+def test_serialize_drops_a_rule_whose_translated_target_is_unpublished(translated_tree):
+    # Same outcome by a different route — the existing live check catches this one.
+    translated_tree.target.live = False
+    translated_tree.target.save()
+    assert serialize_rules(translated_tree.canonical) == []
+
+
+def test_serialize_is_unaffected_for_an_untranslated_page(routed_page):
+    serialized = serialize_rules(routed_page.canonical)
+    assert serialized[0]["target"] == routed_page.target.get_url()

--- a/springfield/cms/templates/cms/routing/resolver.html
+++ b/springfield/cms/templates/cms/routing/resolver.html
@@ -1,0 +1,63 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{#
+ Lightweight client resolver page. Deliberately standalone and minimal — a
+ sub-1.5s bounce that evaluates rules on the client and redirects. Zero inline
+ <script>/<style> (CSP); all data reaches the JS via data-* attributes and all strings
+ via Fluent -> data-* -> Mozilla.Utils.trans.
+#}
+<!doctype html>
+<html lang="{{ LANG }}" dir="{{ DIR }}" data-country-code="{{ country_code }}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {# Not a canonical content page — keep it out of search indexes. #}
+    <meta name="robots" content="noindex,nofollow">
+    <title>{{ ftl('routing-resolver-preparing') }}</title>
+
+    {# No-JS fallback: straight to canonical content, keeping the visitor's attribution and
+       carrying the loop-breaker so the destination doesn't serve this page again. #}
+    <noscript><meta http-equiv="refresh" content="0; url={{ fallback_url }}"></noscript>
+
+    {{ css_bundle('cms_routing_resolver') }}
+
+    {# site bundle sets window.site.platform, which mozilla-client (in `lib`) reads. #}
+    {{ js_bundle('site') }}
+  </head>
+
+  <body>
+    {# Localized strings for the bundled JS, read via Mozilla.Utils.trans('preparing'). #}
+    <div id="strings" data-preparing="{{ ftl('routing-resolver-preparing') }}"></div>
+
+    <main
+      class="routing-resolver"
+      data-routing-rules='{{ routing_rules|tojson }}'
+      data-routing-manifest='{{ routing_manifest|tojson }}'
+      data-canonical-url="{{ canonical_url }}"
+      data-loop-breaker-param="{{ loop_breaker_param }}"
+      {% if routing_fake_signals %}data-routing-fake-signals='{{ routing_fake_signals|tojson }}'{% endif %}
+    >
+      <p class="routing-resolver-status">{{ ftl('routing-resolver-preparing') }}</p>
+      {#
+       The escape hatch. <noscript> does not render when JS is enabled but the bundle fails to
+       load or throws — and `static/` is build output, so a missing bundle is a real deploy
+       failure. Without this, such a visitor is stranded on a page with no link and no control.
+       Always present in the markup (so it works with no CSS and no JS, and screen readers and
+       keyboard users reach it immediately); CSS fades it in after the evaluator's own budget has
+       elapsed, so a visitor whose redirect is working never sees it.
+      #}
+      <p class="routing-resolver-escape"><a href="{{ fallback_url }}">{{ ftl('routing-resolver-continue') }}</a></p>
+      <noscript>
+        <p><a href="{{ fallback_url }}">{{ ftl('routing-resolver-continue') }}</a></p>
+      </noscript>
+    </main>
+
+    {# mozilla-client / mozilla-utils / uitour, then the resolver entrypoint. #}
+    {{ js_bundle('lib') }}
+    {{ js_bundle('cms_routing_resolver') }}
+  </body>
+</html>

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -92,6 +92,18 @@ CACHE_TIME_SHORT = 60 * 10  # 10 mins
 CACHE_TIME_MED = 60 * 60  # 1 hour
 CACHE_TIME_LONG = 60 * 60 * 6  # 6 hours
 
+# How long the User Routing resolver page may be reused. It is a CDN-cacheable page that freezes
+# per-page state into its body — the rules' target URLs, whether routing is paused, and the
+# visitor's country — and nothing purges it, so this is how long any of those may be stale.
+#
+# Deliberately a setting rather than a constant, and deliberately the same value the page already
+# inherited from the cache middleware, so nothing about its caching changes on merge. Lowering it
+# shrinks every staleness window but costs origin work on each miss, and that trade depends on
+# release traffic and whether CDN shielding is on — neither knowable from here, and neither live
+# until the `user_routing` waffle switch is on, because no resolver is served while it is off.
+# Tunable by env var so the number can be chosen by whoever owns that trade, without a deploy.
+ROUTING_RESOLVER_CACHE_SECONDS = config("ROUTING_RESOLVER_CACHE_SECONDS", default="600", parser=int)
+
 
 CACHES = {
     "default": {

--- a/tests/unit/spec/cms/routing/evaluator.js
+++ b/tests/unit/spec/cms/routing/evaluator.js
@@ -80,6 +80,15 @@ describe('cms/routing/evaluator.es6.js', function () {
             expect(compareVersions('129.1', '129.0.5')).toEqual(1);
         });
 
+        it('reports no comparison for a value that only contains a version', function () {
+            // Previously these were coerced to 129 by stripping the leading junk or
+            // ignoring the trailing remainder, which let a garbage value match a rule.
+            expect(compareVersions('garbage129', '129')).toBeNull();
+            expect(compareVersions('129beta', '129')).toBeNull();
+            expect(compareVersions('129.0.1-beta', '129')).toBeNull();
+            expect(compareVersions('v129', '129')).toBeNull();
+        });
+
         it('reports no comparison at all when either side has no version in it', function () {
             // Not 0 — "no answer" and "equal" must not be the same value, or every
             // ordered operator reads a garbage value as equal and matches on it.

--- a/tests/unit/spec/cms/routing/evaluator.js
+++ b/tests/unit/spec/cms/routing/evaluator.js
@@ -194,18 +194,12 @@ describe('cms/routing/evaluator.es6.js', function () {
                     available('129.0')
                 )
             ).toEqual(NOT_MATCHED);
-            expect(
-                evaluateCondition(
-                    cond('firefox_version', 'not_gte', '128', 'version'),
-                    available('129.0')
-                )
-            ).toEqual(NOT_MATCHED);
         });
 
         it('supports integer and boolean comparisons', function () {
             expect(
                 evaluateCondition(
-                    cond('profile_age', 'gt', '30', 'integer'),
+                    cond('profile_age_weeks', 'gt', '30', 'integer'),
                     available(45)
                 )
             ).toEqual(MATCHED);
@@ -227,10 +221,9 @@ describe('cms/routing/evaluator.es6.js', function () {
         // `?oldversion=unknown` when it has no prior version to report, so this is live
         // traffic. The evaluator must treat it like a signal it never got.
         const ORDERED = ['lt', 'lte', 'gt', 'gte'];
-        const NEGATED_ORDERED = ['not_lt', 'not_lte', 'not_gt', 'not_gte'];
 
         it('never matches an ordered version comparison against an unparseable value', function () {
-            ORDERED.concat(NEGATED_ORDERED).forEach(function (operator) {
+            ORDERED.forEach(function (operator) {
                 expect(
                     evaluateCondition(
                         cond('oldversion', operator, '128', 'version'),
@@ -241,10 +234,10 @@ describe('cms/routing/evaluator.es6.js', function () {
         });
 
         it('never matches an ordered integer comparison against an unparseable value', function () {
-            ORDERED.concat(NEGATED_ORDERED).forEach(function (operator) {
+            ORDERED.forEach(function (operator) {
                 expect(
                     evaluateCondition(
-                        cond('profile_age', operator, '30', 'integer'),
+                        cond('profile_age_weeks', operator, '30', 'integer'),
                         available('unknown')
                     )
                 ).toEqual(NOT_MATCHED);
@@ -255,12 +248,6 @@ describe('cms/routing/evaluator.es6.js', function () {
             // The whole point: a negated unknown must stay not-matched. Equality and
             // membership go through the same rule, so `is_not` and `not_in` cannot
             // claim a garbage value differs from what the author asked for.
-            expect(
-                evaluateCondition(
-                    cond('oldversion', 'not_gte', '128', 'version'),
-                    available('unknown')
-                )
-            ).toEqual(NOT_MATCHED);
             expect(
                 evaluateCondition(
                     cond('oldversion', 'not_equals', '128', 'version'),
@@ -275,7 +262,7 @@ describe('cms/routing/evaluator.es6.js', function () {
             ).toEqual(NOT_MATCHED);
             expect(
                 evaluateCondition(
-                    cond('profile_age', 'not_equals', '30', 'integer'),
+                    cond('profile_age_weeks', 'not_equals', '30', 'integer'),
                     available('unknown')
                 )
             ).toEqual(NOT_MATCHED);
@@ -285,24 +272,34 @@ describe('cms/routing/evaluator.es6.js', function () {
             // Guard for the sentinel: 0 is a real value, not "no value".
             expect(
                 evaluateCondition(
-                    cond('profile_age', 'lte', '30', 'integer'),
+                    cond('profile_age_weeks', 'lte', '30', 'integer'),
                     available(0)
                 )
             ).toEqual(MATCHED);
             expect(
                 evaluateCondition(
-                    cond('profile_age', 'equals', '0', 'integer'),
+                    cond('profile_age_weeks', 'equals', '0', 'integer'),
                     available('0')
                 )
             ).toEqual(MATCHED);
         });
 
-        it('every operator is present and paired with its negation', function () {
+        it('every operator declares a comparison and a negation flag', function () {
             Object.keys(OPERATORS).forEach(function (key) {
                 const op = OPERATORS[key];
                 expect(typeof op.compare).toEqual('string');
                 expect(typeof op.negated).toEqual('boolean');
             });
+        });
+
+        it('carries no negated form of an ordered comparison', function () {
+            // Each would duplicate an operator that already exists — `not_gte` is `lt`.
+            // Dropped from the Python registry, so the client must not accept them either.
+            ['not_lt', 'not_lte', 'not_gt', 'not_gte'].forEach(
+                function (operator) {
+                    expect(OPERATORS[operator]).toBeUndefined();
+                }
+            );
         });
     });
 

--- a/tests/unit/spec/cms/routing/evaluator.js
+++ b/tests/unit/spec/cms/routing/evaluator.js
@@ -1,0 +1,488 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    MATCHED,
+    NOT_MATCHED,
+    PENDING,
+    SIGNAL_AVAILABLE,
+    SIGNAL_PENDING,
+    SIGNAL_UNAVAILABLE,
+    OPERATORS,
+    compareVersions,
+    evaluateCondition,
+    evaluateRule,
+    decideOutcome,
+    evaluateRules
+} from '../../../../../media/js/cms/routing/evaluator.es6.js';
+
+// --- helpers ---------------------------------------------------------------
+
+function cond(signal, operator, expected, valueType) {
+    return {
+        signal: signal,
+        operator: operator,
+        expected: expected,
+        valueType: valueType || 'string'
+    };
+}
+
+function available(value) {
+    return { status: SIGNAL_AVAILABLE, value: value };
+}
+
+const pending = { status: SIGNAL_PENDING };
+const unavailable = { status: SIGNAL_UNAVAILABLE };
+
+function states(map) {
+    return new Map(Object.keys(map).map((name) => [name, map[name]]));
+}
+
+// A provider whose reads are described by `reads` (name -> () => Promise) and whose
+// per-signal budgets come from `budgets` (name -> ms, default 500).
+function fakeProvider(reads, budgets) {
+    return {
+        read: function (name) {
+            return reads[name]();
+        },
+        getBudgetMs: function (name) {
+            return (budgets && budgets[name]) || 500;
+        }
+    };
+}
+
+const resolveWith = (value) => () => Promise.resolve(value);
+const never = () =>
+    new window.Promise(function () {
+        /* intentionally never resolves */
+    });
+const delayed = (value, ms) => () =>
+    new window.Promise(function (resolve) {
+        window.setTimeout(function () {
+            resolve(value);
+        }, ms);
+    });
+
+describe('cms/routing/evaluator.es6.js', function () {
+    describe('compareVersions', function () {
+        it('normalizes bare, rv-prefixed and fully-qualified versions', function () {
+            expect(compareVersions('rv:129', '129')).toEqual(0);
+            expect(compareVersions('129', '129.0.0')).toEqual(0);
+            expect(compareVersions('129.0.1', '129')).toEqual(1);
+        });
+
+        it('compares numerically, not as strings', function () {
+            expect(compareVersions('9', '100')).toEqual(-1);
+            expect(compareVersions('100', '9')).toEqual(1);
+            expect(compareVersions('129.1', '129.0.5')).toEqual(1);
+        });
+
+        it('reports no comparison at all when either side has no version in it', function () {
+            // Not 0 — "no answer" and "equal" must not be the same value, or every
+            // ordered operator reads a garbage value as equal and matches on it.
+            expect(compareVersions('unknown', '129')).toBeNull();
+            expect(compareVersions('129', 'unknown')).toBeNull();
+            expect(compareVersions('', '129')).toBeNull();
+            expect(compareVersions(null, '129')).toBeNull();
+        });
+    });
+
+    describe('evaluateCondition', function () {
+        it('matches / does not match a resolved positive condition', function () {
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is', 'windows', 'enum'),
+                    available('windows')
+                )
+            ).toEqual(MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is', 'windows', 'enum'),
+                    available('linux')
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        it('flips matched<->not-matched for a negated resolved condition', function () {
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is_not', 'windows', 'enum'),
+                    available('linux')
+                )
+            ).toEqual(MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is_not', 'windows', 'enum'),
+                    available('windows')
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        it('leaves a pending signal PENDING — positive and negated alike', function () {
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is', 'windows', 'enum'),
+                    pending
+                )
+            ).toEqual(PENDING);
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is_not', 'windows', 'enum'),
+                    pending
+                )
+            ).toEqual(PENDING);
+            // A missing state is treated as pending too.
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is', 'windows', 'enum'),
+                    undefined
+                )
+            ).toEqual(PENDING);
+        });
+
+        it('treats an unavailable signal as NOT_MATCHED and never flips it to a match', function () {
+            // The subtle point: a negated *unknown* must not become a match.
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is', 'windows', 'enum'),
+                    unavailable
+                )
+            ).toEqual(NOT_MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('platform', 'is_not', 'windows', 'enum'),
+                    unavailable
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        it('supports set membership (in / not_in)', function () {
+            const c = cond('platform', 'in', 'windows, osx', 'enum');
+            expect(evaluateCondition(c, available('osx'))).toEqual(MATCHED);
+            expect(evaluateCondition(c, available('linux'))).toEqual(
+                NOT_MATCHED
+            );
+            const n = cond('platform', 'not_in', 'windows, osx', 'enum');
+            expect(evaluateCondition(n, available('linux'))).toEqual(MATCHED);
+            expect(evaluateCondition(n, available('windows'))).toEqual(
+                NOT_MATCHED
+            );
+        });
+
+        it('splits set-membership values on newlines as well as commas', function () {
+            // Authors may enter one value per line in the textarea.
+            const c = cond('platform', 'in', 'windows\nosx\nlinux', 'enum');
+            expect(evaluateCondition(c, available('osx'))).toEqual(MATCHED);
+            expect(evaluateCondition(c, available('android'))).toEqual(
+                NOT_MATCHED
+            );
+        });
+
+        it('supports version comparisons', function () {
+            expect(
+                evaluateCondition(
+                    cond('firefox_version', 'gte', '128', 'version'),
+                    available('129.0')
+                )
+            ).toEqual(MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('firefox_version', 'lt', '128', 'version'),
+                    available('129.0')
+                )
+            ).toEqual(NOT_MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('firefox_version', 'not_gte', '128', 'version'),
+                    available('129.0')
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        it('supports integer and boolean comparisons', function () {
+            expect(
+                evaluateCondition(
+                    cond('profile_age', 'gt', '30', 'integer'),
+                    available(45)
+                )
+            ).toEqual(MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('is_firefox', 'is', 'true', 'boolean'),
+                    available(true)
+                )
+            ).toEqual(MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('is_firefox', 'is', 'true', 'boolean'),
+                    available(false)
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        // A value that arrived but says nothing — Firefox itself sends
+        // `?oldversion=unknown` when it has no prior version to report, so this is live
+        // traffic. The evaluator must treat it like a signal it never got.
+        const ORDERED = ['lt', 'lte', 'gt', 'gte'];
+        const NEGATED_ORDERED = ['not_lt', 'not_lte', 'not_gt', 'not_gte'];
+
+        it('never matches an ordered version comparison against an unparseable value', function () {
+            ORDERED.concat(NEGATED_ORDERED).forEach(function (operator) {
+                expect(
+                    evaluateCondition(
+                        cond('oldversion', operator, '128', 'version'),
+                        available('unknown')
+                    )
+                ).toEqual(NOT_MATCHED);
+            });
+        });
+
+        it('never matches an ordered integer comparison against an unparseable value', function () {
+            ORDERED.concat(NEGATED_ORDERED).forEach(function (operator) {
+                expect(
+                    evaluateCondition(
+                        cond('profile_age', operator, '30', 'integer'),
+                        available('unknown')
+                    )
+                ).toEqual(NOT_MATCHED);
+            });
+        });
+
+        it('does not turn an unparseable value into a match by negating it', function () {
+            // The whole point: a negated unknown must stay not-matched. Equality and
+            // membership go through the same rule, so `is_not` and `not_in` cannot
+            // claim a garbage value differs from what the author asked for.
+            expect(
+                evaluateCondition(
+                    cond('oldversion', 'not_gte', '128', 'version'),
+                    available('unknown')
+                )
+            ).toEqual(NOT_MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('oldversion', 'not_equals', '128', 'version'),
+                    available('unknown')
+                )
+            ).toEqual(NOT_MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('oldversion', 'not_in', '128, 129', 'version'),
+                    available('unknown')
+                )
+            ).toEqual(NOT_MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('profile_age', 'not_equals', '30', 'integer'),
+                    available('unknown')
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        it('still compares a parseable value that happens to be zero', function () {
+            // Guard for the sentinel: 0 is a real value, not "no value".
+            expect(
+                evaluateCondition(
+                    cond('profile_age', 'lte', '30', 'integer'),
+                    available(0)
+                )
+            ).toEqual(MATCHED);
+            expect(
+                evaluateCondition(
+                    cond('profile_age', 'equals', '0', 'integer'),
+                    available('0')
+                )
+            ).toEqual(MATCHED);
+        });
+
+        it('every operator is present and paired with its negation', function () {
+            Object.keys(OPERATORS).forEach(function (key) {
+                const op = OPERATORS[key];
+                expect(typeof op.compare).toEqual('string');
+                expect(typeof op.negated).toEqual('boolean');
+            });
+        });
+    });
+
+    describe('evaluateRule — conjunction', function () {
+        const rule = {
+            target: 'x',
+            conditions: [
+                cond('platform', 'is', 'windows', 'enum'),
+                cond('country', 'is', 'US', 'string')
+            ]
+        };
+
+        it('is MATCHED only when all conditions match', function () {
+            expect(
+                evaluateRule(
+                    rule,
+                    states({
+                        platform: available('windows'),
+                        country: available('US')
+                    })
+                )
+            ).toEqual(MATCHED);
+        });
+
+        it('short-circuits to NOT_MATCHED on one failed condition, even with a pending sibling', function () {
+            expect(
+                evaluateRule(
+                    rule,
+                    states({ platform: available('linux'), country: pending })
+                )
+            ).toEqual(NOT_MATCHED);
+        });
+
+        it('is PENDING when some conditions are pending and none have failed', function () {
+            expect(
+                evaluateRule(
+                    rule,
+                    states({ platform: available('windows'), country: pending })
+                )
+            ).toEqual(PENDING);
+        });
+
+        it('a matchAll rule is MATCHED immediately, ignoring conditions and signals', function () {
+            const everyone = { target: 'ALL', matchAll: true, conditions: [] };
+            expect(evaluateRule(everyone, states({}))).toEqual(MATCHED);
+        });
+
+        it('an empty, non-matchAll rule is NOT_MATCHED (no match-everyone footgun)', function () {
+            const empty = { target: 'x', matchAll: false, conditions: [] };
+            expect(evaluateRule(empty, states({}))).toEqual(NOT_MATCHED);
+        });
+
+        it('a rule with no matchAll flag and no conditions is NOT_MATCHED', function () {
+            expect(evaluateRule({ target: 'x' }, states({}))).toEqual(
+                NOT_MATCHED
+            );
+        });
+    });
+
+    describe('decideOutcome — priority-strict', function () {
+        const high = { target: 'HIGH', conditions: [cond('a', 'is', '1')] };
+        const low = { target: 'LOW', conditions: [cond('b', 'is', '1')] };
+
+        it('the first matched rule wins', function () {
+            const out = decideOutcome(
+                [high, low],
+                states({ a: available('1'), b: available('1') })
+            );
+            expect(out.status).toEqual(MATCHED);
+            expect(out.target).toEqual('HIGH');
+        });
+
+        it('a pending higher-priority rule blocks a matched lower-priority rule', function () {
+            const out = decideOutcome(
+                [high, low],
+                states({ a: pending, b: available('1') })
+            );
+            expect(out.status).toEqual(PENDING);
+        });
+
+        it('a lower-priority rule wins once every higher rule is definitively not-matched', function () {
+            const out = decideOutcome(
+                [high, low],
+                states({ a: available('0'), b: available('1') })
+            );
+            expect(out.status).toEqual(MATCHED);
+            expect(out.target).toEqual('LOW');
+        });
+
+        it('is NOT_MATCHED when no rule matches', function () {
+            const out = decideOutcome(
+                [high, low],
+                states({ a: available('0'), b: available('0') })
+            );
+            expect(out.status).toEqual(NOT_MATCHED);
+        });
+    });
+
+    describe('evaluateRules — async under the timeout envelope', function () {
+        const high = { target: 'HIGH', conditions: [cond('a', 'is', 'yes')] };
+        const low = { target: 'LOW', conditions: [cond('b', 'is', 'yes')] };
+
+        it('resolves to the matched rule target', async function () {
+            const out = await evaluateRules(
+                [high],
+                fakeProvider({ a: resolveWith('yes') }),
+                { globalTimeoutMs: 1000 }
+            );
+            expect(out.status).toEqual(MATCHED);
+            expect(out.target).toEqual('HIGH');
+        });
+
+        it('a slow higher-priority match still wins over a fast lower-priority match', async function () {
+            // If a pending high rule failed to block, the fast low rule would win here.
+            const provider = fakeProvider(
+                { a: delayed('yes', 40), b: resolveWith('yes') },
+                { a: 1000, b: 1000 }
+            );
+            const out = await evaluateRules([high, low], provider, {
+                globalTimeoutMs: 1000
+            });
+            expect(out.status).toEqual(MATCHED);
+            expect(out.target).toEqual('HIGH');
+        });
+
+        it('a lower-priority rule wins only after the higher rule is decided not-matched', async function () {
+            const provider = fakeProvider(
+                { a: delayed('no', 30), b: resolveWith('yes') },
+                { a: 1000, b: 1000 }
+            );
+            const out = await evaluateRules([high, low], provider, {
+                globalTimeoutMs: 1000
+            });
+            expect(out.status).toEqual(MATCHED);
+            expect(out.target).toEqual('LOW');
+        });
+
+        it('forces closure to not-matched when the global cap is hit', async function () {
+            const provider = fakeProvider({ a: never }, { a: 5000 });
+            const out = await evaluateRules([high], provider, {
+                globalTimeoutMs: 60
+            });
+            expect(out.status).toEqual(NOT_MATCHED);
+            expect(out.timedOut).toBe(true);
+        });
+
+        it('treats a signal that exceeds its per-signal budget as not-matched', async function () {
+            const provider = fakeProvider({ a: never }, { a: 40 });
+            const out = await evaluateRules([high], provider, {
+                globalTimeoutMs: 1000
+            });
+            expect(out.status).toEqual(NOT_MATCHED);
+            expect(out.timedOut).toBe(false);
+        });
+
+        it('a read rejection makes the signal unavailable (not-matched)', async function () {
+            const provider = fakeProvider(
+                { a: () => Promise.reject(new Error('nope')) },
+                { a: 1000 }
+            );
+            const out = await evaluateRules([high], provider, {
+                globalTimeoutMs: 1000
+            });
+            expect(out.status).toEqual(NOT_MATCHED);
+        });
+
+        it('a timed-out signal under a negated condition never becomes a match', async function () {
+            // "platform is_not linux" with platform timing out must NOT route.
+            const negatedRule = {
+                target: 'NEG',
+                conditions: [cond('platform', 'is_not', 'linux', 'enum')]
+            };
+            const provider = fakeProvider(
+                { platform: never },
+                { platform: 40 }
+            );
+            const out = await evaluateRules([negatedRule], provider, {
+                globalTimeoutMs: 1000
+            });
+            expect(out.status).toEqual(NOT_MATCHED);
+        });
+    });
+});

--- a/tests/unit/spec/cms/routing/readers.js
+++ b/tests/unit/spec/cms/routing/readers.js
@@ -7,6 +7,7 @@
 import {
     SOURCE_CDN_GEO,
     SOURCE_UITOUR,
+    aiControlsPosture,
     createGeoReader,
     createUserAgentReader,
     createUITourReader,
@@ -26,6 +27,92 @@ function settle(promise) {
 }
 
 describe('cms/routing/readers.es6.js', function () {
+    describe('aiControlsPosture', function () {
+        // Firefox reports a state per AI feature with no overall summary. These are the
+        // shapes getConfiguration('aiControls') actually returns, per UITour.sys.mjs.
+        const untouched = {
+            default: 'available',
+            translations: 'default',
+            pdfjsAltText: 'default',
+            smartTabGroups: 'default',
+            linkPreviewKeyPoints: 'default',
+            sidebarChatbot: 'default',
+            smartWindow: 'default'
+        };
+
+        it('reads an untouched profile as neutral', function () {
+            expect(aiControlsPosture(untouched)).toEqual('neutral');
+        });
+
+        it('treats explicit "available" as no choice, like "default"', function () {
+            // Firefox's own wording: available = "you'll see it and can use it";
+            // enabled = "you've opted in". Only the latter is a choice.
+            const allAvailable = Object.assign({}, untouched, {
+                translations: 'available',
+                sidebarChatbot: 'available'
+            });
+            expect(aiControlsPosture(allAvailable)).toEqual('neutral');
+        });
+
+        it('reads the global block as blocked_all, whatever the features say', function () {
+            expect(
+                aiControlsPosture(
+                    Object.assign({}, untouched, {
+                        default: 'blocked',
+                        sidebarChatbot: 'enabled'
+                    })
+                )
+            ).toEqual('blocked_all');
+        });
+
+        it('reads every feature blocked as blocked_all even without the master', function () {
+            const all = { default: 'available' };
+            Object.keys(untouched)
+                .filter((k) => k !== 'default')
+                .forEach((k) => {
+                    all[k] = 'blocked';
+                });
+            expect(aiControlsPosture(all)).toEqual('blocked_all');
+        });
+
+        it('distinguishes opting in, blocking, and doing both', function () {
+            expect(
+                aiControlsPosture(
+                    Object.assign({}, untouched, { sidebarChatbot: 'enabled' })
+                )
+            ).toEqual('enabled_some');
+            expect(
+                aiControlsPosture(
+                    Object.assign({}, untouched, { translations: 'blocked' })
+                )
+            ).toEqual('blocked_some');
+            expect(
+                aiControlsPosture(
+                    Object.assign({}, untouched, {
+                        sidebarChatbot: 'enabled',
+                        translations: 'blocked'
+                    })
+                )
+            ).toEqual('mixed');
+        });
+
+        it('folds in AI features Firefox has not shipped yet', function () {
+            // Keys are iterated, never named, so a new feature needs no change here.
+            expect(
+                aiControlsPosture({
+                    default: 'available',
+                    somethingBrandNew: 'enabled'
+                })
+            ).toEqual('enabled_some');
+        });
+
+        it('returns undefined for a payload it cannot read', function () {
+            expect(aiControlsPosture(undefined)).toBeUndefined();
+            expect(aiControlsPosture(null)).toBeUndefined();
+            expect(aiControlsPosture('nope')).toBeUndefined();
+        });
+    });
+
     describe('geo reader (CDN geo header)', function () {
         it('reads the server-rendered data-country-code attribute', async function () {
             const reader = createGeoReader({

--- a/tests/unit/spec/cms/routing/readers.js
+++ b/tests/unit/spec/cms/routing/readers.js
@@ -1,0 +1,336 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    SOURCE_CDN_GEO,
+    SOURCE_UITOUR,
+    createGeoReader,
+    createUserAgentReader,
+    createUITourReader,
+    createUrlReader,
+    createProvider
+} from '../../../../../media/js/cms/routing/readers.es6.js';
+
+// Resolve a promise to its value, or the sentinel REJECTED — lets a single helper
+// assert both outcomes without depending on a particular jasmine version's
+// expectAsync.
+const REJECTED = { rejected: true };
+function settle(promise) {
+    return promise.then(
+        (value) => value,
+        () => REJECTED
+    );
+}
+
+describe('cms/routing/readers.es6.js', function () {
+    describe('geo reader (CDN geo header)', function () {
+        it('reads the server-rendered data-country-code attribute', async function () {
+            const reader = createGeoReader({
+                root: { dataset: { countryCode: 'US' } }
+            });
+            expect(await reader.read({ name: 'country' })).toEqual('US');
+        });
+
+        it('is unavailable when the attribute is absent', async function () {
+            const reader = createGeoReader({ root: { dataset: {} } });
+            expect(await settle(reader.read({ name: 'country' }))).toBe(
+                REJECTED
+            );
+        });
+    });
+
+    describe('user-agent reader (Mozilla.Client)', function () {
+        const firefox = {
+            isFirefox: true,
+            platform: 'windows',
+            _getFirefoxVersion: () => '129.0'
+        };
+
+        it('maps Mozilla.Client output to signal values', async function () {
+            const reader = createUserAgentReader({ client: firefox });
+            expect(await reader.read({ name: 'platform' })).toEqual('windows');
+            expect(await reader.read({ name: 'firefox_version' })).toEqual(
+                '129.0'
+            );
+            expect(await reader.read({ name: 'is_firefox' })).toBe(true);
+        });
+
+        it('reads browser_language as the top preference, region dropped', async function () {
+            const reader = createUserAgentReader({
+                client: firefox,
+                navigator: { languages: ['fr-CA', 'en-US'], language: 'fr-CA' }
+            });
+            expect(await reader.read({ name: 'browser_language' })).toEqual(
+                'fr'
+            );
+        });
+
+        it('reads browser_language without Mozilla.Client present', async function () {
+            // navigator.languages is a plain browser API, so this must work off Firefox
+            // where the Mozilla.Client global is absent.
+            const reader = createUserAgentReader({
+                client: null,
+                navigator: { languages: ['de'], language: 'de' }
+            });
+            expect(await reader.read({ name: 'browser_language' })).toEqual(
+                'de'
+            );
+        });
+
+        it('falls back to navigator.language when languages is empty', async function () {
+            const reader = createUserAgentReader({
+                client: firefox,
+                navigator: { languages: [], language: 'es-MX' }
+            });
+            expect(await reader.read({ name: 'browser_language' })).toEqual(
+                'es'
+            );
+        });
+
+        it('is unavailable for browser_language when the browser reports none', async function () {
+            const reader = createUserAgentReader({
+                client: firefox,
+                navigator: { languages: [], language: '' }
+            });
+            expect(
+                await settle(reader.read({ name: 'browser_language' }))
+            ).toBe(REJECTED);
+        });
+
+        it('yields false for is_firefox when stubbed non-Firefox', async function () {
+            const reader = createUserAgentReader({
+                client: {
+                    isFirefox: false,
+                    platform: 'windows',
+                    _getFirefoxVersion: () => ''
+                }
+            });
+            expect(await reader.read({ name: 'is_firefox' })).toBe(false);
+        });
+
+        it('still reads platform off Firefox, but firefox_version is unavailable', async function () {
+            const reader = createUserAgentReader({
+                client: {
+                    isFirefox: false,
+                    platform: 'osx',
+                    _getFirefoxVersion: () => ''
+                }
+            });
+            expect(await reader.read({ name: 'platform' })).toEqual('osx');
+            expect(await settle(reader.read({ name: 'firefox_version' }))).toBe(
+                REJECTED
+            );
+        });
+    });
+
+    describe('UITour reader', function () {
+        it('resolves a value once the ping and getConfiguration answer', async function () {
+            const uiTour = {
+                ping: (cb) => cb(),
+                getConfiguration: (key, cb) => cb({ defaultBrowser: true })
+            };
+            const reader = createUITourReader({ uiTour: uiTour, timeout: 100 });
+            const value = await reader.read({
+                name: 'is_default_browser',
+                browserStateKey: 'appinfo'
+            });
+            expect(value).toBe(true);
+        });
+
+        it('stays pending then times out to unavailable when the ping never answers', async function () {
+            const stuck = {
+                ping: function () {
+                    /* never calls back */
+                },
+                getConfiguration: function () {
+                    /* never called */
+                }
+            };
+            const reader = createUITourReader({ uiTour: stuck, timeout: 30 });
+            const outcome = await settle(
+                reader.read({
+                    name: 'is_default_browser',
+                    browserStateKey: 'appinfo'
+                })
+            );
+            expect(outcome).toBe(REJECTED);
+        });
+
+        it('is unavailable when UITour is absent', async function () {
+            const reader = createUITourReader({ uiTour: null, timeout: 30 });
+            const outcome = await settle(
+                reader.read({
+                    name: 'is_default_browser',
+                    browserStateKey: 'appinfo'
+                })
+            );
+            expect(outcome).toBe(REJECTED);
+        });
+    });
+
+    describe('URL reader', function () {
+        it('reads query params by signal name', async function () {
+            const reader = createUrlReader({
+                search: '?utm_source=google&utm_medium=cpc'
+            });
+            expect(await reader.read({ name: 'utm_source' })).toEqual('google');
+            expect(await reader.read({ name: 'utm_medium' })).toEqual('cpc');
+        });
+
+        it('is unavailable when the param is absent', async function () {
+            const reader = createUrlReader({ search: '?utm_source=google' });
+            expect(await settle(reader.read({ name: 'utm_campaign' }))).toBe(
+                REJECTED
+            );
+        });
+
+        it('reads oldversion, normalizing the rv: prefix', async function () {
+            const reader = createUrlReader({ search: '?oldversion=rv:129' });
+            expect(await reader.read({ name: 'oldversion' })).toEqual('129');
+        });
+
+        it('reads oldversion verbatim when already normalized', async function () {
+            const reader = createUrlReader({ search: '?oldversion=129.0.1' });
+            expect(await reader.read({ name: 'oldversion' })).toEqual(
+                '129.0.1'
+            );
+        });
+
+        it('is unavailable when oldversion is absent', async function () {
+            const reader = createUrlReader({ search: '?utm_source=google' });
+            expect(await settle(reader.read({ name: 'oldversion' }))).toBe(
+                REJECTED
+            );
+        });
+
+        it('resolves oldversion=unknown with no version rather than rejecting', async function () {
+            // Firefox sends this when it has no prior version to report. The visitor did
+            // supply a value, so the read succeeds; deciding that an unparseable value
+            // proves nothing is the evaluator's job, and it fails closed on this.
+            const reader = createUrlReader({ search: '?oldversion=unknown' });
+            expect(await reader.read({ name: 'oldversion' })).toBeNull();
+        });
+
+        it('reads locale from the <html lang> attribute', async function () {
+            const reader = createUrlReader({ search: '', lang: 'de' });
+            expect(await reader.read({ name: 'locale' })).toEqual('de');
+        });
+
+        it('prefers an explicit ?locale= over <html lang>', async function () {
+            const reader = createUrlReader({
+                search: '?locale=pt-BR',
+                lang: 'de'
+            });
+            expect(await reader.read({ name: 'locale' })).toEqual('pt-BR');
+        });
+
+        it('is unavailable when neither ?locale= nor <html lang> is set', async function () {
+            const reader = createUrlReader({ search: '', lang: null });
+            expect(await settle(reader.read({ name: 'locale' }))).toBe(
+                REJECTED
+            );
+        });
+
+        it('reads language as the locale with the region dropped', async function () {
+            // One condition covers every regional variant: en matches en-US/en-GB/en-CA.
+            const reader = createUrlReader({ search: '', lang: 'en-CA' });
+            expect(await reader.read({ name: 'language' })).toEqual('en');
+            expect(await reader.read({ name: 'locale' })).toEqual('en-CA');
+        });
+
+        it('reads language from a region-free locale unchanged', async function () {
+            const reader = createUrlReader({ search: '', lang: 'de' });
+            expect(await reader.read({ name: 'language' })).toEqual('de');
+        });
+
+        it('derives language from an explicit ?locale= override too', async function () {
+            const reader = createUrlReader({
+                search: '?locale=pt-BR',
+                lang: 'de'
+            });
+            expect(await reader.read({ name: 'language' })).toEqual('pt');
+        });
+
+        it('is unavailable for language when no locale can be determined', async function () {
+            const reader = createUrlReader({ search: '', lang: null });
+            expect(await settle(reader.read({ name: 'language' }))).toBe(
+                REJECTED
+            );
+        });
+    });
+
+    describe('createProvider — composes the adapters for the evaluator', function () {
+        const manifest = {
+            country: { source: 'cdn_geo' },
+            platform: { source: 'user_agent' },
+            is_default_browser: {
+                source: 'uitour',
+                browserStateKey: 'appinfo'
+            },
+            utm_source: { source: 'url' }
+        };
+
+        function provider() {
+            return createProvider(manifest, {
+                root: { dataset: { countryCode: 'DE' } },
+                client: {
+                    platform: 'linux',
+                    isFirefox: true,
+                    _getFirefoxVersion: () => '1'
+                },
+                uiTour: {
+                    ping: (cb) => cb(),
+                    getConfiguration: (key, cb) => cb({ defaultBrowser: false })
+                },
+                search: '?utm_source=bing',
+                timeout: 100
+            });
+        }
+
+        it('routes each signal to the right source adapter', async function () {
+            const p = provider();
+            expect(await p.read('country')).toEqual('DE');
+            expect(await p.read('platform')).toEqual('linux');
+            expect(await p.read('is_default_browser')).toBe(false);
+            expect(await p.read('utm_source')).toEqual('bing');
+        });
+
+        it('gives UITour signals the longer per-key budget', function () {
+            const p = provider();
+            expect(p.getBudgetMs('is_default_browser')).toEqual(800);
+            expect(p.getBudgetMs('country')).toEqual(500);
+            expect(p.getBudgetMs('utm_source')).toEqual(500);
+        });
+
+        it('is unavailable for a signal missing from the manifest', async function () {
+            const p = provider();
+            expect(await settle(p.read('not_in_manifest'))).toBe(REJECTED);
+        });
+
+        it('exposes the source identifiers that mirror the Python registry', function () {
+            expect(SOURCE_CDN_GEO).toEqual('cdn_geo');
+            expect(SOURCE_UITOUR).toEqual('uitour');
+        });
+    });
+
+    describe('createProvider — fake signals (preview_signal)', function () {
+        it('resolves faked signals immediately and reads the rest live', async function () {
+            const manifest = {
+                platform: { source: 'user_agent' },
+                utm_source: { source: 'url' }
+            };
+            const p = createProvider(manifest, {
+                client: { platform: 'linux', isFirefox: true },
+                search: '?utm_source=bing',
+                fakes: { platform: 'windows' }
+            });
+            // Faked signal wins over the live reader value.
+            expect(await p.read('platform')).toEqual('windows');
+            // Un-faked signal still reads live.
+            expect(await p.read('utm_source')).toEqual('bing');
+        });
+    });
+});

--- a/tests/unit/spec/cms/routing/resolver.js
+++ b/tests/unit/spec/cms/routing/resolver.js
@@ -1,0 +1,253 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    initResolver,
+    appendLoopBreaker,
+    preserveQueryString,
+    RESERVED_ROUTING_PARAMS,
+    onResolveOutcome
+} from '../../../../../media/js/cms/routing/resolver.es6.js';
+
+function makeRoot(rules, manifest, canonical, param) {
+    const el = document.createElement('main');
+    el.setAttribute('data-routing-rules', JSON.stringify(rules));
+    el.setAttribute('data-routing-manifest', JSON.stringify(manifest));
+    el.setAttribute('data-canonical-url', canonical);
+    el.setAttribute('data-loop-breaker-param', param);
+    return el;
+}
+
+const RULES = [
+    {
+        target: '/target/',
+        conditions: [
+            {
+                signal: 'utm_source',
+                operator: 'is',
+                expected: 'x',
+                valueType: 'string'
+            }
+        ]
+    }
+];
+const MANIFEST = { utm_source: { source: 'url' } };
+
+describe('cms/routing/resolver.es6.js', function () {
+    describe('appendLoopBreaker', function () {
+        it('appends the marker, choosing ? or & correctly', function () {
+            expect(appendLoopBreaker('/c/', 'routed')).toEqual('/c/?routed=1');
+            expect(appendLoopBreaker('/c/?a=b', 'routed')).toEqual(
+                '/c/?a=b&routed=1'
+            );
+        });
+    });
+
+    describe('preserveQueryString', function () {
+        const reserved = RESERVED_ROUTING_PARAMS;
+
+        it('returns the url unchanged when there is nothing to preserve', function () {
+            expect(preserveQueryString('/target/', '', reserved)).toEqual(
+                '/target/'
+            );
+            expect(
+                preserveQueryString('/target/', undefined, reserved)
+            ).toEqual('/target/');
+        });
+
+        it('merges inbound params onto a clean url', function () {
+            expect(
+                preserveQueryString(
+                    '/target/',
+                    '?utm_source=update&oldversion=151',
+                    reserved
+                )
+            ).toEqual('/target/?utm_source=update&oldversion=151');
+        });
+
+        it('merges onto a url that already has a query string', function () {
+            expect(
+                preserveQueryString('/target/?a=b', '?utm_source=x', reserved)
+            ).toEqual('/target/?a=b&utm_source=x');
+        });
+
+        it('does not overwrite or duplicate a key the destination already carries', function () {
+            expect(
+                preserveQueryString(
+                    '/target/?utm_source=keep',
+                    '?utm_source=drop&utm_medium=email',
+                    reserved
+                )
+            ).toEqual('/target/?utm_source=keep&utm_medium=email');
+        });
+
+        it('strips reserved routing params', function () {
+            expect(
+                preserveQueryString(
+                    '/target/',
+                    '?routing=1&routed=1&preview_rule=2&preview_signal=x&utm_source=keep',
+                    reserved
+                )
+            ).toEqual('/target/?utm_source=keep');
+        });
+
+        it('preserves a fragment on the destination', function () {
+            expect(
+                preserveQueryString(
+                    '/target/#section',
+                    '?utm_source=x',
+                    reserved
+                )
+            ).toEqual('/target/?utm_source=x#section');
+        });
+    });
+
+    describe('onResolveOutcome', function () {
+        it('is a no-op telemetry seam', function () {
+            expect(onResolveOutcome({ status: 'matched' })).toBeUndefined();
+        });
+    });
+
+    describe('initResolver', function () {
+        it('returns null when there is no resolver element', function () {
+            expect(initResolver({ root: null })).toBeNull();
+        });
+
+        it('navigates to the matched rule target, preserving the inbound query string', async function () {
+            let navigated;
+            const root = makeRoot(RULES, MANIFEST, '/canon/', 'routed');
+            await initResolver({
+                root: root,
+                navigate: (url) => {
+                    navigated = url;
+                },
+                providerOptions: {
+                    search: '?utm_source=x&utm_campaign=spring'
+                },
+                evaluatorOptions: { globalTimeoutMs: 500 }
+            });
+            // Attribution (the matched signal + campaign) rides through to the target.
+            expect(navigated).toEqual(
+                '/target/?utm_source=x&utm_campaign=spring'
+            );
+        });
+
+        it('navigates to canonical with the loop-breaker on no match, preserving attribution', async function () {
+            let navigated;
+            const root = makeRoot(RULES, MANIFEST, '/canon/', 'routed');
+            await initResolver({
+                root: root,
+                navigate: (url) => {
+                    navigated = url;
+                },
+                providerOptions: {
+                    search: '?utm_source=nope&utm_campaign=spring'
+                },
+                evaluatorOptions: { globalTimeoutMs: 500 }
+            });
+            expect(navigated).toEqual(
+                '/canon/?utm_source=nope&utm_campaign=spring&routed=1'
+            );
+        });
+
+        it('does not carry reserved routing params onto the destination, nor duplicate the loop-breaker', async function () {
+            let navigated;
+            const root = makeRoot(RULES, MANIFEST, '/canon/', 'routed');
+            await initResolver({
+                root: root,
+                navigate: (url) => {
+                    navigated = url;
+                },
+                // A stale loop-breaker + preview params must be stripped, utm kept.
+                providerOptions: {
+                    search: '?utm_source=nope&routing=1&routed=1&preview_rule=3'
+                },
+                evaluatorOptions: { globalTimeoutMs: 500 }
+            });
+            expect(navigated).toEqual('/canon/?utm_source=nope&routed=1');
+        });
+
+        // The resolver renders *at* the canonical URL. If the destination is pushed, the
+        // interstitial sits one Back press away — where it either bounces the visitor
+        // forward again or, restored from the back/forward cache, shows a frozen
+        // "Preparing your page…" with no heading, no link and no control.
+        function spyLocation() {
+            return {
+                assign: jasmine.createSpy('assign'),
+                replace: jasmine.createSpy('replace')
+            };
+        }
+
+        it('replaces the resolver in history when routing to a target', async function () {
+            const windowLocation = spyLocation();
+            await initResolver({
+                root: makeRoot(RULES, MANIFEST, '/canon/', 'routed'),
+                windowLocation: windowLocation,
+                providerOptions: { search: '?utm_source=x' },
+                evaluatorOptions: { globalTimeoutMs: 500 }
+            });
+            expect(windowLocation.replace).toHaveBeenCalledWith(
+                '/target/?utm_source=x'
+            );
+            expect(windowLocation.assign).not.toHaveBeenCalled();
+        });
+
+        it('replaces the resolver in history on the canonical fallback too', async function () {
+            // The fallback carries the loop-breaker, so replacing here also stops
+            // ?routed=1 accumulating in the visitor's history.
+            const windowLocation = spyLocation();
+            await initResolver({
+                root: makeRoot(RULES, MANIFEST, '/canon/', 'routed'),
+                windowLocation: windowLocation,
+                providerOptions: { search: '?utm_source=nope' },
+                evaluatorOptions: { globalTimeoutMs: 500 }
+            });
+            expect(windowLocation.replace).toHaveBeenCalledWith(
+                '/canon/?utm_source=nope&routed=1'
+            );
+            expect(windowLocation.assign).not.toHaveBeenCalled();
+        });
+
+        it('applies fake signals from the preview data blob', async function () {
+            let navigated;
+            const rules = [
+                {
+                    target: '/faked/',
+                    conditions: [
+                        {
+                            signal: 'platform',
+                            operator: 'is',
+                            expected: 'windows',
+                            valueType: 'enum'
+                        }
+                    ]
+                }
+            ];
+            const root = makeRoot(
+                rules,
+                { platform: { source: 'user_agent' } },
+                '/canon/',
+                'routed'
+            );
+            root.setAttribute(
+                'data-routing-fake-signals',
+                JSON.stringify({ platform: 'windows' })
+            );
+            await initResolver({
+                root: root,
+                navigate: (url) => {
+                    navigated = url;
+                },
+                // Live client would report linux; the fake blob makes it windows.
+                providerOptions: {
+                    client: { platform: 'linux', isFirefox: true }
+                },
+                evaluatorOptions: { globalTimeoutMs: 500 }
+            });
+            expect(navigated).toEqual('/faked/');
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Add the User Routing resolver page and its client-side rule evaluation — layer 2 of 4, still dark behind the `user_routing` waffle switch.

**Layer 2 of 4**, based on `stack/1-schema`. See 1/4 for the stack's shape and why every layer ships dark.
Layer 1 gave us rules with no way to act on them; this one makes a page able to *serve* on them. Nothing
adopts the mixin yet, so no page in the site changes behaviour — that is layer 4.

## Significant changes and points to review

- **All rule evaluation happens on the client — the server never matches a rule.** This is the central
  design constraint and the thing to hold in mind while reading. The resolver page is CDN-cacheable, so it
  cannot depend on who is asking. It ships the page's rules and the metadata for the signals they test as
  `data-*` attributes (CSP-clean, no inline script) and the client decides. The one exception is the
  visitor's country, which is server-rendered as an attribute because the VCL already folds geo into the
  cache key.

- **`dispatch.py` is a pure function, and it is the highest-value thing to review.** `decide_routing()`
  takes seven booleans and returns one of three decisions; it touches no request, no ORM and no settings,
  so every combination is cheap to test and the precedence between them is readable in one place. The
  outermost gate is the `user_routing` waffle switch — off ⇒ canonical exactly as today.

- **`RoutingMixin` lands here with its two adoption hooks and the `serve()` adapter** (`mixins.py`).
  `serve()` is deliberately thin: it reads flags off the request and page, hands them to `decide_routing`,
  and performs the chosen branch. Policy is in the pure function, not in the method. **Layer 3 reopens this
  class** to add the admin tab, so it is half a class here by design.

- **The gate and the serializer must answer the same question.** `_has_live_routing_rules()` calls the
  same `usable_rules()` the serializer uses, rather than counting rules itself. If those two ever diverge,
  a page either serves a resolver with nothing in it (a holding page, then a bounce straight back) or
  refuses to route on rules that would have worked. There are tests pinning the agreement.

- **`ROUTING_RESOLVER_CACHE_SECONDS` (`settings/base.py`) is deliberately left at 600s** — the same value
  the page already inherited from the cache middleware, so nothing about its caching changes on merge. It
  is how long the frozen target URLs, pause state and country may be stale, since **nothing purges this
  page**. It is an env var rather than a constant because choosing a lower number is a real trade against
  origin work, and the VCL folds geo into the cache key so entries are already per-geo-and-querystring —
  shortening the lifetime multiplies origin work across all of those buckets. That number wants
  release-traffic data behind it.

- **Preview flows for staff (`preview.py`):** `?preview_rule=<id>` redirects straight to a rule's target
  and `?preview_signal=platform:windows` renders the resolver with a signal faked, so an author can
  exercise the real client path without matching the condition themselves. Both send `no-store`.

- **Client code:** `resolver.es6.js` is the entry point; `evaluator.es6.js` (operator semantics) and
  `readers.es6.js` (signal reading) are imported by it rather than being bundle entries of their own, so
  all three ship together.

- **Mechanical, skim these:** the Fluent strings (`l10n/en/cms-routing-resolver.ftl`), the resolver
  template and its stylesheet, and the two `static-bundles.json` entries.

## Testing

```bash
python -m pytest springfield/cms/routing/tests/ -q
npm run build && npm run jasmine
```

Expected: **296 routing tests** and **556 JS specs** pass on this layer.

There is still nothing to click through — no page type adopts the mixin until layer 4, so organic traffic
and the admin are both untouched by this PR.
