### PR TITLE
Move the invalid `ref_key` Sentry probe into `serve`

### DIFF
--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2529,25 +2529,27 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
 
         context = super().get_context(request, *args, **kwargs)
 
+        # The defaults stand for every case where there is no usable `ref_key`:
+        # no invite link to offer and no progress to report.
         context["invite_url"] = ""
-        if referral_id := request.GET.get("ref_key"):
-            try:
-                invite_code = crypto.referral_id_to_invite_code(referral_id)
-                context["invite_url"] = crypto.invite_url_for_code(invite_code)
-            except ValueError:
-                # Treated like a missing `ref_key` rather than raising. Only a
-                # correctly sized one is reported, because this is a public page
-                # and anything can land in the query string. At the right length
-                # it plausibly came from the referral flow, so a spike is worth
-                # seeing. The value itself is masked out of the event by
-                # `SENSITIVE_FIELDS_TO_MASK_ENTIRELY`.
-                if len(referral_id) == REFERRAL_ID_LENGTH:
-                    with new_scope() as scope:
-                        scope.fingerprint = ["referral-hub-invalid-ref-key"]
-                        capture_message(
-                            "ReferralHubPage received a ref_key that is not a valid referral ID",
-                            level="warning",
-                        )
+        context["install_count"] = 0
+
+        referral_id = request.GET.get("ref_key", "")
+        try:
+            # Validates as well as encrypts -- `referral_id_to_invite_code`
+            # runs the same `validate_referral_id` that `serve()` does, so a
+            # missing or malformed value lands in the `except` below.
+            invite_code = crypto.referral_id_to_invite_code(referral_id)
+            context["invite_url"] = crypto.invite_url_for_code(invite_code)
+        except ValueError:
+            # Left at the defaults rather than raising, and deliberately not
+            # reported. `serve()` is what rejects and reports a public request
+            # without a usable `ref_key`, so nothing from the referral flow can
+            # reach this point. What can reach it are the callers that skip
+            # `serve()` -- CMS preview, and Wagtail's
+            # `serve_password_required_response`, which calls `get_context`
+            # directly -- and a bad value from those is not a signal.
+            return context
 
         context["install_count"] = self._get_install_count(referral_id)
 
@@ -2556,10 +2558,10 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
     def _get_install_count(self, referral_id: str) -> int:
         """Installs credited to this ref_key, or 0 if it cannot be determined.
 
-        Returns 0 rather than raising for every failure mode -- no ref_key, an
-        unknown ref_key, or the referral table being unavailable -- because the
-        impact dashboard is one optional part of this page and must not be able
-        to fail the whole hub render.
+        Returns 0 rather than raising for every failure mode -- an unknown
+        ref_key, or the referral table being unavailable -- because the impact
+        dashboard is one optional part of this page and must not be able to fail
+        the whole hub render.
 
         Note this collapses "we don't know" and "you genuinely have 0 installs"
         into the same value. If the design ever needs to distinguish them (e.g.
@@ -2584,16 +2586,31 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
 
         The hub is meaningless without a referral ID -- there is no invite link to
         copy and no progress to show -- so a URL missing that part is treated as
-        not found rather than served empty. Wagtail's serve_preview builds its own
-        TemplateResponse instead of calling serve(), so CMS preview is unaffected
-        by this and still renders with an empty invite URL.
+        not found rather than served empty. This is the only place that rejects,
+        and the only place a bad `ref_key` is reported, because it is the only
+        one every public request passes through. `serve_preview()` renders the
+        page without coming through here, so CMS preview is unaffected and still
+        shows an empty invite URL.
         """
+        ref_key = request.GET.get("ref_key", "")
         try:
             # The referral ID arrives already-canonical from Firefox, so this is
             # deliberately strict: exactly REFERRAL_ID_LENGTH characters of
             # uppercase Crockford base32, with no case- or glyph-folding.
-            validate_referral_id(request.GET.get("ref_key"))
+            validate_referral_id(ref_key)
         except ValueError:
+            # Only a correctly sized `ref_key` is reported, because this is a
+            # public page and anything can land in the query string. At the right
+            # length it plausibly came from the referral flow, so a spike is worth
+            # seeing. The value itself is masked out of the event by
+            # `SENSITIVE_FIELDS_TO_MASK_ENTIRELY`.
+            if len(ref_key) == REFERRAL_ID_LENGTH:
+                with new_scope() as scope:
+                    scope.fingerprint = ["referral-hub-invalid-ref-key"]
+                    capture_message(
+                        "ReferralHubPage received a ref_key that is not a valid referral ID",
+                        level="warning",
+                    )
             # Without this, CMSLocaleFallbackMiddleware would see the 404, find
             # this very page live at the same path, and redirect to it forever.
             mark_locale_fallback_exempt(request)

--- a/springfield/cms/tests/test_referral_pages.py
+++ b/springfield/cms/tests/test_referral_pages.py
@@ -76,35 +76,12 @@ def test_hub_page_get_context_invite_url_empty_when_ref_key_invalid(rf):
     site = Site.objects.get(is_default_site=True)
     hub_page = ReferralHubPageFactory(parent=site.root_page)
 
-    # A ref_key that is not a valid referral ID (here it has separators and is
-    # the wrong length) is treated like a missing one instead of raising.
-    context = hub_page.get_context(rf.get("/invite/?ref_key=not-a-valid-ref-key"))
-
-    assert context["invite_url"] == ""
-
-
-def test_hub_page_reports_correctly_sized_invalid_ref_key(rf):
-    site = Site.objects.get(is_default_site=True)
-    hub_page = ReferralHubPageFactory(parent=site.root_page)
-
-    # Right length but `I` is not a Crockford symbol, so this plausibly came
-    # from the referral flow and is worth a Sentry warning.
+    # Right length, but `I` is not a Crockford symbol, so this is the shape that
+    # serve() reports. Reaching get_context with it means serve() was skipped
+    # (CMS preview, serve_password_required_response), which is not the referral
+    # flow, so it is treated like a missing ref_key and reported nowhere.
     with patch(CAPTURE_MESSAGE) as capture:
         context = hub_page.get_context(rf.get("/invite/?ref_key=A7B9K2M4PXQRSTVI"))
-
-    assert context["invite_url"] == ""
-    assert capture.call_count == 1
-    assert capture.call_args.kwargs["level"] == "warning"
-
-
-def test_hub_page_stays_quiet_for_wrong_length_ref_key(rf):
-    site = Site.objects.get(is_default_site=True)
-    hub_page = ReferralHubPageFactory(parent=site.root_page)
-
-    # Anything can land in a public query string, so a ref_key that is not even
-    # the right length is ignored rather than filling Sentry with scanner noise.
-    with patch(CAPTURE_MESSAGE) as capture:
-        context = hub_page.get_context(rf.get("/invite/?ref_key=junk"))
 
     assert context["invite_url"] == ""
     assert capture.call_count == 0
@@ -319,6 +296,33 @@ def test_hub_page_serve_raises_404_for_unusable_ref_key(rf, query, why):
 
     with pytest.raises(Http404):
         hub_page.serve(rf.get(f"/invite/{query}"))
+
+
+@pytest.mark.parametrize(
+    ("ref_key", "reports"),
+    [
+        # Right length but `I` is not a Crockford symbol, so this plausibly came
+        # from the referral flow and is worth a Sentry warning.
+        ("A7B9K2M4PXQRSTVI", True),
+        # Anything can land in a public query string, so a ref_key that is not
+        # even the right length is ignored rather than filling Sentry with
+        # scanner noise. Length is the only axis the prefilter looks at, so one
+        # case pins it.
+        ("junk", False),
+    ],
+)
+def test_hub_page_serve_reports_only_a_correctly_sized_invalid_ref_key(rf, ref_key, reports):
+    """serve() is the only gate every public request passes, so it reports."""
+    site = Site.objects.get(is_default_site=True)
+    hub_page = ReferralHubPageFactory(parent=site.root_page)
+
+    with patch(CAPTURE_MESSAGE) as capture:
+        with pytest.raises(Http404):
+            hub_page.serve(rf.get(f"/invite/?ref_key={ref_key}"))
+
+    assert capture.call_count == (1 if reports else 0)
+    if reports:
+        assert capture.call_args.kwargs["level"] == "warning"
 
 
 def test_hub_page_serve_succeeds_for_a_well_formed_ref_key(rf):


### PR DESCRIPTION
`serve` 404s a malformed `ref_key` before `get_context` runs, so the probe could only ever fire for CMS preview and other callers that skip `serve`. It was watching editors, not the referral flow.

`get_context` still tolerates a bad key for those callers, and now returns early instead, which drops a guaranteed-miss install lookup.