### PR TITLE
WT-1477 auto select browser tab

### DIFF
--- a/media/js/cms/components/flare-browser-detect.es6.js
+++ b/media/js/cms/components/flare-browser-detect.es6.js
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Coarse detection of the visitor's browser.
+ *
+ * Every Chromium-based browser also reports "Chrome" in its user agent, and every
+ * iOS browser is a WebKit wrapper reporting "Safari", so the order of these
+ * checks matters: branded browsers have to be ruled out first, and Safari has to
+ * come last. Browsers we have no comparison for return 'other' rather than
+ * falling through to 'chrome' or 'safari', so callers fall back instead of
+ * matching the wrong thing.
+ *
+ * Detection is best-effort, and 'safari' is the weakest answer it gives: it is
+ * whatever WebKit is left after the known brands are excluded. A branded iOS
+ * browser we don't know about - or an in-app webview such as Facebook's or
+ * Instagram's - is reported as Safari rather than 'other'.
+ *
+ * Brave is deliberately indistinguishable from Chrome here - it ships Chrome's
+ * user agent verbatim. Use isBrave() for that.
+ *
+ * @param {String} ua - Optional user agent string, to facilitate testing.
+ * @returns {String} One of 'firefox', 'edge', 'opera', 'chrome', 'safari', 'other'.
+ */
+export const detectBrowser = function (ua) {
+    ua = typeof ua !== 'undefined' ? ua : navigator.userAgent;
+
+    // Firefox forks and iOS Firefox. Same exclusion list as site.isFirefox().
+    if (
+        /\s(Firefox|FxiOS)/.test(ua) &&
+        !/Iceweasel|IceCat|SeaMonkey|Camino|like Firefox/i.test(ua)
+    ) {
+        return 'firefox';
+    }
+
+    // EdgA on Android, EdgiOS on iOS. Legacy Edge/EdgeHTML used "Edge".
+    if (/Edg\/|EdgA\/|EdgiOS\/|Edge\//.test(ua)) {
+        return 'edge';
+    }
+
+    // OPR on desktop and Android, OPT/OPiOS on iOS.
+    if (/OPR\/|OPT\/|OPiOS\/|Opera Mini|Opera\//.test(ua)) {
+        return 'opera';
+    }
+
+    // Branded browsers we have no comparison for. They have to be ruled out
+    // before the Chrome and Safari checks below, because they all borrow one of
+    // those two tokens: Chromium forks carry "Chrome", and on iOS every browser
+    // is a WebKit wrapper carrying "Safari". Left to fall through they would be
+    // reported as the browser they are built on rather than falling back.
+    if (
+        /Vivaldi|YaBrowser|SamsungBrowser|Whale|DuckDuckGo|Focus\/|Klar\/|Puffin/.test(
+            ua
+        )
+    ) {
+        return 'other';
+    }
+
+    // CriOS is Chrome on iOS.
+    if (/Chrome\/|Chromium\/|CriOS\//.test(ua)) {
+        return 'chrome';
+    }
+
+    // Best-effort Safari. This is a catch-all, not a positive identification:
+    // genuine Safari and an unrecognised WebKit wrapper are indistinguishable
+    // here, since the wrappers append their own token but keep Safari's intact.
+    // A branded iOS browser missing from the list above is therefore read as
+    // Safari - the failure mode is a plausible neighbouring tab, not a crash, so
+    // it is left as a known limitation rather than guessed at more aggressively.
+    if (/Safari\//.test(ua)) {
+        return 'safari';
+    }
+
+    return 'other';
+};
+
+/**
+ * Detect Brave, which reports Chrome's user agent verbatim and can only be
+ * identified by the API it injects.
+ *
+ * @returns {Promise<Boolean>} Resolves false when the API is missing or throws.
+ */
+export const isBrave = function () {
+    return new Promise(function (resolve) {
+        try {
+            if (
+                !navigator.brave ||
+                typeof navigator.brave.isBrave !== 'function'
+            ) {
+                resolve(false);
+                return;
+            }
+            navigator.brave.isBrave().then(
+                function (result) {
+                    resolve(Boolean(result));
+                },
+                function () {
+                    resolve(false);
+                }
+            );
+        } catch (e) {
+            resolve(false);
+        }
+    });
+};

--- a/media/js/cms/components/flare-browser-tabs.es6.js
+++ b/media/js/cms/components/flare-browser-tabs.es6.js
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { detectBrowser, isBrave } from './flare-browser-detect.es6';
+
+/**
+ * Auto-select the tab comparing the visitor's own browser against Firefox.
+ *
+ * Kept out of flare-tabs.es6.js: tabs are a general-purpose component, and
+ * only the browser comparison tables care who the visitor is. A tablist opts
+ * in purely by having tabs with a data-browser attribute, which TabBlock's
+ * "Detected browser" field sets. Tablists without it are left alone.
+ */
+
+// Where visitors with no tab of their own end up. Firefox users land here too:
+// the tables all compare Firefox against something else, so there is never a
+// Firefox tab to select.
+const FALLBACK_BROWSER = 'chrome';
+
+function getBrowserTab(tablist, browser) {
+    return browser
+        ? tablist.querySelector('[role=tab][data-browser="' + browser + '"]')
+        : null;
+}
+
+/**
+ * @param {Array<TabsAutomatic>} tabInstances - as returned by setupTabs().
+ */
+export default function setupBrowserTabs(tabInstances) {
+    if (!tabInstances || !tabInstances.length) {
+        return;
+    }
+
+    const browser = detectBrowser();
+
+    tabInstances.forEach(function (tabs) {
+        const tablist = tabs.tablistNode;
+
+        // Opt-in check.
+        if (!tablist.querySelector('[role=tab][data-browser]')) {
+            return;
+        }
+
+        // Select synchronously, so a single tab is always shown rather than
+        // leaving the pre-JS state (every panel visible) up while the Brave
+        // check below settles.
+        const match =
+            getBrowserTab(tablist, browser) ||
+            getBrowserTab(tablist, FALLBACK_BROWSER);
+        if (match) {
+            tabs.setSelectedTab(match, false);
+        }
+
+        // Brave ships Chrome's user agent verbatim, so a Brave tab can only be
+        // resolved asynchronously. Only worth asking when a Brave tab exists
+        // and detection landed on Chrome, which is what Brave looks like.
+        const braveTab = getBrowserTab(tablist, 'brave');
+        if (browser === 'chrome' && braveTab && navigator.brave) {
+            // The result can land after the visitor has already picked a tab, at
+            // which point applying it would yank the panel out from under them.
+            // An explicit choice always outranks this guess, so watch for one
+            // and stand down if it comes.
+            let hasActed = false;
+            const noteAction = function () {
+                hasActed = true;
+            };
+            const events = ['click', 'keydown', 'focusin'];
+            events.forEach(function (name) {
+                tablist.addEventListener(name, noteAction, true);
+            });
+
+            isBrave().then(function (result) {
+                events.forEach(function (name) {
+                    tablist.removeEventListener(name, noteAction, true);
+                });
+                if (result && !hasActed) {
+                    tabs.setSelectedTab(braveTab, false);
+                }
+            });
+        }
+    });
+}

--- a/media/js/cms/components/flare-tabs.es6.js
+++ b/media/js/cms/components/flare-tabs.es6.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-class TabsAutomatic {
+export class TabsAutomatic {
     constructor(groupNode) {
         this.tablistNode = groupNode;
 
@@ -45,9 +45,6 @@ class TabsAutomatic {
             const isCurrent = currentTab === tab;
 
             tab.setAttribute('aria-selected', isCurrent ? 'true' : 'false');
-            // Tabindex: only the current tab is in the keyboard focus
-            // order, the rest are reachable via arrow/Home/End keys.
-            tab.setAttribute('tabindex', isCurrent ? '0' : '-1');
             if (tabpanel) {
                 tabpanel.classList.toggle('is-hidden', !isCurrent);
             }
@@ -101,7 +98,6 @@ class TabsAutomatic {
                 this.setSelectedTab(this.lastTab);
                 flag = true;
                 break;
-
             default:
                 break;
         }
@@ -117,9 +113,16 @@ class TabsAutomatic {
     }
 }
 
+/**
+ * Initialise every tablist on the page.
+ *
+ * @returns {Array<TabsAutomatic>} The instances, so callers that need to drive
+ *          selection - see flare-browser-tabs.es6.js - can do so through the
+ *          same object, keeping tab state, panels and focus order consistent.
+ */
 export default function setupTabs() {
     const tablists = document.querySelectorAll('.fl-tabs-nav[role="tablist"]');
-    tablists.forEach(function (tablist) {
-        new TabsAutomatic(tablist);
+    return Array.from(tablists).map(function (tablist) {
+        return new TabsAutomatic(tablist);
     });
 }

--- a/media/js/cms/flare.es6.js
+++ b/media/js/cms/flare.es6.js
@@ -21,6 +21,7 @@ import { setupSetAsDefault } from './components/flare-set-as-default.es6';
 import setupSlidingCarousels from './components/flare-sliding-carousel.es6';
 import setupRoadmap from './components/flare-roadmap.es6';
 import setupTabs from './components/flare-tabs.es6';
+import setupBrowserTabs from './components/flare-browser-tabs.es6';
 import setupTopicListSidebar from './components/flare-topic-list-sidebar.es6';
 import setupTypewriter, { typewriter } from './components/flare-typewriter.es6';
 import setupVideo from './components/flare-video.es6';
@@ -43,7 +44,9 @@ function setupComponents() {
     setupDownloadDropdown();
     setupQRCodeSnippet();
     setupRoadmap();
-    setupTabs();
+    // Browser auto-selection runs on the instances setupTabs() returns, and
+    // only affects tablists whose tabs declare a browser.
+    setupBrowserTabs(setupTabs());
     setupTopicListSidebar();
     setupTypewriter();
     setupDialogs();

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -97,6 +97,17 @@ DEFAULT_BROWSER_CHOICES = [
     ("is-default", "Firefox is default browser"),
     ("is-not-default", "Firefox is not default browser"),
 ]
+# Browsers a tab can be auto-selected for. There is no Firefox option: the
+# comparison tables all pit Firefox against something else, so Firefox users are
+# sent to the Chrome tab instead - see flare-browser-tabs.es6.js.
+DETECTED_BROWSER_CHOICES = [
+    ("", "No auto-selection"),
+    ("chrome", "Chrome"),
+    ("edge", "Edge"),
+    ("safari", "Safari"),
+    ("opera", "Opera"),
+    ("brave", "Brave"),
+]
 GEO_CHOICES = [
     ("US", "United States"),
     ("GB", "United Kingdom"),
@@ -1679,6 +1690,14 @@ class TabComparisonTableBlock(blocks.StreamBlock):
 class TabBlock(blocks.StructBlock):
     tab_name = blocks.CharBlock(label="Tab name")
     icon = IconChoiceBlock(required=False, label="Tab icon", help_text="Optional icon shown before the tab name in the tab list.")
+    detected_browser = blocks.ChoiceBlock(
+        choices=DETECTED_BROWSER_CHOICES,
+        default="",
+        required=False,
+        label="Detected browser",
+        help_text="Auto-select this tab for visitors using this browser. Leave empty to never auto-select it. "
+        "Visitors on Firefox, or on a browser no tab claims, get the Chrome tab.",
+    )
     heading = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
     image = ImageChooserBlock(required=False)
     description = RichTextBlock(features=EXPANDED_TEXT_FEATURES, required=False)

--- a/springfield/cms/templates/cms/blocks/tabs.html
+++ b/springfield/cms/templates/cms/blocks/tabs.html
@@ -10,7 +10,7 @@
     <div class="fl-tabs">
       <div class="fl-tabs-nav" id="fl-tablist-{{ section_id }}" aria-label="tabs-{{ section_id }}" role="tablist">
         {% for tab in value.tabs %}
-          <button type="button" class="fl-tabs-tab" role="tab" id="fl-tab-{{ section_id }}-{{ loop.index }}" aria-controls="fl-tab-panel-{{ section_id }}-{{ loop.index }}">
+          <button type="button" class="fl-tabs-tab" role="tab" id="fl-tab-{{ section_id }}-{{ loop.index }}" aria-controls="fl-tab-panel-{{ section_id }}-{{ loop.index }}"{% if tab.detected_browser %} data-browser="{{ tab.detected_browser }}"{% endif %}>
             <span class="fl-tabs-tab-label">{{ tab.tab_name }}</span>
             {% if tab.icon_name %}
               <include:icon

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -22,6 +22,7 @@ from wagtail.models import Locale, Page, Site
 
 from lib.l10n_utils import fluent_l10n, get_locale
 from springfield.cms.blocks import (
+    DETECTED_BROWSER_CHOICES,
     ROADMAP_STATUS_LABELS,
     ROADMAP_TAG_ICONS,
     ROADMAP_TAG_LABELS,
@@ -4834,6 +4835,47 @@ def test_tabs_block_tab_button_omits_the_icon_when_none_is_chosen():
     for button in buttons:
         assert button.find("span", class_="fl-icon") is None
     assert [b.get_text(strip=True) for b in buttons] == ["First tab", "Legacy tab"]
+
+
+def test_tabs_block_tab_button_renders_its_detected_browser():
+    """flare-browser-tabs.es6.js selects a tab by matching data-browser to the
+    visitor's browser, so the chosen value has to reach the markup. The tab name
+    cannot carry this: it is translated, and matching on it would fail
+    everywhere but English."""
+    tablist = _render_tablist([{"tab_name": "Chrome vs Firefox", "detected_browser": "chrome"}])
+
+    button = tablist.find("button", attrs={"role": "tab"})
+    assert button["data-browser"] == "chrome"
+
+
+def test_tabs_block_tab_button_omits_detected_browser_when_unset():
+    """Auto-selection is opt-in per tab, including for tabs saved before the
+    field existed. An empty choice stores "", which as data-browser="" would
+    make the tab a match candidate for a browser that never gets detected."""
+    tablist = _render_tablist([{"tab_name": "First tab", "detected_browser": ""}, {"tab_name": "Legacy tab"}])
+
+    buttons = tablist.find_all("button", attrs={"role": "tab"})
+    assert len(buttons) == 2
+    for button in buttons:
+        assert "data-browser" not in button.attrs
+
+
+def test_tabs_block_renders_a_distinct_detected_browser_per_tab():
+    """The five browser tabs must each carry their own value: a single shared or
+    last-wins attribute would auto-select the same tab for everyone."""
+    browsers = ["chrome", "edge", "safari", "opera", "brave"]
+    tablist = _render_tablist([{"tab_name": browser.title(), "detected_browser": browser} for browser in browsers])
+
+    buttons = tablist.find_all("button", attrs={"role": "tab"})
+    assert [button["data-browser"] for button in buttons] == browsers
+
+
+def test_tab_block_rejects_firefox_as_a_detected_browser():
+    """There is no Firefox tab to auto-select - the tables all compare Firefox
+    against something else - so Firefox visitors are sent to the Chrome tab
+    instead. Offering the choice would let an author build a tab that can never
+    be selected."""
+    assert "firefox" not in dict(DETECTED_BROWSER_CHOICES)
 
 
 def _email_href(html):

--- a/tests/unit/spec/cms/components/flare-browser-detect.js
+++ b/tests/unit/spec/cms/components/flare-browser-detect.js
@@ -1,0 +1,170 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    detectBrowser,
+    isBrave
+} from '../../../../../media/js/cms/components/flare-browser-detect.es6';
+
+describe('flare-browser-detect.es6.js', function () {
+    describe('detectBrowser', function () {
+        const UAS = {
+            firefox:
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0',
+            'firefox-windows':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0',
+            'firefox-android':
+                'Mozilla/5.0 (Android 14; Mobile; rv:140.0) Gecko/140.0 Firefox/140.0',
+            'firefox-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/127.0 Mobile/15E148 Safari/605.1.15',
+            chrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+            'chrome-macos':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+            'chrome-android':
+                'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+            'chrome-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.0.0 Mobile/15E148 Safari/604.1',
+            edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0',
+            'edge-android':
+                'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 EdgA/126.0.0.0',
+            'edge-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/126.0.0.0 Mobile/15E148 Safari/605.1.15',
+            'edge-legacy':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17763',
+            opera: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 OPR/112.0.0.0',
+            'opera-android':
+                'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 OPR/82.0.0.0',
+            'opera-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) OPT/5.0.0 Mobile/15E148 Safari/605.1.15',
+            safari: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+            'safari-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+            vivaldi:
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Vivaldi/6.8.3381.48',
+            samsung:
+                'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36',
+            yandex: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 YaBrowser/24.6.0.0 Safari/537.36',
+            // Branded WebKit wrappers. Every one of these keeps Safari's token
+            // and appends its own, so they reach the Safari check unless caught.
+            'duckduckgo-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15',
+            'duckduckgo-android':
+                'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/126.0.0.0 DuckDuckGo/5 Mobile Safari/537.36',
+            'firefox-focus-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Focus/126.0 Mobile/15E148 Safari/605.1.15',
+            'firefox-klar-ios':
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Klar/126.0 Mobile/15E148 Safari/605.1.15',
+            puffin: 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 Puffin/9.10.0',
+            seamonkey:
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0 SeaMonkey/2.53.18',
+            curl: 'curl/8.4.0'
+        };
+
+        const EXPECTED = {
+            firefox: 'firefox',
+            'firefox-windows': 'firefox',
+            'firefox-android': 'firefox',
+            'firefox-ios': 'firefox',
+            chrome: 'chrome',
+            'chrome-macos': 'chrome',
+            'chrome-android': 'chrome',
+            'chrome-ios': 'chrome',
+            edge: 'edge',
+            'edge-android': 'edge',
+            'edge-ios': 'edge',
+            'edge-legacy': 'edge',
+            opera: 'opera',
+            'opera-android': 'opera',
+            'opera-ios': 'opera',
+            safari: 'safari',
+            'safari-ios': 'safari',
+            // Chromium forks with no comparison tab of their own must fall back
+            // rather than be mistaken for Chrome.
+            vivaldi: 'other',
+            samsung: 'other',
+            yandex: 'other',
+            // Branded wrappers around WebKit or Chromium. Reporting these as
+            // safari/chrome would send the visitor to a tab for a browser they
+            // are not using, instead of the documented Chrome fallback.
+            'duckduckgo-ios': 'other',
+            'duckduckgo-android': 'other',
+            'firefox-focus-ios': 'other',
+            'firefox-klar-ios': 'other',
+            puffin: 'other',
+            // non-Chromium others
+            seamonkey: 'other',
+            curl: 'other'
+        };
+
+        Object.keys(EXPECTED).forEach(function (key) {
+            it('should detect ' + key + ' as ' + EXPECTED[key], function () {
+                expect(detectBrowser(UAS[key])).toEqual(EXPECTED[key]);
+            });
+        });
+
+        it('should fall back to navigator.userAgent when given no argument', function () {
+            spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(
+                UAS.safari
+            );
+            expect(detectBrowser()).toEqual('safari');
+        });
+
+        it('should report an unrecognised WebKit wrapper as safari, a known limitation', function () {
+            const unknownWrapper =
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 NewPrivacyBrowser/2 Safari/605.1.15';
+            expect(detectBrowser(unknownWrapper)).toEqual('safari');
+        });
+
+        it('should report Brave as chrome, since it copies Chrome exactly', function () {
+            expect(detectBrowser(UAS.chrome)).toEqual('chrome');
+        });
+    });
+
+    describe('isBrave', function () {
+        afterEach(function () {
+            delete navigator.brave;
+        });
+
+        it('should resolve false when the API is absent', async function () {
+            await expectAsync(isBrave()).toBeResolvedTo(false);
+        });
+
+        it('should resolve false when brave exists but isBrave is not callable', async function () {
+            navigator.brave = {};
+            await expectAsync(isBrave()).toBeResolvedTo(false);
+        });
+
+        it('should resolve true when the API confirms Brave', async function () {
+            navigator.brave = {
+                isBrave: () => Promise.resolve(true)
+            };
+            await expectAsync(isBrave()).toBeResolvedTo(true);
+        });
+
+        it('should resolve false when the API denies Brave', async function () {
+            navigator.brave = {
+                isBrave: () => Promise.resolve(false)
+            };
+            await expectAsync(isBrave()).toBeResolvedTo(false);
+        });
+
+        it('should resolve false when the API rejects', async function () {
+            navigator.brave = {
+                isBrave: () => Promise.reject(new Error('nope'))
+            };
+            await expectAsync(isBrave()).toBeResolvedTo(false);
+        });
+
+        it('should resolve false when the API throws synchronously', async function () {
+            navigator.brave = {
+                isBrave: () => {
+                    throw new Error('nope');
+                }
+            };
+            await expectAsync(isBrave()).toBeResolvedTo(false);
+        });
+    });
+});

--- a/tests/unit/spec/cms/components/flare-browser-tabs.js
+++ b/tests/unit/spec/cms/components/flare-browser-tabs.js
@@ -1,0 +1,402 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import setupBrowserTabs from '../../../../../media/js/cms/components/flare-browser-tabs.es6';
+import setupTabs from '../../../../../media/js/cms/components/flare-tabs.es6';
+
+const UAS = {
+    firefox:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0',
+    chrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+    edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0',
+    opera: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 OPR/112.0.0.0',
+    safari: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+    vivaldi:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Vivaldi/6.8.3381.48',
+    duckduckgo:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+};
+
+const BROWSERS = ['edge', 'chrome', 'safari', 'opera', 'brave'];
+
+describe('flare-browser-tabs.es6.js', function () {
+    let container;
+
+    function buildTablist(browsers, id) {
+        id = id || 'hub';
+        const tabs = browsers
+            .map(function (browser, i) {
+                const index = i + 1;
+                const attr = browser ? ' data-browser="' + browser + '"' : '';
+                return (
+                    '<button type="button" role="tab" id="fl-tab-' +
+                    id +
+                    '-' +
+                    index +
+                    '" aria-controls="fl-tab-panel-' +
+                    id +
+                    '-' +
+                    index +
+                    '"' +
+                    attr +
+                    '>' +
+                    (browser || 'plain') +
+                    '</button>'
+                );
+            })
+            .join('');
+        const panels = browsers
+            .map(function (browser, i) {
+                return (
+                    '<div id="fl-tab-panel-' +
+                    id +
+                    '-' +
+                    (i + 1) +
+                    '" role="tabpanel"></div>'
+                );
+            })
+            .join('');
+        return (
+            '<div class="fl-tabs-nav" role="tablist">' +
+            tabs +
+            '</div>' +
+            panels
+        );
+    }
+
+    function render(markup) {
+        container = document.createElement('div');
+        container.innerHTML = markup;
+        document.body.appendChild(container);
+    }
+
+    function selected() {
+        const tab = container.querySelector('[role=tab][aria-selected="true"]');
+        return tab ? tab.getAttribute('data-browser') || tab.id : null;
+    }
+
+    function useAgent(ua) {
+        spyOnProperty(navigator, 'userAgent', 'get').and.returnValue(ua);
+    }
+
+    afterEach(function () {
+        if (container) {
+            container.remove();
+            container = null;
+        }
+        delete navigator.brave;
+    });
+
+    describe('matching the visitor to a tab', function () {
+        it('should select the tab for the visitor’s own browser', function () {
+            useAgent(UAS.safari);
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(selected()).toEqual('safari');
+        });
+
+        ['edge', 'chrome', 'safari', 'opera'].forEach(function (browser) {
+            it(
+                'should select the ' + browser + ' tab on ' + browser,
+                function () {
+                    useAgent(UAS[browser]);
+                    render(buildTablist(BROWSERS));
+
+                    setupBrowserTabs(setupTabs());
+
+                    expect(selected()).toEqual(browser);
+                }
+            );
+        });
+
+        it('should select the Chrome tab for Firefox visitors', function () {
+            useAgent(UAS.firefox);
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(selected()).toEqual('chrome');
+        });
+
+        it('should select the Chrome tab for a browser no tab claims', function () {
+            useAgent(UAS.vivaldi);
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(selected()).toEqual('chrome');
+        });
+
+        it('should select the Chrome tab on a branded iOS browser, not the Safari tab', function () {
+            // DuckDuckGo and its like carry Safari's token, so without the brand
+            // check they land on the Safari tab - a browser the visitor is not
+            // using - rather than following the documented Chrome fallback.
+            useAgent(UAS.duckduckgo);
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(selected()).toEqual('chrome');
+        });
+
+        it('should leave the first tab selected when there is no Chrome tab to fall back to', function () {
+            useAgent(UAS.firefox);
+            render(buildTablist(['edge', 'safari']));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(selected()).toEqual('edge');
+        });
+
+        it('should not touch a tablist whose tabs declare no browser', function () {
+            // Tabs are used for plenty of things that have nothing to do with
+            // browsers; those must keep their first-tab default.
+            useAgent(UAS.safari);
+            render(buildTablist([null, null, null]));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(selected()).toEqual('fl-tab-hub-1');
+        });
+
+        it('should handle several tablists on one page independently', function () {
+            useAgent(UAS.opera);
+            render(
+                buildTablist(BROWSERS, 'one') +
+                    buildTablist([null, null], 'two')
+            );
+
+            setupBrowserTabs(setupTabs());
+
+            const chosen = container.querySelectorAll(
+                '[role=tab][aria-selected="true"]'
+            );
+            expect(chosen.length).toEqual(2);
+            expect(chosen[0].getAttribute('data-browser')).toEqual('opera');
+            expect(chosen[1].id).toEqual('fl-tab-two-1');
+        });
+
+        it('should show exactly one panel', function () {
+            useAgent(UAS.safari);
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+
+            const visible = Array.from(
+                container.querySelectorAll('[role=tabpanel]')
+            ).filter(function (panel) {
+                return !panel.classList.contains('is-hidden');
+            });
+            expect(visible.length).toEqual(1);
+            expect(visible[0].id).toEqual('fl-tab-panel-hub-3');
+        });
+
+        it('should not move focus, since the visitor has not acted', function () {
+            useAgent(UAS.safari);
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+
+            expect(document.activeElement).not.toEqual(
+                container.querySelector('[data-browser="safari"]')
+            );
+        });
+
+        it('should do nothing when given no tab instances', function () {
+            useAgent(UAS.safari);
+            render(buildTablist(BROWSERS));
+
+            expect(function () {
+                setupBrowserTabs([]);
+                setupBrowserTabs(undefined);
+            }).not.toThrow();
+            expect(selected()).toBeNull();
+        });
+    });
+
+    describe('Brave, which is indistinguishable from Chrome by user agent', function () {
+        it('should switch to the Brave tab once the API confirms it', async function () {
+            useAgent(UAS.chrome);
+            navigator.brave = { isBrave: () => Promise.resolve(true) };
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+            // Selected synchronously first, so no page is left with every panel
+            // showing while the promise settles.
+            expect(selected()).toEqual('chrome');
+
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(selected()).toEqual('brave');
+        });
+
+        it('should stay on Chrome when the API denies Brave', async function () {
+            useAgent(UAS.chrome);
+            navigator.brave = { isBrave: () => Promise.resolve(false) };
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(selected()).toEqual('chrome');
+        });
+
+        it('should not ask when there is no Brave tab', async function () {
+            useAgent(UAS.chrome);
+            const isBrave = jasmine
+                .createSpy('isBrave')
+                .and.returnValue(Promise.resolve(true));
+            navigator.brave = { isBrave: isBrave };
+            render(buildTablist(['chrome', 'safari']));
+
+            setupBrowserTabs(setupTabs());
+            await Promise.resolve();
+
+            expect(isBrave).not.toHaveBeenCalled();
+            expect(selected()).toEqual('chrome');
+        });
+
+        it('should not ask when the visitor is plainly not Chrome', async function () {
+            useAgent(UAS.opera);
+            const isBrave = jasmine
+                .createSpy('isBrave')
+                .and.returnValue(Promise.resolve(true));
+            navigator.brave = { isBrave: isBrave };
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+            await Promise.resolve();
+
+            expect(isBrave).not.toHaveBeenCalled();
+            expect(selected()).toEqual('opera');
+        });
+
+        it('should not move focus when it switches to Brave', async function () {
+            useAgent(UAS.chrome);
+            navigator.brave = { isBrave: () => Promise.resolve(true) };
+            render(buildTablist(BROWSERS));
+
+            setupBrowserTabs(setupTabs());
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(document.activeElement).not.toEqual(
+                container.querySelector('[data-browser="brave"]')
+            );
+        });
+    });
+
+    describe('a Brave result that arrives late', function () {
+        // The API is answered by hand here so the visitor can act in the window
+        // while it is still pending - the situation the guard exists for.
+        let resolveBrave;
+
+        function setupWithPendingBrave() {
+            useAgent(UAS.chrome);
+            navigator.brave = {
+                isBrave: () =>
+                    new Promise(function (resolve) {
+                        resolveBrave = resolve;
+                    })
+            };
+            render(buildTablist(BROWSERS));
+            setupBrowserTabs(setupTabs());
+        }
+
+        async function settle(result) {
+            resolveBrave(result);
+            await new Promise(function (resolve) {
+                setTimeout(resolve, 0);
+            });
+        }
+
+        function tab(browser) {
+            return container.querySelector('[data-browser="' + browser + '"]');
+        }
+
+        afterEach(function () {
+            resolveBrave = null;
+        });
+
+        it('should still apply when the visitor has done nothing', async function () {
+            setupWithPendingBrave();
+            expect(selected()).toEqual('chrome');
+
+            await settle(true);
+
+            expect(selected()).toEqual('brave');
+        });
+
+        it('should not overwrite a tab the visitor clicked while it was pending', async function () {
+            setupWithPendingBrave();
+
+            tab('safari').click();
+            expect(selected()).toEqual('safari');
+
+            await settle(true);
+
+            expect(selected()).toEqual('safari');
+        });
+
+        it('should not overwrite a tab the visitor reached by arrow key', async function () {
+            setupWithPendingBrave();
+            tab('chrome').dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    key: 'ArrowRight',
+                    bubbles: true
+                })
+            );
+            expect(selected()).toEqual('safari');
+
+            await settle(true);
+
+            expect(selected()).toEqual('safari');
+        });
+
+        it('should not overwrite a tab the visitor reached by Home or End', async function () {
+            setupWithPendingBrave();
+
+            tab('chrome').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'End', bubbles: true })
+            );
+            expect(selected()).toEqual('brave');
+            await settle(true);
+
+            expect(selected()).toEqual('brave');
+        });
+
+        it('should stand down once the visitor tabs into the tablist', async function () {
+            setupWithPendingBrave();
+            tab('safari').focus();
+            expect(selected()).toEqual('chrome');
+
+            await settle(true);
+
+            expect(selected()).toEqual('chrome');
+        });
+
+        it('should leave the visitor’s choice alone even when the API denies Brave', async function () {
+            setupWithPendingBrave();
+
+            tab('opera').click();
+            await settle(false);
+
+            expect(selected()).toEqual('opera');
+        });
+
+        it('should stop listening for interaction once it has settled', async function () {
+            setupWithPendingBrave();
+            await settle(true);
+            expect(selected()).toEqual('brave');
+            tab('edge').click();
+
+            expect(selected()).toEqual('edge');
+        });
+    });
+});

--- a/tests/unit/spec/cms/components/flare-tabs.js
+++ b/tests/unit/spec/cms/components/flare-tabs.js
@@ -1,0 +1,251 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import setupTabs, {
+    TabsAutomatic
+} from '../../../../../media/js/cms/components/flare-tabs.es6';
+
+describe('flare-tabs.es6.js', function () {
+    let container;
+
+    function render(count, id) {
+        id = id || 'hub';
+        let markup = '<div class="fl-tabs-nav" role="tablist">';
+        for (let i = 1; i <= count; i += 1) {
+            markup +=
+                '<button type="button" role="tab" id="fl-tab-' +
+                id +
+                '-' +
+                i +
+                '" aria-controls="fl-tab-panel-' +
+                id +
+                '-' +
+                i +
+                '">Tab ' +
+                i +
+                '</button>';
+        }
+        markup += '</div>';
+        for (let i = 1; i <= count; i += 1) {
+            markup +=
+                '<div id="fl-tab-panel-' +
+                id +
+                '-' +
+                i +
+                '" role="tabpanel"></div>';
+        }
+        container = document.createElement('div');
+        container.innerHTML = markup;
+        document.body.appendChild(container);
+    }
+
+    function tabs() {
+        return Array.from(container.querySelectorAll('[role=tab]'));
+    }
+
+    function selectedIndex() {
+        return tabs().findIndex(function (tab) {
+            return tab.getAttribute('aria-selected') === 'true';
+        });
+    }
+
+    function panelHidden(index) {
+        return container
+            .querySelectorAll('[role=tabpanel]')
+            [index].classList.contains('is-hidden');
+    }
+
+    afterEach(function () {
+        if (container) {
+            container.remove();
+            container = null;
+        }
+    });
+
+    describe('setupTabs', function () {
+        it('should return an instance per tablist', function () {
+            render(3, 'one');
+            const second = document.createElement('div');
+            second.innerHTML = '<div class="fl-tabs-nav" role="tablist"></div>';
+            container.appendChild(second);
+
+            const instances = setupTabs();
+
+            // flare-browser-tabs.es6.js drives selection through these, so an
+            // empty or undefined return would silently disable auto-selection.
+            expect(instances.length).toEqual(2);
+            expect(instances[0] instanceof TabsAutomatic).toBe(true);
+        });
+
+        it('should return an empty array when the page has no tablists', function () {
+            expect(setupTabs()).toEqual([]);
+        });
+    });
+
+    describe('initial state', function () {
+        beforeEach(function () {
+            render(3);
+            setupTabs();
+        });
+
+        it('should select the first tab', function () {
+            expect(selectedIndex()).toEqual(0);
+        });
+
+        it('should show only the first panel', function () {
+            expect(panelHidden(0)).toBe(false);
+            expect(panelHidden(1)).toBe(true);
+            expect(panelHidden(2)).toBe(true);
+        });
+
+        it('should keep every tab in the keyboard tab order', function () {
+            tabs().forEach(function (tab) {
+                expect(tab.getAttribute('tabindex')).toBeNull();
+            });
+        });
+
+        it('should not focus the first tab on load', function () {
+            // Focusing here would scroll the page down to the tablist before the
+            // visitor has done anything.
+            expect(document.activeElement).not.toEqual(tabs()[0]);
+        });
+    });
+
+    describe('interaction', function () {
+        beforeEach(function () {
+            render(3);
+            setupTabs();
+        });
+
+        function press(key, index) {
+            tabs()[index].dispatchEvent(
+                new KeyboardEvent('keydown', { key: key, bubbles: true })
+            );
+        }
+
+        it('should select a clicked tab', function () {
+            tabs()[2].click();
+
+            expect(selectedIndex()).toEqual(2);
+            expect(panelHidden(0)).toBe(true);
+            expect(panelHidden(2)).toBe(false);
+        });
+
+        it('should move to the next tab on ArrowRight', function () {
+            press('ArrowRight', 0);
+            expect(selectedIndex()).toEqual(1);
+        });
+
+        it('should wrap to the first tab from the last on ArrowRight', function () {
+            tabs()[2].click();
+            press('ArrowRight', 2);
+            expect(selectedIndex()).toEqual(0);
+        });
+
+        it('should move to the previous tab on ArrowLeft', function () {
+            tabs()[2].click();
+            press('ArrowLeft', 2);
+            expect(selectedIndex()).toEqual(1);
+        });
+
+        it('should wrap to the last tab from the first on ArrowLeft', function () {
+            press('ArrowLeft', 0);
+            expect(selectedIndex()).toEqual(2);
+        });
+
+        it('should jump to the first tab on Home and the last on End', function () {
+            press('End', 0);
+            expect(selectedIndex()).toEqual(2);
+            press('Home', 2);
+            expect(selectedIndex()).toEqual(0);
+        });
+
+        it('should focus the tab it moves to by keyboard', function () {
+            press('ArrowRight', 0);
+            expect(document.activeElement).toEqual(tabs()[1]);
+        });
+    });
+
+    describe('tabbing through the tablist', function () {
+        beforeEach(function () {
+            render(3);
+            setupTabs();
+        });
+
+        it('should not change the selection when a tab merely receives focus', function () {
+            tabs()[2].focus();
+
+            expect(selectedIndex()).toEqual(0);
+            expect(panelHidden(0)).toBe(false);
+            expect(panelHidden(2)).toBe(true);
+        });
+
+        it('should not swallow Enter, so a focused tab can be activated', function () {
+            const tab = tabs()[2];
+            const event = new KeyboardEvent('keydown', {
+                key: 'Enter',
+                bubbles: true,
+                cancelable: true
+            });
+            tab.dispatchEvent(event);
+
+            expect(event.defaultPrevented).toBe(false);
+        });
+
+        it('should not swallow Space, so a focused tab can be activated', function () {
+            const event = new KeyboardEvent('keydown', {
+                key: ' ',
+                bubbles: true,
+                cancelable: true
+            });
+            tabs()[2].dispatchEvent(event);
+
+            expect(event.defaultPrevented).toBe(false);
+        });
+
+        it('should select a tab activated by keyboard', function () {
+            tabs()[2].focus();
+            tabs()[2].click();
+
+            expect(selectedIndex()).toEqual(2);
+            expect(panelHidden(2)).toBe(false);
+        });
+
+        it('should still consume the arrow keys it handles', function () {
+            const event = new KeyboardEvent('keydown', {
+                key: 'ArrowRight',
+                bubbles: true,
+                cancelable: true
+            });
+            tabs()[0].dispatchEvent(event);
+
+            expect(event.defaultPrevented).toBe(true);
+        });
+    });
+
+    describe('setSelectedTab', function () {
+        it('should not move focus when asked not to', function () {
+            render(3);
+            const instance = setupTabs()[0];
+
+            instance.setSelectedTab(tabs()[2], false);
+
+            expect(selectedIndex()).toEqual(2);
+            expect(document.activeElement).not.toEqual(tabs()[2]);
+        });
+
+        it('should tolerate a tab whose panel is missing', function () {
+            // Panels and tabs are rendered by separate loops in tabs.html, so a
+            // mismatch is possible in malformed content.
+            render(1);
+            container.querySelector('[role=tabpanel]').remove();
+
+            expect(function () {
+                setupTabs();
+            }).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

This PRs adds a new feature which auto select the browser comparison tab based on user's brwoser.

## Significant changes and points to review

- Auto selects the following browser when there is a match: Chrome, Safari, Opera, Brave, and Edge.
- fallback to Chrome when it is Firefox or when it doesn't match any of the above

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1477

## Testing

Go to one of the invite links using the following browsers: Firefox, Chrome, Safari, Opera, Brave, and Edge
