### PR TITLE
 Restrict tabs to Firefox referral pages only

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1707,16 +1707,22 @@ class TabsBlock(blocks.StructBlock):
         template = "cms/blocks/tabs.html"
 
 
-class MediaBlock(blocks.StreamBlock):
-    image = ImageVariantsBlock(required=False)
-    video = VideoBlock(required=False)
-    animation = AnimationBlock(required=False)
-    qr_code = QRCodeBlock(required=False)
-    tabs = TabsBlock(required=False)
+def MediaBlock(allow_tabs=False, *args, **kwargs):
+    local_blocks = []
+    if allow_tabs:
+        local_blocks.append(("tabs", TabsBlock(required=False)))
 
-    class Meta:
-        label = "Media"
-        template = "cms/blocks/media.html"
+    class _MediaBlock(blocks.StreamBlock):
+        image = ImageVariantsBlock(required=False)
+        video = VideoBlock(required=False)
+        animation = AnimationBlock(required=False)
+        qr_code = QRCodeBlock(required=False)
+
+        class Meta:
+            label = "Media"
+            template = "cms/blocks/media.html"
+
+    return _MediaBlock(local_blocks or None, *args, **kwargs)
 
 
 # Content
@@ -3105,25 +3111,28 @@ class ShowcaseSettings(blocks.StructBlock):
         form_classname = "compact-form struct-block"
 
 
-class ShowcaseBlock(blocks.StructBlock):
-    settings = ShowcaseSettings()
-    headline = RichTextBlock(features=HEADING_TEXT_FEATURES)
-    description = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
-    media = MediaBlock(max_num=1)
-    caption_title = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
-    caption_description = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
-    cta = MixedButtonsBlock(
-        button_types=get_button_types(),
-        min_num=0,
-        max_num=2,
-        required=False,
-        label="Call to Action",
-    )
+def ShowcaseBlock(allow_tabs=False, *args, **kwargs):
+    class _ShowcaseBlock(blocks.StructBlock):
+        settings = ShowcaseSettings()
+        headline = RichTextBlock(features=HEADING_TEXT_FEATURES)
+        description = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
+        media = MediaBlock(allow_tabs=allow_tabs, max_num=1)
+        caption_title = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
+        caption_description = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
+        cta = MixedButtonsBlock(
+            button_types=get_button_types(),
+            min_num=0,
+            max_num=2,
+            required=False,
+            label="Call to Action",
+        )
 
-    class Meta:
-        template = "cms/blocks/sections/showcase.html"
-        label = "Showcase"
-        label_format = "{headline}"
+        class Meta:
+            template = "cms/blocks/sections/showcase.html"
+            label = "Showcase"
+            label_format = "{headline}"
+
+    return _ShowcaseBlock(*args, **kwargs)
 
 
 class CardGalleryCard(blocks.StructBlock):

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2478,7 +2478,7 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
 
     upper_content = StreamField(
         [
-            ("showcase", ShowcaseBlock()),
+            ("showcase", ShowcaseBlock(allow_tabs=True)),
         ],
         max_num=1,
         null=True,
@@ -2497,7 +2497,7 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
     )
     extra_content = StreamField(
         [
-            ("showcase", ShowcaseBlock()),
+            ("showcase", ShowcaseBlock(allow_tabs=True)),
         ],
         max_num=1,
         null=True,
@@ -2636,7 +2636,7 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
     upper_content = StreamField(
         [
             ("intro", KitIntroBlock()),
-            ("showcase", ShowcaseBlock()),
+            ("showcase", ShowcaseBlock(allow_tabs=True)),
             ("cards_list", CardsListBlock(template="cms/blocks/sections/cards-list-section.html")),
         ],
         null=True,

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -2725,9 +2725,9 @@ def test_showcase_block(index_page, placeholder_images, rf):
                 assert not cta, "Expected .fl-showcase-cta to be absent when no CTA buttons are set"
 
 
-def _render_showcase(media):
+def _render_showcase(media, allow_tabs=False):
     """Render a ShowcaseBlock around the given raw media stream."""
-    block = ShowcaseBlock()
+    block = ShowcaseBlock(allow_tabs=allow_tabs)
     value = block.to_python(
         {
             "settings": {"layout": "default"},
@@ -2752,7 +2752,8 @@ def test_showcase_block_wraps_tabs_media_in_a_div_not_a_figure():
                 "value": {"section_id": "hub", "tabs": [{"tab_name": "First tab", "description": "<p>Tab description</p>"}]},
                 "id": "2026shx0-0000-0000-0000-000000000001",
             }
-        ]
+        ],
+        allow_tabs=True,
     )
 
     assert soup.find("figure") is None


### PR DESCRIPTION
## One-line summary

Restrict tabs and comparison table to Firefox referral pages only

## Significant changes and points to review

- Convert MediaBlock and ShowcaseBlock to factory functions with allow_tabs=False
- Use allow_tabs=True on referral hub and get-firefox page showcases

## Issue / Bugzilla link

[WT-1281](https://mozilla-hub.atlassian.net/browse/WT-1281)

## Testing

Can you still add them where they need to go. Are they not available on other pages?