### PR TITLE
Display section ID when tabs collapsed

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1703,7 +1703,7 @@ class TabsBlock(blocks.StructBlock):
 
     class Meta:
         label = "Tabs"
-        label_format = "Tabs"
+        label_format = "{section_id}"
         template = "cms/blocks/tabs.html"
 
 


### PR DESCRIPTION
## One-line summary

Display section ID when tabs collapsed

## Testing

View the template in the Wagtail editor.