### PR TITLE
Use `aria-labelledby` for tablist

### DIFF
--- a/springfield/cms/templates/cms/blocks/tabs.html
+++ b/springfield/cms/templates/cms/blocks/tabs.html
@@ -8,7 +8,7 @@
   {% if value.tabs %}
     {% set section_id = value.section_id %}
     <div class="fl-tabs">
-      <div class="fl-tabs-nav" id="fl-tablist-{{ section_id }}" aria-label="tabs-{{ section_id }}" role="tablist">
+      <div class="fl-tabs-nav" id="fl-tablist-{{ section_id }}" aria-labelledby="tabs-{{ section_id }}" role="tablist">
         {% for tab in value.tabs %}
           <button type="button" class="fl-tabs-tab" role="tab" id="fl-tab-{{ section_id }}-{{ loop.index }}" aria-controls="fl-tab-panel-{{ section_id }}-{{ loop.index }}"{% if tab.detected_browser %} data-browser="{{ tab.detected_browser }}"{% endif %}>
             <span class="fl-tabs-tab-label">{{ tab.tab_name }}</span>


### PR DESCRIPTION
## One-line summary

Uses `aria-labelledby` instead of `aria-label` for referencing tablist label IDREF.

## Significant changes and points to review

N/A

## Issue / Bugzilla link

N/A

## Testing

Tabs are used on the `/invite/` page.

- Using a screen reader focus the tablist and check that it reads the accessible name.
- Or [use the browser’s developer tools to inspect the accessibility tree](https://devtoolstips.org/tips/en/see-accessibility-tree/) to confirm the tablist has the correct label.
