### PR TITLE
Use share specific nav and footer on referral invitee page

### DIFF
--- a/springfield/cms/templates/cms/referral_get_firefox_page.html
+++ b/springfield/cms/templates/cms/referral_get_firefox_page.html
@@ -10,6 +10,10 @@
 
 {% block body_class %}fl-referral-get-firefox-page{% endblock %}
 
+{% block flare_header %}
+  {% include 'cms/includes/referral-hub-custom-header.html' %}
+{% endblock %}
+
 {% block content %}
 <div class="fl-page">
   <div class="fl-main">
@@ -47,6 +51,8 @@
   </div>
 </div>
 {% endblock %}
+
+{% block pre_footer %}{% endblock %}
 
 {% block js %}
   {#


### PR DESCRIPTION
## One-line summary

Use share specific nav and footer on referral invitee page

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1477


