### PR TITLE
Use disable download buttons in header and footer of invitee page

### DIFF
--- a/springfield/cms/templates/cms/referral_get_firefox_page.html
+++ b/springfield/cms/templates/cms/referral_get_firefox_page.html
@@ -10,6 +10,12 @@
 
 {% block body_class %}fl-referral-get-firefox-page{% endblock %}
 
+{% block flare_header %}
+  {% with hide_nav_download_button=True, theme="dark" %}
+    {% include 'cms/includes/site-header.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block content %}
 <div class="fl-page">
   <div class="fl-main">
@@ -47,6 +53,8 @@
   </div>
 </div>
 {% endblock %}
+
+{% block pre_footer %}{% endblock %}
 
 {% block js %}
   {#


### PR DESCRIPTION
## One-line summary

Use disable download buttons in header and footer of invitee page
 
https://mozilla-hub.atlassian.net/browse/WT-1477