### PR TITLE
fix gradient-top overflow in dark mode

### DIFF
--- a/media/css/cms/flare-template.css
+++ b/media/css/cms/flare-template.css
@@ -100,6 +100,15 @@ body.fl-modal-open {
     z-index: 0;
 }
 
+/* The ::before glow below is wider than its container so the blur's soft edges
+   stay off screen. Clip that horizontal bleed, or it becomes scrollable overflow
+   and the page gets a horizontal scrollbar in dark mode. */
+.has-gradient-top {
+    overflow-x: clip;
+    position: relative;
+    z-index: 0;
+}
+
 .has-gradient-top::before {
     --gradient-height: 70vh;
     background-image: var(--token-gradient-blurred-bg);


### PR DESCRIPTION
## One-line summary

This PR fixes the horizontal overflow for /invite and /get-firefox page in Nightly. 

## Significant changes and points to review

1. `content: var(--content-dark-mode-only)` — the pseudo-element only exists in dark mode ('' in `flare-dark-theme.css`, unset in light). In light mode there's no overflow at all.
2. Firefox derives `prefers-color-scheme` for page content from the browser theme, not just the OS. A Nightly running the dark theme reports dark to the page while Chrome on the same machine reports light.

## Issue / Bugzilla link



## Testing

http://localhost:8000/en-US/invite/?ref_key=TESTTESTTESTTEST
