### PR TITLE
Handle unavailable URL when getting active locale URL

### DIFF
--- a/springfield/cms/models/base.py
+++ b/springfield/cms/models/base.py
@@ -227,6 +227,9 @@ class AbstractSpringfieldCMSPage(WagtailBasePage):
         """
         url = super().get_url(request)
 
+        if not url:
+            return url
+
         active_language = normalize_language(translation.get_language())
         fallback_locales = getattr(settings, "FALLBACK_LOCALES", {})
 


### PR DESCRIPTION
## Significant changes and points to review

Page.get_url(request) can return None when:
- the site root page has no translation in that locale (homepage translation deleted, or never created);
- the page was moved outside the site-root subtree (e.g. under Wagtail's root or an unattached branch);
- the cached root-path list disagrees with the DB. Site.get_site_root_paths() caches under wagtail_site_root_paths for 3600s, and the default cache is springfield.base.cache.SimpleDictCache — a LocMemCache subclass, so it's per worker process. clear_site_root_paths_cache() fires only in the process that saved the site-root page (pages.py:788), so after a locale homepage is created, deleted, or re-slugged, other workers can serve for up to an hour with a root-path list that no longer matches the tree.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1609
