### PR TITLE
allowing testimonial cards to have no attribution

### DIFF
--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -2187,7 +2187,11 @@ def StepCardListBlock(allow_uitour=False, *args, **kwargs):
 
 class CardTestimonialBlock(blocks.StructBlock):
     content = RichTextBlock(features=HEADING_TEXT_FEATURES)
-    attribution = RichTextBlock(features=HEADING_TEXT_FEATURES)
+    attribution = RichTextBlock(
+        features=HEADING_TEXT_FEATURES,
+        required=False,
+        help_text="Optional. Leave blank to show the quote with no attribution.",
+    )
     attribution_role = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
     attribution_image = ImageVariantsBlock(required=False)
 

--- a/springfield/cms/templates/cms/blocks/card-testimonial.html
+++ b/springfield/cms/templates/cms/blocks/card-testimonial.html
@@ -9,7 +9,9 @@
   {% if value.attribution_image and value.attribution_image.image %}
     <content:image>{% include_block value.attribution_image %}</content:image>
   {% endif %}
-  <content:attribution>{{ value.attribution|richtext|remove_p_tag }}</content:attribution>
+  {% if value.attribution %}
+    <content:attribution>{{ value.attribution|richtext|remove_p_tag }}</content:attribution>
+  {% endif %}
   {% if value.attribution_role %}
     <content:attribution_role>{{ value.attribution_role|richtext|remove_p_tag }}</content:attribution_role>
   {% endif %}

--- a/springfield/cms/templates/components/card-testimonial.html
+++ b/springfield/cms/templates/components/card-testimonial.html
@@ -6,15 +6,17 @@
 
 <blockquote class="fl-card-testimonial">
   <div class="fl-card-testimonial-quote fl-body">{{ contents.body }}</div>
-  <footer class="fl-card-testimonial-footer">
-    {% if contents.image %}
-      <div class="fl-card-testimonial-image">{{ contents.image }}</div>
-    {% endif %}
-    <div class="fl-card-testimonial-meta">
-      <cite class="fl-card-testimonial-attribution">{{ contents.attribution }}</cite>
-      {% if contents.attribution_role %}
-        <span class="fl-card-testimonial-role">{{ contents.attribution_role }}</span>
+  {% if contents.attribution %}
+    <footer class="fl-card-testimonial-footer">
+      {% if contents.image %}
+        <div class="fl-card-testimonial-image">{{ contents.image }}</div>
       {% endif %}
-    </div>
-  </footer>
+      <div class="fl-card-testimonial-meta">
+        <cite class="fl-card-testimonial-attribution">{{ contents.attribution }}</cite>
+        {% if contents.attribution_role %}
+          <span class="fl-card-testimonial-role">{{ contents.attribution_role }}</span>
+        {% endif %}
+      </div>
+    </footer>
+  {% endif %}
 </blockquote>

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -4534,9 +4534,12 @@ def assert_card_block(card_el, card_data, context, region_name, heading_tag, blo
             assert blockquote
             quote_text = BeautifulSoup(t["content"], "html.parser").get_text()
             assert quote_text in blockquote.get_text()
-            attribution_text = BeautifulSoup(t["attribution"], "html.parser").get_text()
             cite_el = blockquote.find("cite", class_="fl-card-testimonial-attribution")
-            assert cite_el and attribution_text in cite_el.get_text()
+            if t.get("attribution"):
+                attribution_text = BeautifulSoup(t["attribution"], "html.parser").get_text()
+                assert cite_el and attribution_text in cite_el.get_text()
+            else:
+                assert cite_el is None
             if t.get("attribution_role"):
                 role_text = BeautifulSoup(t["attribution_role"], "html.parser").get_text()
                 role_el = blockquote.find("span", class_="fl-card-testimonial-role")


### PR DESCRIPTION
## One-line summary
Make the Testimonial block's Attribution field optional.

## Significant changes and points to review
- `CardTestimonialBlock.attribution` is now `required=False` (`springfield/cms/blocks.py`).
- Both testimonial templates now render the whole footer (image + attribution + role) only when attribution is present, so a blank attribution shows just the quote — no empty footer gap. No CSS changes needed; footer spacing was already flex `gap`, not a border/margin on a sibling.
- Updated the shared `assert_card_block` test helper (`test_blocks.py`) to handle the no-attribution case instead of assuming a `<cite>` always exists.

## Issue / Bugzilla link


## Testing
- `pytest springfield/cms/tests/test_blocks.py -k "card or testimonial"` — 32 passed.
- Manually confirmed in admin: clearing Attribution saves fine, and the frontend renders the quote with no leftover footer space.