### PR TITLE
WT-1281: add waffle switch to force Nightly on the referral get-firefox page (desktop + Android)

### DIFF
--- a/media/js/base/mobile-attribution.js
+++ b/media/js/base/mobile-attribution.js
@@ -60,16 +60,21 @@ if (typeof window.Mozilla === 'undefined') {
      * @param {String} [referralContent] - Optional utm_content for referral attribution
      *   (e.g. "fxrefer1HR4FZ672Z8Y0E4HW"). When provided, appended to the Android
      *   Play Store referrer string. Has no effect on iOS.
+     * @param {String} [packageId] - Android Play Store package id, e.g.
+     *   "org.mozilla.firefox" (default) or "org.mozilla.fenix" (Nightly).
+     *   Has no effect on iOS.
      */
     MobileAttribution.getStoreUrl = function (
         campaign,
         isAndroid,
-        referralContent
+        referralContent,
+        packageId
     ) {
         var encoded = encodeURIComponent(campaign);
         if (isAndroid) {
             var url =
-                'https://play.google.com/store/apps/details?id=org.mozilla.firefox' +
+                'https://play.google.com/store/apps/details?id=' +
+                (packageId || 'org.mozilla.firefox') +
                 '&referrer=utm_source%3Dwww.firefox.com%26utm_medium%3Dreferral' +
                 '%26utm_campaign%3D' +
                 encoded;

--- a/media/js/firefox/referral/referral-attribution.es6.js
+++ b/media/js/firefox/referral/referral-attribution.es6.js
@@ -43,19 +43,40 @@ ReferralAttribution.getInvitationCode = () => {
 };
 
 /**
+ * Reads the Play Store package id (e.g. "org.mozilla.firefox" or
+ * "org.mozilla.fenix") off a badge's current href, so rewrites preserve
+ * whichever channel the server originally rendered (e.g. via the
+ * REFERRAL_FORCE_NIGHTLY_QA switch) instead of assuming Release.
+ * @param {String|null} href
+ * @return {String|null}
+ */
+ReferralAttribution.getPackageIdFromHref = (href) => {
+    if (!href) {
+        return null;
+    }
+    const match = href.match(/[?&]id=([^&]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+};
+
+/**
  * Rewrites Android store badges to include (or exclude) the referral utm_content.
- * Delegates URL construction to MobileAttribution.getStoreUrl.
+ * Delegates URL construction to MobileAttribution.getStoreUrl. Preserves each
+ * badge's existing Play Store package id rather than assuming Release.
  * @param {String|null} referralContent - e.g. "fxrefer1HR4FZ672Z8Y0E4HW", or null to strip.
  */
 ReferralAttribution.rewriteAndroidLinks = (referralContent) => {
     const campaign = referralContent ? REFERRAL_CAMPAIGN : UNCHECKED_CAMPAIGN;
-    const storeUrl = window.Mozilla.MobileAttribution.getStoreUrl(
-        campaign,
-        true,
-        referralContent
-    );
     const badges = document.querySelectorAll('.fl-store-button-android');
     for (const badge of badges) {
+        const packageId = ReferralAttribution.getPackageIdFromHref(
+            badge.getAttribute('href')
+        );
+        const storeUrl = window.Mozilla.MobileAttribution.getStoreUrl(
+            campaign,
+            true,
+            referralContent,
+            packageId
+        );
         badge.setAttribute('href', storeUrl);
     }
 };

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -42,6 +42,7 @@ from wagtail_thumbnail_choice_block import ThumbnailRadioSelect
 from lib import l10n_utils
 from lib.l10n_utils.fluent import ftl, ftl_lazy
 from springfield.base.geo import get_country_from_request
+from springfield.base.waffle import switch
 from springfield.cms.blocks import (
     HEADING_TEXT_FEATURES,
     UI_TOUR_CLASSES,
@@ -2847,6 +2848,9 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
             "utm_medium": "referral",
             "utm_campaign": "firefox-referral",
         }
+        # QA-only override: forces the desktop download CTA to Nightly instead
+        # of Release. See WT-1281.
+        context["channel"] = "nightly" if switch("REFERRAL_FORCE_NIGHTLY_QA") else "release"
         return context
 
     @referral_geo_check

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2848,8 +2848,8 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
             "utm_medium": "referral",
             "utm_campaign": "firefox-referral",
         }
-        # QA-only override: forces the desktop download CTA to Nightly instead
-        # of Release. See WT-1281.
+
+        # QA-only override: forces the download CTA to Nightly instead of Release. See WT-1281.
         context["channel"] = "nightly" if switch("REFERRAL_FORCE_NIGHTLY_QA") else "release"
         return context
 

--- a/springfield/cms/templates/cms/blocks/referral-download-cta.html
+++ b/springfield/cms/templates/cms/blocks/referral-download-cta.html
@@ -23,6 +23,7 @@
         cta_text="{{ ftl('download-button-download-firefox') }}"
         block_position="primary cta"
         specific_version="win"
+        channel="{{ channel }}"
         exclude_unsupported_content=True
       />
     </include:conditional-display>
@@ -34,6 +35,7 @@
         cta_text="{{ ftl('download-button-download-firefox') }}"
         block_position="primary cta"
         specific_version="osx"
+        channel="{{ channel }}"
         exclude_unsupported_content=True
       />
     </include:conditional-display>

--- a/springfield/cms/templates/cms/blocks/referral-download-cta.html
+++ b/springfield/cms/templates/cms/blocks/referral-download-cta.html
@@ -62,6 +62,7 @@
         cta_text="{{ ftl('download-button-download-firefox') }}"
         block_position="primary cta"
         show_store_button=true
+        channel="{{ channel }}"
         exclude_unsupported_content=True
       />
     </include:conditional-display>

--- a/springfield/cms/templates/components/download-firefox-button.html
+++ b/springfield/cms/templates/components/download-firefox-button.html
@@ -71,8 +71,14 @@
 
   {% if show_store_button %}
     {% set campaign = (utm_parameters or {}).get("utm_campaign") %}
+    {#
+      Firefox Nightly for Android is a separate Play Store listing
+      (org.mozilla.fenix). There is no equivalent public Nightly listing on
+      the Apple App Store, so iOS always links to the Release app.
+    #}
+    {% set android_product = "firefox_nightly" if channel == "nightly" else "firefox" %}
     {% set ios_url = app_store_url('firefox', campaign) %}
-    {% set android_url = play_store_url('firefox', campaign) %}
+    {% set android_url = play_store_url(android_product, campaign) %}
     {{ apple_app_store_button(href=ios_url, class_name="fl-store-button fl-store-button-ios") }}
     {{ google_play_button(href=android_url, id='playStoreLink-primary', class_name="fl-store-button fl-store-button-android") }}
   {% endif %}

--- a/springfield/cms/templates/components/download-firefox-button.html
+++ b/springfield/cms/templates/components/download-firefox-button.html
@@ -8,7 +8,8 @@
 
 {% set is_forced = specific_version and specific_version != "default" %}
 {% set resolved_os = specific_version if is_forced else "win" %}
-{% set download_firefox_thanks_link = download_firefox_thanks_link(os=resolved_os) %}
+{% set channel = channel|default("release", true) %}
+{% set download_firefox_thanks_link = download_firefox_thanks_link(os=resolved_os, channel=channel) %}
 {% set link_href = download_firefox_thanks_link['download_link_direct'] if is_forced else download_firefox_thanks_link['transition_url'] %}
 
 {#

--- a/springfield/cms/tests/test_referral_pages.py
+++ b/springfield/cms/tests/test_referral_pages.py
@@ -569,6 +569,30 @@ def test_get_firefox_page_get_context_includes_utm_parameters(rf):
     assert context["utm_parameters"]["utm_medium"] == "referral"
 
 
+def test_get_firefox_page_get_context_channel_defaults_to_release(rf):
+    """Without the REFERRAL_FORCE_NIGHTLY_QA switch active, the download CTA
+    must build a Release Bouncer link, as it always has."""
+    page = _get_firefox_page()
+    code = crypto.referral_id_to_invite_code(REFERRAL_ID)
+
+    with patch("springfield.base.waffle.switch_is_active", return_value=False):
+        context = page.get_context(rf.get(f"/en-US/get-firefox/?invitation={code}"))
+
+    assert context["channel"] == "release"
+
+
+def test_get_firefox_page_get_context_channel_forced_to_nightly_by_switch(rf):
+    """QA-only override (WT-1281): the REFERRAL_FORCE_NIGHTLY_QA switch forces
+    the download CTA to build a Nightly Bouncer link instead of Release."""
+    page = _get_firefox_page()
+    code = crypto.referral_id_to_invite_code(REFERRAL_ID)
+
+    with patch("springfield.base.waffle.switch_is_active", return_value=True):
+        context = page.get_context(rf.get(f"/en-US/get-firefox/?invitation={code}"))
+
+    assert context["channel"] == "nightly"
+
+
 def test_get_firefox_page_renders_download_button(client, settings):
     """The referral page template must render an actual download button (not the
     context-dump skeleton) so the referral-attribution JS has a link to decorate."""
@@ -621,6 +645,50 @@ def test_get_firefox_page_renders_download_button(client, settings):
     referral_root = soup.find(attrs={"data-referral-code": True})
     assert referral_root is not None
     assert referral_root["data-referral-code"] == code
+
+
+def test_get_firefox_page_renders_nightly_download_link_when_switch_active(client, settings):
+    """QA-only override (WT-1281): with REFERRAL_FORCE_NIGHTLY_QA active, the
+    rendered download button(s) must point at a Nightly Bouncer product,
+    not Release."""
+    settings.STUB_ATTRIBUTION_RATE = 1
+    settings.STUB_ATTRIBUTION_HMAC_KEY = "test-hmac-key"
+
+    site = Site.objects.get(is_default_site=True)
+    page = ReferralGetFirefoxPageFactory(parent=site.root_page, slug="get-firefox")
+    page.upper_content = [
+        {
+            "type": "intro",
+            "id": "aa000000-0000-0000-0000-000000000001",
+            "value": {
+                "settings": {"slim": False},
+                "heading": {
+                    "superheading_text": '<p data-block-key="a"></p>',
+                    "heading_text": '<p data-block-key="b">Download Firefox</p>',
+                    "subheading_text": '<p data-block-key="c"></p>',
+                },
+                "buttons": [
+                    {
+                        "type": "referral_download",
+                        "id": "bb000000-0000-0000-0000-000000000001",
+                        "value": {},
+                    }
+                ],
+            },
+        }
+    ]
+    page.save()
+
+    code = crypto.referral_id_to_invite_code(REFERRAL_ID)
+    with patch(GEO_MOCK, return_value="US"), patch("springfield.base.waffle.switch_is_active", return_value=True):
+        response = client.get(f"/en-US/get-firefox/?invitation={code}")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    download_link = soup.find(class_="download-link")
+    assert download_link is not None
+    assert "firefox-nightly" in download_link["data-direct-link"]
 
 
 # Duplicate-block validation

--- a/springfield/cms/tests/test_referral_pages.py
+++ b/springfield/cms/tests/test_referral_pages.py
@@ -646,6 +646,11 @@ def test_get_firefox_page_renders_download_button(client, settings):
     assert referral_root is not None
     assert referral_root["data-referral-code"] == code
 
+    # The Android Play Store badge must default to the Release app.
+    android_badge = soup.find(class_="fl-store-button-android")
+    assert android_badge is not None
+    assert "id=org.mozilla.firefox" in android_badge["href"]
+
 
 def test_get_firefox_page_renders_nightly_download_link_when_switch_active(client, settings):
     """QA-only override (WT-1281): with REFERRAL_FORCE_NIGHTLY_QA active, the
@@ -689,6 +694,11 @@ def test_get_firefox_page_renders_nightly_download_link_when_switch_active(clien
     download_link = soup.find(class_="download-link")
     assert download_link is not None
     assert "firefox-nightly" in download_link["data-direct-link"]
+
+    # The Android Play Store badge must point at the separate Nightly listing.
+    android_badge = soup.find(class_="fl-store-button-android")
+    assert android_badge is not None
+    assert "id=org.mozilla.fenix" in android_badge["href"]
 
 
 # Duplicate-block validation

--- a/springfield/firefox/templatetags/helpers.py
+++ b/springfield/firefox/templatetags/helpers.py
@@ -229,11 +229,10 @@ def download_firefox_thanks(
 
 @library.global_function
 @jinja2.pass_context
-def download_firefox_thanks_link(ctx, locale=None, locale_in_transition=False, os="win"):
+def download_firefox_thanks_link(ctx, locale=None, locale_in_transition=False, os="win", channel="release"):
     """Transition URL and direct download link to build a Firefox download button
     similar to  download_firefox_thanks()."""
 
-    channel = "release"
     locale = locale or get_locale(ctx["request"])
     transition_url = "/thanks/"
     version = firefox_desktop.latest_version(channel)

--- a/springfield/firefox/tests/test_helpers.py
+++ b/springfield/firefox/tests/test_helpers.py
@@ -347,6 +347,32 @@ class TestDownloadThanksButton(TestCase):
         assert "test-css-class" in link.attr("class")
 
 
+class TestDownloadFirefoxThanksLink(TestCase):
+    def _render(self, os="win", channel=None):
+        rf = RequestFactory()
+        get_request = rf.get("/fake")
+        get_request.locale = "en-US"
+        channel_kwarg = f", channel='{channel}'" if channel else ""
+        return render(
+            f"{{{{ download_firefox_thanks_link(os='{os}'{channel_kwarg})['download_link_direct'] }}}}",
+            {"request": get_request},
+        )
+
+    def test_defaults_to_release(self):
+        href = self._render(os="osx")
+        assert "product=firefox-latest-ssl" in href
+
+    def test_channel_can_be_forced_to_nightly(self):
+        href = self._render(os="osx", channel="nightly")
+        assert "product=firefox-nightly-latest-ssl" in href
+
+    def test_channel_can_be_forced_to_nightly_on_windows(self):
+        # win is a stub-installer platform, so nightly resolves to a
+        # channel-specific stub rather than the l10n/latest-ssl suffix.
+        href = self._render(os="win", channel="nightly")
+        assert "product=firefox-nightly-stub" in href
+
+
 class TestFirefoxURL(TestCase):
     rf = RequestFactory()
 

--- a/tests/unit/spec/base/mobile-attribution/mobile-attribution.js
+++ b/tests/unit/spec/base/mobile-attribution/mobile-attribution.js
@@ -179,6 +179,35 @@ describe('mobile-attribution.js', function () {
             // already-encoded referrer param string
             expect(url).toContain('fxreferABCDEFGHJKMNPQR');
         });
+
+        it('uses the given packageId for the Android URL (e.g. Nightly)', function () {
+            const url = Mozilla.MobileAttribution.getStoreUrl(
+                'test-19',
+                true,
+                null,
+                'org.mozilla.fenix'
+            );
+            expect(
+                url.indexOf(
+                    'https://play.google.com/store/apps/details?id=org.mozilla.fenix'
+                )
+            ).toBe(0);
+        });
+
+        it('defaults to the Release packageId when none is given', function () {
+            const url = Mozilla.MobileAttribution.getStoreUrl('test-19', true);
+            expect(url.indexOf(ANDROID_STORE_PREFIX)).toBe(0);
+        });
+
+        it('ignores packageId for the iOS URL', function () {
+            const url = Mozilla.MobileAttribution.getStoreUrl(
+                'test-19',
+                false,
+                null,
+                'org.mozilla.fenix'
+            );
+            expect(url.indexOf(IOS_STORE_PREFIX)).toBe(0);
+        });
     });
 
     describe('rewriteLinks', function () {

--- a/tests/unit/spec/firefox/referral/referral-attribution.js
+++ b/tests/unit/spec/firefox/referral/referral-attribution.js
@@ -79,6 +79,29 @@ describe('referral-attribution.es6.js', function () {
         });
     });
 
+    describe('getPackageIdFromHref', function () {
+        it('reads the id query param from a Play Store href', function () {
+            expect(
+                ReferralAttribution.getPackageIdFromHref(
+                    'https://play.google.com/store/apps/details?id=org.mozilla.fenix&referrer=x'
+                )
+            ).toEqual('org.mozilla.fenix');
+        });
+
+        it('returns null for a null/empty href', function () {
+            expect(ReferralAttribution.getPackageIdFromHref(null)).toBeNull();
+            expect(ReferralAttribution.getPackageIdFromHref('')).toBeNull();
+        });
+
+        it('returns null when there is no id param', function () {
+            expect(
+                ReferralAttribution.getPackageIdFromHref(
+                    'https://play.google.com/store/apps/details?referrer=x'
+                )
+            ).toBeNull();
+        });
+    });
+
     describe('meetsRequirements', function () {
         it('returns false on iOS (iOS cannot participate)', function () {
             window.site.platform = 'ios';
@@ -214,6 +237,23 @@ describe('referral-attribution.es6.js', function () {
             ReferralAttribution.processAttributionRequest(true);
 
             expect(ReferralAttribution.applyReferral).not.toHaveBeenCalled();
+        });
+
+        it('preserves a server-rendered Nightly package id (WT-1281) instead of reverting to Release', function () {
+            const badge = fixture.querySelector('.fl-store-button-android');
+            badge.setAttribute(
+                'href',
+                'https://play.google.com/store/apps/details?id=org.mozilla.fenix&referrer=utm_source%3Dwww.firefox.com%26utm_medium%3Dreferral%26utm_campaign%3Dget-firefox'
+            );
+
+            ReferralAttribution.processAttributionRequest(true);
+
+            expect(badge.getAttribute('href')).toContain(
+                'id=org.mozilla.fenix'
+            );
+            expect(badge.getAttribute('href')).not.toContain(
+                'id=org.mozilla.firefox'
+            );
         });
     });
 


### PR DESCRIPTION
## Summary
- Adds a `REFERRAL_FORCE_NIGHTLY_QA` waffle switch so QA can force the Firefox referral program's `/get-firefox/?invitation=<code>` page to download Nightly instead of Release, without waiting for a Release ship.
- **Desktop (Windows/Mac):** read once server-side in `ReferralGetFirefoxPage.get_context()` and threaded down through the existing referral CTA render chain. `download_firefox_thanks_link()` gained a `channel="release"` kwarg (previously hardcoded), and the `download-firefox-button` component now accepts an optional `channel` prop defaulting to `"release"` so its other existing call sites are unchanged.
- **Android:** when the switch is active, the Play Store badge links to `org.mozilla.fenix` (Firefox Nightly) instead of `org.mozilla.firefox` (Release). The JS-side referral attribution now preserves whichever package id the server rendered instead of unconditionally overwriting it back to Release: `MobileAttribution.getStoreUrl` gained an optional `packageId` parameter, and `ReferralAttribution.rewriteAndroidLinks` reads each badge's existing href to extract the package id before rebuilding the URL.
- **iOS:** stays on Release since there is no public Nightly listing on the App Store.
- The page carries its normal ~10 minute CDN cache TTL; baking `switch()` straight into a cached template like this is an existing, accepted convention elsewhere in the codebase (e.g. `download_as_default`, `sentry-js`), so no new cache-bypass or live-flag-delivery infrastructure was introduced.

## Test plan
- [x] Python: `test_helpers.py::TestDownloadFirefoxThanksLink` -- default release channel, and `channel="nightly"` override for both a stub-installer platform (win) and a non-stub platform (osx)
- [x] Python: `test_referral_pages.py` -- `get_context()` channel defaults to release / forced to nightly by the switch, plus end-to-end render checks that both the desktop `.download-link` and Android `.fl-store-button-android` badge switch to Nightly when the switch is active
- [x] JS: `mobile-attribution.js` -- `getStoreUrl` uses a custom `packageId` when given, defaults to Release when omitted, ignores it for iOS
- [x] JS: `referral-attribution.js` -- `getPackageIdFromHref` parses the id param from Play Store URLs, and `rewriteAndroidLinks` preserves a server-rendered Nightly package id
- [x] Full Python suite (2131 tests) and JS suite (619 specs) pass
- [x] `ruff check` / `ruff format` / `eslint` / `prettier` pass
- [ ] Manually verify in a deployed environment: flip `REFERRAL_FORCE_NIGHTLY_QA` on via Wagtail/Django admin, load `/en-US/get-firefox/?invitation=<code>`, confirm desktop buttons point at a Nightly Bouncer URL and Android badge points at `org.mozilla.fenix`; flip off and confirm reversion to Release