### PR TITLE
Add carousel block to upper content WT-1619

### DIFF
--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2777,6 +2777,7 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
             ("intro", KitIntroBlock(allow_referral_download=True)),
             ("showcase", ShowcaseBlock(allow_tabs=True)),
             ("cards_list", CardsListBlock(template="cms/blocks/sections/cards-list-section.html")),
+            ("carousel", CarouselBlock()),
         ],
         null=True,
         blank=True,


### PR DESCRIPTION
## One-line summary

Add carousel block to upper content on referral invitee page

