### PR TITLE
Add conditionals to intro block

### DIFF
--- a/media/css/cms/components/flare-intro.css
+++ b/media/css/cms/components/flare-intro.css
@@ -19,12 +19,15 @@
    is what tells us whether the intro is first, not the intro's own. Conditional variants of the
    same intro occupy one position and only one is ever visible, so a wrapper preceded by another
    intro wrapper counts as first too. The :has() keeps that narrow: a conditional notification
-   ahead of the intro still reduces the padding, as it does when neither is conditional. */
-:not(.conditional-display) > .fl-intro:first-child,
-.conditional-display:first-child > .fl-intro,
-.conditional-display:first-child:has(.fl-intro)
-    + .conditional-display
-    > .fl-intro {
+   ahead of the intro still reduces the padding, as it does when neither is conditional.
+
+   The wrapper context sits in :where() so it contributes no specificity: every selector
+   here scores the same as the plain `.fl-intro:first-child` this replaced, which keeps
+   `.is-slim` and `.fl-home-intro` winning the ties they already won. */
+:where(:not(.conditional-display)) > .fl-intro:first-child,
+:where(.conditional-display:first-child) > .fl-intro:first-child,
+:where(.conditional-display:first-child:has(.fl-intro) + .conditional-display)
+    > .fl-intro:first-child {
     padding-block: var(--token-layout-md);
 }
 
@@ -281,11 +284,13 @@
 }
 
 @media (--viewport-sm-up) {
-    :not(.conditional-display) > .fl-intro:first-child,
-    .conditional-display:first-child > .fl-intro,
-    .conditional-display:first-child:has(.fl-intro)
-        + .conditional-display
-        > .fl-intro {
+    :where(:not(.conditional-display)) > .fl-intro:first-child,
+    :where(.conditional-display:first-child) > .fl-intro:first-child,
+    :where(
+            .conditional-display:first-child:has(.fl-intro)
+                + .conditional-display
+        )
+        > .fl-intro:first-child {
         padding-block: var(--token-layout-lg);
     }
 

--- a/media/css/cms/components/flare-intro.css
+++ b/media/css/cms/components/flare-intro.css
@@ -12,18 +12,8 @@
     text-align: center;
 }
 
-/* give the intro more vertical padding when it's used as the first component on a page.
-   This is primary use case, but sometimes a notification at the top should reduce the padding.
-
-   A conditionally-displayed intro is the only child of its wrapper, so the wrapper's position
-   is what tells us whether the intro is first, not the intro's own. Conditional variants of the
-   same intro occupy one position and only one is ever visible, so a wrapper preceded by another
-   intro wrapper counts as first too. The :has() keeps that narrow: a conditional notification
-   ahead of the intro still reduces the padding, as it does when neither is conditional.
-
-   The wrapper context sits in :where() so it contributes no specificity: every selector
-   here scores the same as the plain `.fl-intro:first-child` this replaced, which keeps
-   `.is-slim` and `.fl-home-intro` winning the ties they already won. */
+/* Intro is the first block, either on its own or inside a conditional,
+   OR two consecutive Intros inside conditionals  */
 :where(:not(.conditional-display)) > .fl-intro:first-child,
 :where(.conditional-display:first-child) > .fl-intro:first-child,
 :where(.conditional-display:first-child:has(.fl-intro) + .conditional-display)

--- a/media/css/cms/components/flare-intro.css
+++ b/media/css/cms/components/flare-intro.css
@@ -13,8 +13,18 @@
 }
 
 /* give the intro more vertical padding when it's used as the first component on a page.
-   This is primary use case, but sometimes a notification at the top should reduce the padding. */
-.fl-intro:first-child {
+   This is primary use case, but sometimes a notification at the top should reduce the padding.
+
+   A conditionally-displayed intro is the only child of its wrapper, so the wrapper's position
+   is what tells us whether the intro is first, not the intro's own. Conditional variants of the
+   same intro occupy one position and only one is ever visible, so a wrapper preceded by another
+   intro wrapper counts as first too. The :has() keeps that narrow: a conditional notification
+   ahead of the intro still reduces the padding, as it does when neither is conditional. */
+:not(.conditional-display) > .fl-intro:first-child,
+.conditional-display:first-child > .fl-intro,
+.conditional-display:first-child:has(.fl-intro)
+    + .conditional-display
+    > .fl-intro {
     padding-block: var(--token-layout-md);
 }
 
@@ -271,7 +281,11 @@
 }
 
 @media (--viewport-sm-up) {
-    .fl-intro:first-child {
+    :not(.conditional-display) > .fl-intro:first-child,
+    .conditional-display:first-child > .fl-intro,
+    .conditional-display:first-child:has(.fl-intro)
+        + .conditional-display
+        > .fl-intro {
         padding-block: var(--token-layout-lg);
     }
 

--- a/media/css/cms/pages/flare-referral-hub.css
+++ b/media/css/cms/pages/flare-referral-hub.css
@@ -106,7 +106,11 @@
     }
 
     /* Lower band */
-    .fl-referral-hub-page .fl-split-page-lower > .fl-intro {
+    .fl-referral-hub-page .fl-split-page-lower > .fl-intro,
+    .fl-referral-hub-page
+        .fl-split-page-lower
+        > .conditional-display
+        > .fl-intro {
         padding-block-end: 0;
     }
 

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -2776,6 +2776,10 @@ class IntroBlockSettings(blocks.StructBlock):
         inline_form=True,
         help_text="Use a more compact layout with reduced spacing.",
     )
+    show_to = ConditionalDisplayBlock(
+        label="Show To",
+        help_text="Control which users can see this content block",
+    )
     anchor_id = blocks.CharBlock(
         required=False,
         help_text="Add an ID to make this section linkable from navigation (e.g., 'overview', 'features')",
@@ -2786,7 +2790,7 @@ class IntroBlockSettings(blocks.StructBlock):
         icon = "cog"
         collapsed = True
         label = "Settings"
-        label_format = "Layout: {layout} - Slim: {slim} - Anchor ID: {anchor_id}"
+        label_format = "Layout: {layout} - Slim: {slim} - Anchor ID: {anchor_id} - Show to: {show_to}"
         form_classname = "compact-form struct-block"
 
 

--- a/springfield/cms/templates/cms/blocks/sections/intro.html
+++ b/springfield/cms/templates/cms/blocks/sections/intro.html
@@ -10,27 +10,32 @@
 {% if value.settings.layout != "vertical" %}
 {% set heading_size = 'fl-heading-lg fl-heading-condensed' %}
 {% endif %}
-<include:intro
-  {% if value.settings.layout != "vertical" %}media_position="{{ value.settings.layout }}"{% endif %}
-  anchor_id="{{ value.settings.anchor_id }}"
-  vertical="{{ value.settings.layout == 'vertical' }}"
-  slim="{{ value.settings.slim }}"
-  remove_border_radius="{{ value.settings.remove_border_radius }}"
-  full_width="{{ value.settings.full_width }}"
->
-  <content:heading>
-    {% include_block value.heading %}
-  </content:heading>
-  {% if value.content %}
-    <content:content>
-      {% include_block value.content %}
-    </content:content>
-  {% endif %}
-  {% if value.media %}
-    <content:media>
-      {% set sizes = "(min-width: 1200px) 934px, (min-width: 600px) 50vw, 100vw" %}
-      {% set widths = "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}" %}
-      {% include_block value.media %}
-    </content:media>
-  {% endif %}
-</include:intro>
+<include:conditional-display
+  condition_settings="{{ value.settings.show_to }}">
+
+  <include:intro
+    {% if value.settings.layout != "vertical" %}media_position="{{ value.settings.layout }}"{% endif %}
+    anchor_id="{{ value.settings.anchor_id }}"
+    vertical="{{ value.settings.layout == 'vertical' }}"
+    slim="{{ value.settings.slim }}"
+    remove_border_radius="{{ value.settings.remove_border_radius }}"
+    full_width="{{ value.settings.full_width }}"
+  >
+    <content:heading>
+      {% include_block value.heading %}
+    </content:heading>
+    {% if value.content %}
+      <content:content>
+        {% include_block value.content %}
+      </content:content>
+    {% endif %}
+    {% if value.media %}
+      <content:media>
+        {% set sizes = "(min-width: 1200px) 934px, (min-width: 600px) 50vw, 100vw" %}
+        {% set widths = "width-{200,400,600,800,1000,1200,1400,1600,1800,2000}" %}
+        {% include_block value.media %}
+      </content:media>
+    {% endif %}
+  </include:intro>
+
+</include:conditional-display>

--- a/springfield/cms/tests/test_conditional_display.py
+++ b/springfield/cms/tests/test_conditional_display.py
@@ -36,7 +36,7 @@ def make_intro(block_id, heading, show_to):
     }
 
 
-def wrappers_around(element):
+def get_conditional_wrappers(element):
     return [el for el in element.parents if "conditional-display" in (el.get("class") or [])]
 
 
@@ -152,37 +152,11 @@ def test_intro_block_conditional_display(intro_conditional_page, rf):
     upper = soup.find("div", class_="fl-split-page-upper")
     conditional_intro, unconditional_intro = upper.find_all("div", class_="fl-intro")
 
-    conditional_wrappers = wrappers_around(conditional_intro)
+    conditional_wrappers = get_conditional_wrappers(conditional_intro)
     assert len(conditional_wrappers) == 1
     assert "condition-is-firefox" in conditional_wrappers[0]["class"]
 
-    # An intro with no conditions set must render bare, as it always has
-    assert wrappers_around(unconditional_intro) == []
-
-
-@pytest.mark.django_db
-def test_intro_conditional_wrapper_is_a_direct_child_of_its_region(intro_conditional_page, rf):
-    """The wrapper takes the intro's place in the region, so CSS can key off its position.
-
-    `.fl-intro:first-child` means "first component on the page", and a wrapped intro is
-    always the only child of its wrapper. flare-intro.css therefore tests the wrapper's
-    position instead, which only holds while the wrapper is a direct child of the region.
-    """
-    response = intro_conditional_page.serve(rf.get(intro_conditional_page.get_full_url()))
-    soup = BeautifulSoup(response.content, "html.parser")
-
-    upper = soup.find("div", class_="fl-split-page-upper")
-    lower = soup.find("div", class_="fl-split-page-lower")
-
-    upper_children = upper.find_all("div", recursive=False)
-    assert "conditional-display" in upper_children[0]["class"]
-    assert upper_children[0].find("div", class_="fl-intro", recursive=False)
-
-    # The lower region's conditional intro is authored second, so its wrapper must not be
-    # the region's first child — otherwise it would pick up the hero padding.
-    lower_children = lower.find_all("div", recursive=False)
-    assert "fl-intro" in lower_children[0]["class"]
-    assert "conditional-display" in lower_children[1]["class"]
+    assert get_conditional_wrappers(unconditional_intro) == []
 
 
 @pytest.mark.django_db

--- a/springfield/cms/tests/test_conditional_display.py
+++ b/springfield/cms/tests/test_conditional_display.py
@@ -9,7 +9,52 @@ from springfield.cms.fixtures.conditional_display_fixtures import (
     get_bind_to_uitour_section,
     get_conditional_display_test_page,
     get_conditional_display_variants,
+    make_show_to,
 )
+from springfield.cms.models import FreeFormPage2026
+
+
+def make_intro(block_id, heading, show_to):
+    return {
+        "type": "intro",
+        "value": {
+            "settings": {
+                "layout": "vertical",
+                "slim": False,
+                "anchor_id": "",
+                "show_to": show_to,
+            },
+            "media": [],
+            "heading": {
+                "superheading_text": "",
+                "heading_text": f'<p data-block-key="{block_id}">{heading}</p>',
+                "subheading_text": "",
+            },
+            "content": [],
+        },
+        "id": f"{block_id}-0000-0000-0000-000000000001",
+    }
+
+
+def wrappers_around(element):
+    return [el for el in element.parents if "conditional-display" in (el.get("class") or [])]
+
+
+@pytest.fixture
+def intro_conditional_page(minimal_site) -> FreeFormPage2026:
+    """A page whose intros mix conditional and unconditional, in both regions."""
+    page = FreeFormPage2026(slug="test-intro-conditional", title="Test Intro Conditional")
+    minimal_site.root_page.add_child(instance=page)
+    page.upper_content = [
+        make_intro("introfx1", "Firefox only", make_show_to(firefox="is-firefox")),
+        make_intro("introal1", "Everyone", make_show_to()),
+    ]
+    page.content = [
+        make_intro("introal2", "Lower, everyone", make_show_to()),
+        make_intro("introfx2", "Lower, non-Firefox only", make_show_to(firefox="not-firefox")),
+    ]
+    page.save_revision().publish()
+    return page
 
 
 @pytest.mark.django_db
@@ -96,6 +141,48 @@ def test_conditional_display_blocks(index_page, rf):
                 assert version_wrapper.get("data-min-version") == str(min_version), f"Block {index}: expected data-min-version='{min_version}'"
             if max_version:
                 assert version_wrapper.get("data-max-version") == str(max_version), f"Block {index}: expected data-max-version='{max_version}'"
+
+
+@pytest.mark.django_db
+def test_intro_block_conditional_display(intro_conditional_page, rf):
+    response = intro_conditional_page.serve(rf.get(intro_conditional_page.get_full_url()))
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    upper = soup.find("div", class_="fl-split-page-upper")
+    conditional_intro, unconditional_intro = upper.find_all("div", class_="fl-intro")
+
+    conditional_wrappers = wrappers_around(conditional_intro)
+    assert len(conditional_wrappers) == 1
+    assert "condition-is-firefox" in conditional_wrappers[0]["class"]
+
+    # An intro with no conditions set must render bare, as it always has
+    assert wrappers_around(unconditional_intro) == []
+
+
+@pytest.mark.django_db
+def test_intro_conditional_wrapper_is_a_direct_child_of_its_region(intro_conditional_page, rf):
+    """The wrapper takes the intro's place in the region, so CSS can key off its position.
+
+    `.fl-intro:first-child` means "first component on the page", and a wrapped intro is
+    always the only child of its wrapper. flare-intro.css therefore tests the wrapper's
+    position instead, which only holds while the wrapper is a direct child of the region.
+    """
+    response = intro_conditional_page.serve(rf.get(intro_conditional_page.get_full_url()))
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    upper = soup.find("div", class_="fl-split-page-upper")
+    lower = soup.find("div", class_="fl-split-page-lower")
+
+    upper_children = upper.find_all("div", recursive=False)
+    assert "conditional-display" in upper_children[0]["class"]
+    assert upper_children[0].find("div", class_="fl-intro", recursive=False)
+
+    # The lower region's conditional intro is authored second, so its wrapper must not be
+    # the region's first child — otherwise it would pick up the hero padding.
+    lower_children = lower.find_all("div", recursive=False)
+    assert "fl-intro" in lower_children[0]["class"]
+    assert "conditional-display" in lower_children[1]["class"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What

Adds **Show To** to the Intro block, so a hero can vary by audience. Same `ConditionalDisplayBlock` and template wrapper that Banner, Section, Notification and Card already use.

No migration. The custom `StreamField` strips block definitions out of `deconstruct()`, so block-level changes don't generate one.

## CSS

The conditional wrapper adds a `<div>` between the region and `.fl-intro`, which breaks two position-dependent rules:

- `.fl-intro:first-child` ("first component on the page") — a wrapped intro is always its wrapper's only child, so it matched everywhere. Now keyed off the wrapper's position, with a `:has(.fl-intro)` leg so conditional *variants* of the same hero all get hero padding while a conditional notification ahead of the intro still reduces it.
- `.fl-referral-hub-page .fl-split-page-lower > .fl-intro` — direct-child, added a wrapped leg.

Both follow the cross-product pattern already in `flare-notification.css`.

## Known limitation

Two conditional Intros still get `<h1>` and `<h2>` by authoring order, not by which one is visible. Verified: same page shows `<h1>` in Firefox and `<h2>` in Chrome, with the `<h1>` sitting in a hidden div.

In non-vertical layouts the type sizes match anyway (`heading_size` is hardcoded); in vertical layout the variants render at different heading sizes.

Editor guidance until that's fixed: give variants identical heading text, and author the variant most visitors will see first.