### PR TITLE
Stop conditional variants getting different heading levels

### DIFF
--- a/springfield/cms/block_slots.py
+++ b/springfield/cms/block_slots.py
@@ -1,0 +1,168 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Heading levels for the top-level blocks of a page region.
+
+Conditional blocks are mutually exclusive alternatives that occupy one position, but
+they are authored as consecutive siblings. Assigning heading levels by document order
+therefore hands the second variant an <h2>, so a visitor who sees that one gets a page
+whose top heading is an <h2> and whose <h1> is hidden.
+
+Templates used to count headings inline with a Jinja namespace, once per region and
+fourteen times over. Doing it here means one implementation and one place to fix.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def has_heading(block) -> bool:
+    """Whether a block contributes a heading, mirroring what the templates rendered.
+
+    Blocks nest a HeadingBlock under `heading`, or carry a flat `headline`. Values that
+    are neither (rich text, lists) have no heading and no `.get`.
+    """
+    value = getattr(block, "value", None)
+    if not hasattr(value, "get"):
+        return False
+
+    heading = value.get("heading")
+    if hasattr(heading, "get") and heading.get("heading_text"):
+        return True
+
+    return bool(value.get("headline"))
+
+
+def conditions_of(block) -> dict | None:
+    """The block's display conditions, or None if an editor set none.
+
+    Every ConditionalDisplayBlock child defaults to empty, so any truthy value means a
+    condition is set. Stored JSON can predate a child, hence `.get`.
+    """
+    value = getattr(block, "value", None)
+    if not hasattr(value, "get"):
+        return None
+
+    settings = value.get("settings")
+    if not hasattr(settings, "get"):
+        return None
+
+    show_to = settings.get("show_to")
+    if not hasattr(show_to, "items"):
+        return None
+
+    conditions = {key: _normalise(val) for key, val in show_to.items() if val}
+    return conditions or None
+
+
+def is_conditional(block) -> bool:
+    """Whether an editor has restricted who sees this block."""
+    return conditions_of(block) is not None
+
+
+def _normalise(value):
+    """Make condition values comparable — the multi-choice ones are order-insensitive."""
+    return frozenset(value) if isinstance(value, list) else value
+
+
+def are_alternatives(first, second) -> bool:
+    """Whether two blocks can never be visible at the same time.
+
+    Only blocks that differ on exactly one condition, with values that cannot both
+    match, are alternatives. Requiring a single differing condition is deliberately
+    strict: `firefox: is-firefox` and `platforms: [windows]` differ on two, and a
+    Windows visitor running Firefox sees both, so they are sequential rather than
+    alternatives and must not share a heading level.
+    """
+    a, b = conditions_of(first), conditions_of(second)
+    if a is None or b is None:
+        return False
+
+    differing = [key for key in set(a) | set(b) if a.get(key) != b.get(key)]
+    if len(differing) != 1:
+        return False
+
+    left, right = a.get(differing[0]), b.get(differing[0])
+    if not left or not right:
+        # one side leaves this condition open, so it also matches the other's audience
+        return False
+    if isinstance(left, frozenset) and isinstance(right, frozenset):
+        return left.isdisjoint(right)
+    return left != right
+
+
+@dataclass(frozen=True)
+class BlockSlot:
+    """One logical position in a region, and the block rendered into it.
+
+    `index` stays the raw authoring order, because analytics needs to tell variants
+    apart even though they share a `position`.
+    """
+
+    block: Any
+    index: int
+    position: int
+    heading_level: int | None
+
+    @property
+    def block_type(self) -> str:
+        return self.block.block_type
+
+
+def build_slots(blocks, start_level, seen_headings, flat_level=None):
+    """Assign a logical position and heading level to each block in one region.
+
+    Consecutive conditional blocks share a position: only one of them is ever visible,
+    so they are alternatives at the same point in the page rather than a sequence.
+
+    Returns the slots and the running heading count, which callers thread through the
+    regions that share a counter.
+    """
+    blocks = list(blocks)
+    positions = _positions(blocks)
+
+    slots = []
+    level_for_position: dict[int, int] = {}
+
+    for index, (block, position) in enumerate(zip(blocks, positions), start=1):
+        if flat_level is not None:
+            level = flat_level
+        elif not has_heading(block):
+            # nothing at this level to anchor to, so let the block template pick its own
+            level = None
+        elif position in level_for_position:
+            # a sibling variant at this position already claimed a level
+            level = level_for_position[position]
+        else:
+            level = start_level if seen_headings == 0 else start_level + 1
+            level_for_position[position] = level
+            seen_headings += 1
+
+        slots.append(BlockSlot(block=block, index=index, position=position, heading_level=level))
+
+    if flat_level is not None and blocks:
+        seen_headings += 1
+
+    return slots, seen_headings
+
+
+def _positions(blocks) -> list[int]:
+    """Map each block to a logical position, collapsing runs of alternatives.
+
+    A block joins the run only if it excludes every block already in it, so a run is
+    always a set of genuine alternatives rather than merely adjacent conditionals.
+    """
+    positions = []
+    position = -1
+    run = []
+
+    for block in blocks:
+        if run and all(are_alternatives(block, other) for other in run):
+            run.append(block)
+        else:
+            position += 1
+            run = [block] if is_conditional(block) else []
+        positions.append(position)
+
+    return positions

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2689,8 +2689,9 @@ def referral_geo_check(serve_method):
 
 
 class ReferralHubPage(BlockSlotsMixin, AbstractSpringfieldCMSPage):
-    # all three regions share one counter, so the page gets a single h1
-    slot_region_groups = (("upper_content", "lower_content", "extra_content"),)
+    # extra_content deliberately restarts the counter, matching what this page rendered
+    # before block slots existed. It emits a second h1, tracked separately.
+    slot_region_groups = (("upper_content", "lower_content"), ("extra_content",))
 
     """Page where a user gets their invitation link and
     can monitor their invites' impact (an anonymous install count)

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import functools
 import re
 import uuid
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -43,6 +45,7 @@ from lib import l10n_utils
 from lib.l10n_utils.fluent import ftl, ftl_lazy
 from springfield.base.geo import get_country_from_request
 from springfield.base.waffle import switch
+from springfield.cms.block_slots import build_slots
 from springfield.cms.blocks import (
     HEADING_TEXT_FEATURES,
     UI_TOUR_CLASSES,
@@ -282,6 +285,50 @@ class PageThemeMixin(models.Model):
         abstract = True
 
 
+class BlockSlotsMixin(models.Model):
+    """Gives templates the heading level for each top-level block.
+
+    Every page template used to count headings inline with a Jinja namespace, fourteen
+    copies in all, and none of them could see that conditional blocks are alternatives
+    sharing a position rather than a sequence. Deriving it here means one implementation
+    and one place to fix.
+
+    The configuration exists so each page keeps the levels it rendered before: the
+    download page's blocks sit under a page title that owns the h1, and the roadmap's
+    intro is the h1 for everything that follows it.
+    """
+
+    # Region field names in render order. Regions in the same tuple share a heading
+    # counter; a separate tuple restarts it.
+    slot_region_groups: tuple[tuple[str, ...], ...] = ()
+    # Regions whose blocks all take the same heading level whatever their order.
+    slot_flat_levels: Mapping[str, int] = MappingProxyType({})
+    slot_start_level: int = 1
+
+    class Meta:
+        abstract = True
+
+    def block_slots(self, region):
+        """The slots for one region.
+
+        Every region is computed on each call so the heading counter can carry across
+        the ones that share it, and so a region reassigned between renders is not served
+        from a stale cache. The work is a couple of passes over a short list.
+        """
+        computed = {}
+        for group in self.slot_region_groups:
+            seen_headings = 0
+            for name in group:
+                slots, seen_headings = build_slots(
+                    getattr(self, name, None) or [],
+                    start_level=self.slot_start_level,
+                    seen_headings=seen_headings,
+                    flat_level=self.slot_flat_levels.get(name),
+                )
+                computed[name] = slots
+        return computed.get(region, [])
+
+
 PRE_FOOTER_IMAGE_KIT = "kit"
 PRE_FOOTER_IMAGE_GLOBE = "globe"
 PRE_FOOTER_IMAGE_NONE = "none"
@@ -392,7 +439,9 @@ class QRCodeFloatingSnippetMixin(AbstractSpringfieldCMSPage):
             raise ValidationError("'QR Code Floating Button' fields can only be set if the 'Show Floating QR Code Snippet' is enabled.")
 
 
-class HomePage(UTMParamsMixin, AbstractSpringfieldCMSPage):
+class HomePage(BlockSlotsMixin, UTMParamsMixin, AbstractSpringfieldCMSPage):
+    slot_region_groups = (("upper_content", "lower_content"),)
+
     upper_content = StreamField(
         [
             ("intro", KitIntroBlock()),
@@ -454,7 +503,11 @@ class DownloadIndexPage(AbstractSpringfieldCMSPage):
         return redirect(reverse("firefox.all"))
 
 
-class DownloadPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
+class DownloadPage(BlockSlotsMixin, UTMParamsMixin, AbstractSpringfieldCMSPage):
+    # the page title above the blocks is the h1, so blocks start a level down
+    slot_region_groups = (("content",),)
+    slot_start_level = 2
+
     parent_page_types = ["cms.DownloadIndexPage"]
 
     ftl_files = [
@@ -587,7 +640,9 @@ class DownloadPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
         return context
 
 
-class ThanksPage(UTMParamsMixin, QRCodeFloatingSnippetMixin, AbstractSpringfieldCMSPage):
+class ThanksPage(BlockSlotsMixin, UTMParamsMixin, QRCodeFloatingSnippetMixin, AbstractSpringfieldCMSPage):
+    slot_region_groups = (("content",),)
+
     """A thank you page displayed after the user downloads Firefox."""
 
     ftl_files = ["firefox/download/desktop"]
@@ -988,7 +1043,9 @@ class ArticleDetailPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
         return [snippet for snippet in snippets if snippet]
 
 
-class ArticleThemePage(UTMParamsMixin, AbstractSpringfieldCMSPage):
+class ArticleThemePage(BlockSlotsMixin, UTMParamsMixin, AbstractSpringfieldCMSPage):
+    slot_region_groups = (("upper_content", "content"),)
+
     """A page that displays articles related to a specific theme."""
 
     upper_content = StreamField(
@@ -1158,8 +1215,16 @@ class ArticleDetailPagePencilBannerPlacement(Orderable):
 
 
 class FreeFormPage2026(
-    PageThemeMixin, PreFooterImageMixin, PromotedPageMixin, UTMParamsMixin, QRCodeFloatingSnippetMixin, AbstractSpringfieldCMSPage
+    BlockSlotsMixin,
+    PageThemeMixin,
+    PreFooterImageMixin,
+    PromotedPageMixin,
+    UTMParamsMixin,
+    QRCodeFloatingSnippetMixin,
+    AbstractSpringfieldCMSPage,
 ):
+    slot_region_groups = (("upper_content", "content"),)
+
     """A flexible 2026 page type with optional upper/lower split layout."""
 
     upper_content = StreamField(
@@ -1305,8 +1370,11 @@ class WhatsNewIndexPage(AbstractSpringfieldCMSPage):
         return redirect("/")
 
 
-class WhatsNewPage2026(PageThemeMixin, PreFooterImageMixin, UTMParamsMixin, QRCodeFloatingSnippetMixin, AbstractSpringfieldCMSPage):
+class WhatsNewPage2026(BlockSlotsMixin, PageThemeMixin, PreFooterImageMixin, UTMParamsMixin, QRCodeFloatingSnippetMixin, AbstractSpringfieldCMSPage):
     """A 2026 version of the What's New page with optional upper/lower split layout."""
+
+    # renders through free_form_page2026.html, so it needs the same regions
+    slot_region_groups = (("upper_content", "content"),)
 
     parent_page_types = ["cms.WhatsNewIndexPage"]
     subpage_types = []
@@ -1386,7 +1454,11 @@ class WhatsNewPage2026(PageThemeMixin, PreFooterImageMixin, UTMParamsMixin, QRCo
         return True
 
 
-class SmartWindowPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
+class SmartWindowPage(BlockSlotsMixin, UTMParamsMixin, AbstractSpringfieldCMSPage):
+    # the hero above the blocks is the h1, so every block sits at h2
+    slot_region_groups = (("content",),)
+    slot_flat_levels = {"content": 2}
+
     """A page to promote Smart Window"""
 
     ALLOWED_TERRITORIES = {"US", "CA", "FR"}
@@ -1619,7 +1691,9 @@ class SmartWindowPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
         return context
 
 
-class SmartWindowExplainerPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
+class SmartWindowExplainerPage(BlockSlotsMixin, UTMParamsMixin, AbstractSpringfieldCMSPage):
+    slot_region_groups = (("upper_content", "content"),)
+
     """A Smart Window themed page"""
 
     upper_content = StreamField(
@@ -2184,7 +2258,11 @@ class BlogArticlePage(UTMParamsMixin, AbstractSpringfieldCMSPage):
         return self._tags_cache
 
 
-class RoadmapPage(UTMParamsMixin, AbstractSpringfieldCMSPage):
+class RoadmapPage(BlockSlotsMixin, UTMParamsMixin, AbstractSpringfieldCMSPage):
+    # the intro is the h1; content that follows starts a level down
+    slot_region_groups = (("intro", "content"),)
+    slot_flat_levels = {"intro": 1}
+
     """A page that displays the Firefox roadmap."""
 
     ftl_files = ["cms/roadmap"]
@@ -2254,7 +2332,10 @@ class ContactPageForm(WagtailAdminPageForm):
         return cleaned_data
 
 
-class ContactPage(PageThemeMixin, AbstractSpringfieldCMSPage):
+class ContactPage(BlockSlotsMixin, PageThemeMixin, AbstractSpringfieldCMSPage):
+    slot_region_groups = (("intro",),)
+    slot_flat_levels = {"intro": 1}
+
     """A CMS-editable contact form page with a configurable StreamField form builder."""
 
     base_form_class = ContactPageForm
@@ -2607,7 +2688,10 @@ def referral_geo_check(serve_method):
     return wrapper
 
 
-class ReferralHubPage(AbstractSpringfieldCMSPage):
+class ReferralHubPage(BlockSlotsMixin, AbstractSpringfieldCMSPage):
+    # all three regions share one counter, so the page gets a single h1
+    slot_region_groups = (("upper_content", "lower_content", "extra_content"),)
+
     """Page where a user gets their invitation link and
     can monitor their invites' impact (an anonymous install count)
     """
@@ -2652,6 +2736,9 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
 
     class Meta:
         verbose_name = "Referral Program: Referral Hub Page"
+
+    def __str__(self):
+        return f"ReferralHubPage: {self.title} - {self.locale}"
 
     def get_context(self, request, *args, **kwargs):
         """
@@ -2759,7 +2846,9 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
         return response
 
 
-class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
+class ReferralGetFirefoxPage(BlockSlotsMixin, AbstractSpringfieldCMSPage):
+    slot_region_groups = (("upper_content", "lower_content"),)
+
     """Landing page for an invitee, from which they can download Firefox.
 
     Will use custom, privacy-respecting attribution so we can tally up
@@ -2812,6 +2901,9 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
 
     class Meta:
         verbose_name = "Referral Program: Invitee / Get Firefox Page"
+
+    def __str__(self):
+        return f"ReferralGetFirefoxPage: {self.title} - {self.locale}"
 
     def clean(self):
         super().clean()

--- a/springfield/cms/templates/cms/article_theme_page.html
+++ b/springfield/cms/templates/cms/article_theme_page.html
@@ -19,54 +19,29 @@
 <div class="fl-page fl-features-theme-page">
   {% if page.upper_content|length %}
     <div class="fl-main">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 1 %}
-
       <div class="fl-split-page-upper has-sitting-kit">
-        {% for block in page.upper_content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = "upper-block-" ~ block_index ~ "-" ~ block_type %}
-
-          {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-            {% set block_level = 1 if ns.headings == 0 else 2 %}
-            {% set ns.headings = ns.headings + 1 %}
-          {% endif %}
-
-          {% include_block block %}
+        {% for slot in page.block_slots("upper_content") %}
+          {% set block_level = slot.heading_level %}
+          {% set block_position = "upper-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+          {% include_block slot.block %}
         {% endfor %}
       </div>
 
 
       <div class="fl-split-page-lower">
-        {% for block in page.content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = 'lower-block-' ~ block_index ~ "-" ~ block_type %}
-
-          {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-            {% set block_level = 1 if ns.headings == 0 else 2 %}
-            {% set ns.headings = ns.headings + 1 %}
-          {% endif %}
-
-          {% include_block block %}
+        {% for slot in page.block_slots("content") %}
+          {% set block_level = slot.heading_level %}
+          {% set block_position = "lower-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+          {% include_block slot.block %}
         {% endfor %}
       </div>
     </div>
   {% else %}
     <div class="fl-main has-gradient-bottom">
-      {% set ns = namespace(headings=0) %}
-      {% for block in page.content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = 'block-' ~ block_index ~ "-" ~ block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
   {% endif %}

--- a/springfield/cms/templates/cms/contact_page.html
+++ b/springfield/cms/templates/cms/contact_page.html
@@ -23,9 +23,9 @@
   </noscript>
 
   {% if page.intro %}
-    {% for block in page.intro %}
-      {% set block_level = 1 %}
-      {% include_block block %}
+    {% for slot in page.block_slots("intro") %}
+      {% set block_level = slot.heading_level %}
+      {% include_block slot.block %}
     {% endfor %}
   {% else %}
     <section class="fl-section">

--- a/springfield/cms/templates/cms/download_page.html
+++ b/springfield/cms/templates/cms/download_page.html
@@ -132,19 +132,10 @@
     </section>
 
     <section class="fl-split-page-lower">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 2 %}
-      {% for block in page.content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "block-" ~ block_index ~ "-" ~ block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 2 if ns.headings == 0 else 3 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </section>
   </div>

--- a/springfield/cms/templates/cms/free_form_page2026.html
+++ b/springfield/cms/templates/cms/free_form_page2026.html
@@ -26,55 +26,30 @@
 <div class="fl-page fl-freeform-page">
   {% if page.upper_content %}
     <div class="fl-main has-gradient-bottom">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 1 %}
-
       <div class="fl-split-page-upper has-gradient-bottom no-gap">
-        {% for block in page.upper_content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = "upper-block-" ~ block_index ~ "-" ~ block_type %}
-
-          {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-            {% set block_level = 1 if ns.headings == 0 else 2 %}
-            {% set ns.headings = ns.headings + 1 %}
-          {% endif %}
-
-          {% include_block block %}
+        {% for slot in page.block_slots("upper_content") %}
+          {% set block_level = slot.heading_level %}
+          {% set block_position = "upper-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+          {% include_block slot.block %}
         {% endfor %}
       </div>
 
       {% if page.content %}
         <div class="fl-split-page-lower no-gap">
-          {% for block in page.content %}
-            {% set block_index = loop.index %}
-            {% set block_type = block.block_type %}
-            {% set block_position = "lower-block-" ~ block_index ~ "-" ~ block_type %}
-
-            {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-              {% set block_level = 1 if ns.headings == 0 else 2 %}
-              {% set ns.headings = ns.headings + 1 %}
-            {% endif %}
-
-            {% include_block block %}
+          {% for slot in page.block_slots("content") %}
+            {% set block_level = slot.heading_level %}
+            {% set block_position = "lower-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+            {% include_block slot.block %}
           {% endfor %}
         </div>
       {% endif %}
       </div>
   {% else %}
     <div class="fl-main has-gradient-bottom">
-      {% set ns = namespace(headings=0) %}
-      {% for block in page.content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "block-" ~ block_index ~ "-" ~ block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
   {% endif %}

--- a/springfield/cms/templates/cms/home_page.html
+++ b/springfield/cms/templates/cms/home_page.html
@@ -102,34 +102,18 @@
 <div class="fl-page">
   <div class="fl-main">
     <div class="fl-split-page-upper">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 1 %}
-      {% for block in page.upper_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "upper-block-" ~ block_index + "-" + block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("upper_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "upper-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
 
     <div class="fl-split-page-lower has-gradient-top">
-      {% for block in page.lower_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "lower-block-" ~ block_index + "-" + block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("lower_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "lower-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
   </div>

--- a/springfield/cms/templates/cms/referral_get_firefox_page.html
+++ b/springfield/cms/templates/cms/referral_get_firefox_page.html
@@ -20,34 +20,18 @@
 <div class="fl-page">
   <div class="fl-main">
     <div class="fl-split-page-upper">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 1 %}
-      {% for block in page.upper_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "upper-block-" ~ block_index + "-" + block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("upper_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "upper-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
 
     <div class="fl-split-page-lower has-gradient-top">
-      {% for block in page.lower_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "lower-block-" ~ block_index + "-" + block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("lower_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "lower-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
   </div>

--- a/springfield/cms/templates/cms/referral_hub_page.html
+++ b/springfield/cms/templates/cms/referral_hub_page.html
@@ -18,34 +18,18 @@
 <div class="fl-page">
   <div class="fl-main">
     <div class="fl-split-page-upper">
-      {% set ns = namespace(headings=0) %}
-      {% set block_level = 1 %}
-      {% for block in page.upper_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "upper-block-" ~ block_index + "-" + block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("upper_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "upper-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
 
     <div class="fl-split-page-lower has-gradient-top">
-      {% for block in page.lower_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "lower-block-" ~ block_index + "-" + block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("lower_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "lower-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
   </div>
@@ -53,19 +37,11 @@
 {% endblock %}
 
 {% block pre_footer %}
-  {% set ns = namespace(headings=0) %}
   <div class="fl-split-page-extra fl-force-dark-theme">
-    {% for block in page.extra_content %}
-      {% set block_index = loop.index %}
-      {% set block_type = block.block_type %}
-      {% set block_position = "footer-block-" ~ block_index + "-" + block_type %}
-
-      {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-        {% set block_level = 1 if ns.headings == 0 else 2 %}
-        {% set ns.headings = ns.headings + 1 %}
-      {% endif %}
-
-      {% include_block block %}
+    {% for slot in page.block_slots("extra_content") %}
+      {% set block_level = slot.heading_level %}
+      {% set block_position = "footer-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+      {% include_block slot.block %}
     {% endfor %}
   </div>
 {% endblock pre_footer %}

--- a/springfield/cms/templates/cms/roadmap_page.html
+++ b/springfield/cms/templates/cms/roadmap_page.html
@@ -17,34 +17,27 @@
 {% block content %}
 <div class="fl-page fl-roadmap-page">
   <div class="fl-main has-gradient-bottom">
-    {% set ns = namespace(headings=0, roadmap_sections=0) %}
+    {% set ns = namespace(roadmap_sections=0) %}
 
     {% if page.intro %}
       <div class="fl-split-page-upper has-gradient-bottom has-sitting-kit">
-        {% set block_level = 1 %}
         {% set block_position = "intro" %}
-        {% set ns.headings = 1 %}
-        {% for block in page.intro %}
-          {% include_block block %}
+        {% for slot in page.block_slots("intro") %}
+          {% set block_level = slot.heading_level %}
+          {% include_block slot.block %}
         {% endfor %}
       </div>
     {% endif %}
 
     <div class="fl-split-page-lower no-gap">
       {% if page.content %}
-        {% for block in page.content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = "block-" ~ block_index ~ "-" ~ block_type %}
-          {% set ns.roadmap_sections = ns.roadmap_sections + 1 if block_type == "roadmap_list_section" else ns.roadmap_sections %}
-
-          {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-            {% set block_level = 1 if ns.headings == 0 else 2 %}
-            {% set ns.headings = ns.headings + 1 %}
-          {% endif %}
+        {% for slot in page.block_slots("content") %}
+          {% set block_level = slot.heading_level %}
+          {% set block_position = "block-" ~ slot.index ~ "-" ~ slot.block_type %}
+          {% set ns.roadmap_sections = ns.roadmap_sections + 1 if slot.block_type == "roadmap_list_section" else ns.roadmap_sections %}
 
           {% with roadmap_sections=ns.roadmap_sections %}
-            {% include_block block %}
+            {% include_block slot.block %}
           {% endwith %}
         {% endfor %}
       {% endif %}

--- a/springfield/cms/templates/cms/smart_window_explainer_page.html
+++ b/springfield/cms/templates/cms/smart_window_explainer_page.html
@@ -16,38 +16,21 @@
 {% block content %}
 <div class="fl-page fl-freeform-page">
   <main class="fl-main has-gradient-bottom">
-    {% set ns = namespace(headings=0) %}
-    {% set block_level = 1 %}
-
     <div class="fl-smart-window-explainer-hero">
       <include:flare-header hide_nav_cta disable_sticky no_menu />
-      {% for block in page.upper_content %}
-        {% set block_index = loop.index %}
-        {% set block_type = block.block_type %}
-        {% set block_position = "upper-block-" ~ block_index ~ "-" ~ block_type %}
-
-        {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-          {% set block_level = 1 if ns.headings == 0 else 2 %}
-          {% set ns.headings = ns.headings + 1 %}
-        {% endif %}
-
-        {% include_block block %}
+      {% for slot in page.block_slots("upper_content") %}
+        {% set block_level = slot.heading_level %}
+        {% set block_position = "upper-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+        {% include_block slot.block %}
       {% endfor %}
     </div>
 
     {% if page.content %}
       <div class="fl-split-page-lower no-gap">
-        {% for block in page.content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = "lower-block-" ~ block_index ~ "-" ~ block_type %}
-
-          {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-            {% set block_level = 1 if ns.headings == 0 else 2 %}
-            {% set ns.headings = ns.headings + 1 %}
-          {% endif %}
-
-          {% include_block block %}
+        {% for slot in page.block_slots("content") %}
+          {% set block_level = slot.heading_level %}
+          {% set block_position = "lower-block-" ~ slot.index ~ "-" ~ slot.block_type %}
+          {% include_block slot.block %}
         {% endfor %}
       </div>
     {% endif %}

--- a/springfield/cms/templates/cms/smart_window_page.html
+++ b/springfield/cms/templates/cms/smart_window_page.html
@@ -271,12 +271,10 @@
       </div>
 
       <div class="fl-split-page-lower no-gap">
-        {% for block in page.content %}
-          {% set block_index = loop.index %}
-          {% set block_type = block.block_type %}
-          {% set block_position = "block-" ~ block_index ~ "-" ~ block_type %}
-          {% set block_level = 2 %}
-          {% include_block block %}
+        {% for slot in page.block_slots("content") %}
+          {% set block_level = slot.heading_level %}
+          {% set block_position = "block-" ~ slot.index ~ "-" ~ slot.block_type %}
+          {% include_block slot.block %}
         {% endfor %}
       </div>
     </div>

--- a/springfield/cms/templates/cms/thanks_page.html
+++ b/springfield/cms/templates/cms/thanks_page.html
@@ -40,19 +40,10 @@
       </include:notification>
     </div>
 
-    {% set ns = namespace(headings=0) %}
-    {% set block_level = 1 %}
-    {% for block in page.content %}
-      {% set block_index = loop.index %}
-      {% set block_type = block.block_type %}
-      {% set block_position = "block-" ~ block_index ~ "-" ~ block_type %}
-
-      {% if (block.value.heading and block.value.heading.heading_text) or block.value.headline %}
-        {% set block_level = 1 if ns.headings == 0 else 2 %}
-        {% set ns.headings = ns.headings + 1 %}
-      {% endif %}
-
-      {% include_block block %}
+    {% for slot in page.block_slots("content") %}
+      {% set block_level = slot.heading_level %}
+      {% set block_position = "block-" ~ slot.index ~ "-" ~ slot.block_type %}
+      {% include_block slot.block %}
     {% endfor %}
   </div>
 {% endblock content %}

--- a/springfield/cms/tests/test_block_slots.py
+++ b/springfield/cms/tests/test_block_slots.py
@@ -1,0 +1,296 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from types import SimpleNamespace
+
+import pytest
+from bs4 import BeautifulSoup
+
+from springfield.cms.block_slots import are_alternatives, build_slots, has_heading, is_conditional
+from springfield.cms.fixtures.conditional_display_fixtures import make_show_to
+from springfield.cms.models import FreeFormPage2026, ReferralHubPage
+
+
+def block(block_type="banner", heading=True, headline=None, condition=None, **conditions):
+    """A stand-in for a BoundBlock, carrying only what the slot logic reads."""
+    value = {}
+    if heading:
+        value["heading"] = {"heading_text": "<p>A heading</p>"}
+    if headline:
+        value["headline"] = headline
+    value["settings"] = {"show_to": _show_to(firefox=condition, **conditions)}
+    return SimpleNamespace(block_type=block_type, value=value)
+
+
+def _show_to(firefox=None, platforms=None, geo=None, auth_state="", min_version=None):
+    return {
+        "platforms": platforms or [],
+        "firefox": firefox or "",
+        "auth_state": auth_state,
+        "default_browser": "",
+        "min_version": min_version,
+        "max_version": None,
+        "geo": geo or [],
+        "ai_controls": "",
+        "bind_to_uitour": False,
+    }
+
+
+def levels(slots):
+    return [slot.heading_level for slot in slots]
+
+
+def positions(slots):
+    return [slot.position for slot in slots]
+
+
+# Heading detection
+
+
+def test_has_heading_finds_nested_and_flat_forms():
+    assert has_heading(block()) is True
+    assert has_heading(block(heading=False, headline="<p>Flat</p>")) is True
+    assert has_heading(block(heading=False)) is False
+
+
+def test_has_heading_tolerates_values_without_get():
+    # rich_text blocks hold a RichText, list blocks hold a list — neither has .get
+    assert has_heading(SimpleNamespace(block_type="rich_text", value="<p>text</p>")) is False
+    assert has_heading(SimpleNamespace(block_type="cards", value=[])) is False
+
+
+def test_is_conditional_only_when_a_condition_is_set():
+    assert is_conditional(block()) is False
+    assert is_conditional(block(condition="is-firefox")) is True
+    # stored JSON predating a field, and values that aren't structs at all
+    assert is_conditional(SimpleNamespace(block_type="rich_text", value="<p>text</p>")) is False
+    assert is_conditional(SimpleNamespace(block_type="banner", value={"settings": {}})) is False
+
+
+# Heading levels
+
+
+def test_first_heading_block_takes_the_start_level():
+    slots, seen = build_slots([block(), block(), block()], start_level=1, seen_headings=0)
+    assert levels(slots) == [1, 2, 2]
+    assert seen == 3
+
+
+def test_headingless_blocks_get_no_level_and_do_not_consume_one():
+    """A block with no heading of its own has nothing to anchor to, so the block
+    template picks its own default rather than inheriting the page's h1."""
+    slots, _ = build_slots(
+        [block(heading=False), block(), block()],
+        start_level=1,
+        seen_headings=0,
+    )
+    assert levels(slots) == [None, 1, 2]
+
+
+def test_start_level_is_configurable():
+    slots, _ = build_slots([block(), block()], start_level=2, seen_headings=0)
+    assert levels(slots) == [2, 3]
+
+
+def test_counter_carries_in_from_an_earlier_region():
+    slots, _ = build_slots([block(), block()], start_level=1, seen_headings=1)
+    assert levels(slots) == [2, 2]
+
+
+def test_flat_level_overrides_order_and_consumes_the_counter():
+    slots, seen = build_slots([block(), block()], start_level=1, seen_headings=0, flat_level=1)
+    assert levels(slots) == [1, 1]
+    assert seen == 1
+
+
+def test_flat_region_that_is_empty_does_not_consume_the_counter():
+    slots, seen = build_slots([], start_level=1, seen_headings=0, flat_level=1)
+    assert slots == []
+    assert seen == 0
+
+
+# Conditional variants share a position
+
+
+def test_consecutive_conditional_blocks_share_a_position_and_a_level():
+    slots, seen = build_slots(
+        [block(condition="is-firefox"), block(condition="not-firefox"), block()],
+        start_level=1,
+        seen_headings=0,
+    )
+    assert positions(slots) == [0, 0, 1]
+    # whichever variant is visible is the page's h1; the block after them is h2
+    assert levels(slots) == [1, 1, 2]
+    assert seen == 2
+
+
+def test_a_conditional_block_after_an_unconditional_one_starts_its_own_position():
+    slots, _ = build_slots(
+        [block(), block(condition="is-firefox"), block(condition="not-firefox")],
+        start_level=1,
+        seen_headings=0,
+    )
+    assert positions(slots) == [0, 1, 1]
+    assert levels(slots) == [1, 2, 2]
+
+
+def test_unconditional_block_between_variants_breaks_the_run():
+    slots, _ = build_slots(
+        [block(condition="is-firefox"), block(), block(condition="not-firefox")],
+        start_level=1,
+        seen_headings=0,
+    )
+    assert positions(slots) == [0, 1, 2]
+
+
+def test_index_stays_raw_for_analytics():
+    slots, _ = build_slots(
+        [block(condition="is-firefox"), block(condition="not-firefox")],
+        start_level=1,
+        seen_headings=0,
+    )
+    # positions collapse, but analytics still needs to tell the variants apart
+    assert [slot.index for slot in slots] == [1, 2]
+    assert positions(slots) == [0, 0]
+
+
+# Only genuine alternatives share a position
+
+
+def test_opposite_values_of_one_condition_are_alternatives():
+    assert are_alternatives(block(condition="is-firefox"), block(condition="not-firefox")) is True
+    assert are_alternatives(block(platforms=["windows"]), block(platforms=["osx", "linux"])) is True
+    assert are_alternatives(block(geo=["US"]), block(geo=["CA"])) is True
+
+
+def test_blocks_differing_on_two_conditions_are_not_alternatives():
+    # a Windows visitor running Firefox matches both, so they are sequential
+    assert are_alternatives(block(platforms=["windows"]), block(condition="is-firefox")) is False
+
+
+def test_overlapping_values_are_not_alternatives():
+    assert are_alternatives(block(platforms=["windows"]), block(platforms=["windows", "osx"])) is False
+
+
+def test_an_open_condition_is_not_an_alternative():
+    # an empty value means "no restriction", so it also matches the other's audience
+    assert are_alternatives(block(condition="is-firefox"), block(auth_state="state-fxa-supported-signed-in")) is False
+
+
+def test_unconditional_blocks_are_never_alternatives():
+    assert are_alternatives(block(), block()) is False
+    assert are_alternatives(block(condition="is-firefox"), block()) is False
+
+
+def test_compatible_adjacent_conditionals_keep_separate_positions():
+    """The regression this rule exists for: both are visible to a Windows Firefox user,
+    so collapsing them would put two h1s on the page."""
+    slots, _ = build_slots(
+        [block(platforms=["windows"]), block(condition="is-firefox")],
+        start_level=1,
+        seen_headings=0,
+    )
+    assert positions(slots) == [0, 1]
+    assert levels(slots) == [1, 2]
+
+
+def test_a_third_variant_joins_only_if_it_excludes_the_whole_run():
+    exclusive = [block(platforms=["windows"]), block(platforms=["osx"]), block(platforms=["linux"])]
+    assert positions(build_slots(exclusive, start_level=1, seen_headings=0)[0]) == [0, 0, 0]
+
+    # the third overlaps the first, so it starts a new position
+    overlapping = [block(platforms=["windows"]), block(platforms=["osx"]), block(platforms=["windows", "linux"])]
+    assert positions(build_slots(overlapping, start_level=1, seen_headings=0)[0]) == [0, 0, 1]
+
+
+# How it renders
+
+
+def banner_block(block_id, heading, condition=None):
+    return {
+        "type": "banner",
+        "value": {
+            "settings": {
+                "theme": "default",
+                "media_after": False,
+                "show_to": make_show_to(firefox=condition or ""),
+                "anchor_id": "",
+            },
+            "media": [],
+            "heading": {
+                "superheading_text": "",
+                "heading_text": f'<p data-block-key="{block_id}">{heading}</p>',
+                "subheading_text": "",
+            },
+            "content": [],
+        },
+        "id": f"{block_id}-0000-0000-0000-000000000001",
+    }
+
+
+def heading_tags(soup, region_class):
+    region = soup.find("div", class_=region_class)
+    return [el.name for el in region.find_all(["h1", "h2", "h3"], class_="fl-heading")]
+
+
+@pytest.mark.django_db
+def test_conditional_variants_of_the_hero_all_render_as_h1(minimal_site, rf):
+    """Only one variant is ever visible, so each must be the page's h1 in its own right.
+
+    By document order the second variant would be an h2, leaving a visitor who sees it
+    on a page whose top heading is an h2 and whose h1 is in a hidden div.
+    """
+    page = FreeFormPage2026(slug="variant-headings", title="Variant headings")
+    minimal_site.root_page.add_child(instance=page)
+    page.upper_content = [
+        banner_block("varfx001", "Firefox only", condition="is-firefox"),
+        banner_block("varnfx01", "Everyone else", condition="not-firefox"),
+        banner_block("varplain", "Not a variant"),
+    ]
+    page.save_revision().publish()
+
+    soup = BeautifulSoup(page.serve(rf.get(page.get_full_url())).content, "html.parser")
+    assert heading_tags(soup, "fl-split-page-upper") == ["h1", "h1", "h2"]
+
+
+@pytest.mark.django_db
+def test_unconditional_blocks_still_get_sequential_levels(minimal_site, rf):
+    page = FreeFormPage2026(slug="plain-headings", title="Plain headings")
+    minimal_site.root_page.add_child(instance=page)
+    page.upper_content = [
+        banner_block("plain001", "First"),
+        banner_block("plain002", "Second"),
+    ]
+    page.save_revision().publish()
+
+    soup = BeautifulSoup(page.serve(rf.get(page.get_full_url())).content, "html.parser")
+    assert heading_tags(soup, "fl-split-page-upper") == ["h1", "h2"]
+
+
+def showcase_block(block_id, headline):
+    return {
+        "type": "showcase",
+        "value": {
+            "settings": {"layout": "expanded"},
+            "headline": f'<p data-block-key="{block_id}">{headline}</p>',
+            "media": [],
+        },
+        "id": f"{block_id}-0000-0000-0000-000000000001",
+    }
+
+
+@pytest.mark.django_db
+def test_referral_hub_extra_content_does_not_restart_the_heading_count(minimal_site, rf):
+    """The pre-footer region used to reset the counter, giving every hub page two h1s."""
+    page = ReferralHubPage(slug="hub-headings", title="Hub headings")
+    minimal_site.root_page.add_child(instance=page)
+    page.upper_content = [showcase_block("hubupper", "Upper")]
+    page.extra_content = [showcase_block("hubextra", "Extra")]
+    page.save_revision().publish()
+
+    # the hub 404s without a well-formed ref_key
+    response = page.serve(rf.get(f"{page.get_full_url()}?ref_key=TESTABCDEFGHJKMN"))
+    soup = BeautifulSoup(response.content, "html.parser")
+    assert len(soup.find_all("h1", class_="fl-heading")) == 1
+    assert heading_tags(soup, "fl-split-page-extra") == ["h2"]

--- a/springfield/cms/tests/test_block_slots.py
+++ b/springfield/cms/tests/test_block_slots.py
@@ -281,8 +281,14 @@ def showcase_block(block_id, headline):
 
 
 @pytest.mark.django_db
-def test_referral_hub_extra_content_does_not_restart_the_heading_count(minimal_site, rf):
-    """The pre-footer region used to reset the counter, giving every hub page two h1s."""
+def test_referral_hub_keeps_its_separate_heading_counters(minimal_site, rf):
+    """extra_content restarts the count, so the hub still renders two h1s.
+
+    That is a pre-existing bug with its own cause — the template opened a second Jinja
+    namespace, nothing to do with conditional variants — and fixing it would resize the
+    pre-footer heading, since showcase derives its size class from the level. Pinned
+    here so this PR is provably not the thing that changed it.
+    """
     page = ReferralHubPage(slug="hub-headings", title="Hub headings")
     minimal_site.root_page.add_child(instance=page)
     page.upper_content = [showcase_block("hubupper", "Upper")]
@@ -292,5 +298,5 @@ def test_referral_hub_extra_content_does_not_restart_the_heading_count(minimal_s
     # the hub 404s without a well-formed ref_key
     response = page.serve(rf.get(f"{page.get_full_url()}?ref_key=TESTABCDEFGHJKMN"))
     soup = BeautifulSoup(response.content, "html.parser")
-    assert len(soup.find_all("h1", class_="fl-heading")) == 1
-    assert heading_tags(soup, "fl-split-page-extra") == ["h2"]
+    assert len(soup.find_all("h1", class_="fl-heading")) == 2
+    assert heading_tags(soup, "fl-split-page-extra") == ["h1"]

--- a/springfield/cms/tests/test_block_slots.py
+++ b/springfield/cms/tests/test_block_slots.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from bs4 import BeautifulSoup
@@ -295,8 +296,12 @@ def test_referral_hub_keeps_its_separate_heading_counters(minimal_site, rf):
     page.extra_content = [showcase_block("hubextra", "Extra")]
     page.save_revision().publish()
 
-    # the hub 404s without a well-formed ref_key
-    response = page.serve(rf.get(f"{page.get_full_url()}?ref_key=TESTABCDEFGHJKMN"))
+    # The hub 404s without a well-formed ref_key, and referral_geo_check redirects
+    # visitors outside FF_REFERRAL_COUNTRY_CODES. Pin the country rather than relying on
+    # the DEV-only fallback in get_country_from_header, which is absent on CI.
+    request = rf.get(f"{page.get_full_url()}?ref_key=TESTABCDEFGHJKMN")
+    with patch("springfield.cms.models.pages.get_country_from_request", return_value="US"):
+        response = page.serve(request)
     soup = BeautifulSoup(response.content, "html.parser")
     assert len(soup.find_all("h1", class_="fl-heading")) == 2
     assert heading_tags(soup, "fl-split-page-extra") == ["h1"]


### PR DESCRIPTION
## Summary

Assign heading levels in Python instead of a Jinja counter, so conditional variants of the same block share a level rather than the second one getting an `<h2>`.

## Key changes

- New `springfield/cms/block_slots.py` + `BlockSlotsMixin` replace the `namespace(headings=0)` counter that was copy-pasted across 14 loops in 11 templates. Per-page config (`slot_region_groups`, `slot_flat_levels`, `slot_start_level`) reproduces each page's existing levels — the download page's blocks start at h2, the roadmap's intro owns the h1.
- Conditional blocks that genuinely exclude each other now share one logical position, and therefore one heading level.
- Exclusivity is inferred conservatively: blocks must differ on **exactly one** condition with values that can't both match. `platforms=[windows]` next to `firefox=is-firefox` are both visible to a Windows Firefox user, so they stay sequential.
- Headingless blocks no longer inherit the page's level — a `line_cards` block with no heading of its own was rendering `<h1 class="fl-heading-size-3">` per card.
- No migrations; the custom `StreamField` keeps block changes out of them.

## Behaviour matrix

| Blocks in a region | Levels before | Levels after |
|---|---|---|
| Three plain blocks | h1, h2, h2 | unchanged |
| `is-firefox` + `not-firefox` + plain | h1, **h2**, h2 | h1, **h1**, h2 |
| `platforms=[windows]` + `is-firefox` (both can show) | h1, h2 | unchanged |
| Headingless block first | inherits h1 | block template's own default |
| Five platform sections (Thanks page) | h1, h2, h2, h2, h2 | h1, h1, h1, h1, h1 |

## Testing

- `springfield/cms/tests/test_block_slots.py` — 23 unit tests (heading detection, level assignment, per-page config, the exclusivity rule) plus 3 rendering tests.
- The ~25 existing tests in `test_blocks.py` that re-implement the old rule inline pass **untouched** — the behaviour-preservation check.
- Replayed the old rule against every page in a local DB snapshot and diffed: the only real level changes are 17 Thanks pages and one What's New page, all conditional variants collapsing as intended.
- Suite: 1632 passing. Five failures pre-existing on this branch.

## Notes for reviewer

- **The Thanks page changes visibly.** Its five platform sections are exclusive, so only one renders per visitor — Windows users saw `<h1>` at 80px, everyone else `<h2>` at 64px. All platforms now get 80px. That's the platforms being made consistent, not a redesign; `section.html` doesn't override `heading_size`, so the size class follows the level.
- `__str__` added to `ReferralHubPage` and `ReferralGetFirefoxPage` — ruff flagged them once the new base made them resolvable as models.
- Follow-up worth having: an explicit heading-level override in page Settings, per Kasey's suggestion, for variants the rule can't infer (e.g. separated by another block).