### PR TITLE
Fix rounded corners and add aspect ratio option for animation videos

### DIFF
--- a/media/css/cms/components/flare-media.css
+++ b/media/css/cms/components/flare-media.css
@@ -124,6 +124,11 @@
     position: absolute;
 }
 
+.fl-video video {
+    object-fit: cover;
+    object-position: center;
+}
+
 /* Animation component with playback modes */
 .fl-animation video {
     margin: 0;

--- a/media/css/cms/components/flare-mediacontent.css
+++ b/media/css/cms/components/flare-mediacontent.css
@@ -44,11 +44,6 @@
     aspect-ratio: 17/20;
 }
 
-.fl-mediacontent.is-narrow .fl-video video {
-    object-fit: cover;
-    object-position: center;
-}
-
 .fl-mediacontent-content .fl-buttons {
     margin-block: var(--token-spacing-lg) var(--token-spacing-md);
 }
@@ -146,6 +141,10 @@
     display: block;
     inline-size: 100%;
     margin: 0;
+}
+
+.fl-mediacontent-media video {
+    border-radius: var(--token-spacing-lg);
 }
 
 .fl-mediacontent-media iframe {

--- a/media/css/cms/components/flare-two-column-cards.css
+++ b/media/css/cms/components/flare-two-column-cards.css
@@ -43,6 +43,10 @@
     margin-block-end: 0;
 }
 
+.fl-two-column-card .media video {
+    border-radius: var(--gallery-card-radius);
+}
+
 .fl-two-column-card .fl-heading {
     margin: 0;
 }

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -144,6 +144,15 @@ AI_CONTROLS_CHOICES = [
     ("available", "AI Controls available"),
     ("unavailable", "AI Controls unavailable"),
 ]
+ANIMATION_ASPECT_RATIO_CHOICES = [
+    ("", "Default (16:9, or 17:20 in Narrow Layout)"),
+    ("16/9", "Widescreen (16:9) - forces widescreen even in Narrow Layout"),
+    ("3/2", "Landscape (3:2)"),
+    ("1/1", "Square (1:1)"),
+    ("4/3", "Standard (4:3)"),
+    ("4/5", "Portrait (4:5)"),
+    ("9/16", "Vertical (9:16)"),
+]
 
 UITOUR_BUTTON_NEW_TAB = "open_new_tab"
 UITOUR_BUTTON_ABOUT_PREFERENCES = "open_about_preferences"
@@ -1443,6 +1452,13 @@ def AnimationBlock(required=True, *args, **kwargs):
             inline_form=True,
         )
         show_pause_button = blocks.BooleanBlock(default=False, required=False)
+        aspect_ratio = blocks.ChoiceBlock(
+            choices=ANIMATION_ASPECT_RATIO_CHOICES,
+            default="",
+            required=False,
+            label="Aspect Ratio",
+            help_text="Match this to the file's real dimensions so it isn't stretched or cropped. Leave as Default if already 16:9.",
+        )
 
         class Meta:
             label = "Animation"

--- a/springfield/cms/templates/cms/blocks/animation.html
+++ b/springfield/cms/templates/cms/blocks/animation.html
@@ -12,4 +12,5 @@
   alt="{{ value.alt }}"
   poster="{{ poster.url }}"
   playback="{{ value.playback }}"
+  aspect_ratio="{{ value.aspect_ratio }}"
 />


### PR DESCRIPTION
## Summary
Animations placed in Media + Content and Two Column Card blocks could render with square corners instead of rounded ones — a cross-browser quirk where GPU-composited `<video>` elements can bypass an ancestor's `overflow: hidden` + `border-radius` clip. 

Also adds an **Aspect Ratio** field to the Animation block so editors can pick a non-16:9 ratio (square, portrait, vertical, etc.) without the video being stretched — previously the container always forced 16:9 with no crop fallback.

## Changes
- `flare-mediacontent.css`, `flare-two-column-cards.css`: explicit `border-radius` on `video` inside media wrappers
- `flare-media.css`: `object-fit: cover` is now the default for all `.fl-video video` (previously only applied in Narrow Layout), so a ratio mismatch crops instead of distorting
- `blocks.py`: new `aspect_ratio` ChoiceBlock on `AnimationBlock`, defaulting to blank (no behavior change for existing content)
- `animation.html`: wires the new field through to the existing `data-aspect-ratio` JS hook

## Test plan
- [ ] `npm run build`, open a page with an animation in Media + Content and confirm rounded corners
- [ ] Set a non-default Aspect Ratio on an animation and confirm it renders at that ratio without stretching
- [ ] Confirm an animation in a Narrow Layout block still crops to 17:20 when Aspect Ratio is left as Default