### PR TITLE
Add analytics tracking to share buttons [WT-1644]

### DIFF
--- a/media/js/cms/components/flare-copy-to-clipboard.es6.js
+++ b/media/js/cms/components/flare-copy-to-clipboard.es6.js
@@ -55,6 +55,15 @@ function initCopyToClipboardButton(buttonEl) {
             iconSuccess.classList.remove('hidden');
             buttonEl.disabled = true;
 
+            if (window.dataLayer) {
+                window.dataLayer.push({
+                    event: 'widget_action',
+                    type: 'copy to clipboard',
+                    action: 'copy',
+                    text: labelEl.textContent
+                });
+            }
+
             if (resetTimer) {
                 clearTimeout(resetTimer);
             }

--- a/media/js/cms/components/flare-copy-to-clipboard.es6.js
+++ b/media/js/cms/components/flare-copy-to-clipboard.es6.js
@@ -43,6 +43,9 @@ function initCopyToClipboardButton(buttonEl) {
 
     buttonEl.addEventListener('click', () => {
         navigator.clipboard.writeText(value).then(() => {
+            buttonEl.dispatchEvent(
+                new CustomEvent('fl-copy-success', { bubbles: true })
+            );
             labelEl.classList.add('opacity-0');
             labelEl.setAttribute('aria-hidden', 'true');
             successLabelEl.classList.remove('opacity-0');

--- a/media/js/cms/components/flare-referral-controls.es6.js
+++ b/media/js/cms/components/flare-referral-controls.es6.js
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function initReferralControls(containerEl) {
+    const emailEl = containerEl.querySelector(
+        '.fl-referral-controls-share-email'
+    );
+    const qrEl = containerEl.querySelector('.fl-referral-controls-qr-button');
+
+    const clipboardEl = containerEl.querySelector(
+        '[data-js="fl-copy-to-clipboard"]'
+    );
+
+    if (clipboardEl) {
+        clipboardEl.addEventListener('click', () => {
+            if (window.dataLayer) {
+                window.dataLayer.push({
+                    event: 'widget_action',
+                    type: 'referral share',
+                    action: 'copy link',
+                });
+            }
+        });
+    }
+
+    if (emailEl) {
+        emailEl.addEventListener('click', () => {
+            if (window.dataLayer) {
+                window.dataLayer.push({
+                    event: 'widget_action',
+                    type: 'referral share',
+                    action: 'mailto link',
+                });
+            }
+        });
+    }
+
+    if (qrEl) {
+        qrEl.addEventListener('click', () => {
+            if (window.dataLayer) {
+                window.dataLayer.push({
+                    event: 'widget_action',
+                    type: 'referral share',
+                    action: 'qr code modal',
+                });
+            }
+        });
+    }
+}
+
+export default function setupReferralControls() {
+    document
+        .querySelectorAll('.fl-referral-controls')
+        .forEach(initReferralControls);
+}

--- a/media/js/cms/components/flare-referral-controls.es6.js
+++ b/media/js/cms/components/flare-referral-controls.es6.js
@@ -15,12 +15,12 @@ function initReferralControls(containerEl) {
     );
 
     if (clipboardEl) {
-        clipboardEl.addEventListener('click', () => {
+        clipboardEl.addEventListener('fl-copy-success', () => {
             if (window.dataLayer) {
                 window.dataLayer.push({
                     event: 'widget_action',
                     type: 'referral share',
-                    action: 'copy link',
+                    action: 'copy link'
                 });
             }
         });
@@ -32,7 +32,7 @@ function initReferralControls(containerEl) {
                 window.dataLayer.push({
                     event: 'widget_action',
                     type: 'referral share',
-                    action: 'mailto link',
+                    action: 'mailto link'
                 });
             }
         });
@@ -44,7 +44,7 @@ function initReferralControls(containerEl) {
                 window.dataLayer.push({
                     event: 'widget_action',
                     type: 'referral share',
-                    action: 'qr code modal',
+                    action: 'qr code modal'
                 });
             }
         });

--- a/media/js/cms/pages/flare-referral-hub.es6.js
+++ b/media/js/cms/pages/flare-referral-hub.es6.js
@@ -6,4 +6,8 @@
 
 import setupReferralControls from '../components/flare-referral-controls.es6';
 
-setupReferralControls();
+if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', setupReferralControls, false);
+} else {
+    setupReferralControls();
+}

--- a/media/js/cms/pages/flare-referral-hub.es6.js
+++ b/media/js/cms/pages/flare-referral-hub.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import setupReferralControls from '../components/flare-referral-controls.es6';
+
+setupReferralControls();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -798,6 +798,12 @@
     },
     {
       "files": [
+        "js/cms/pages/flare-referral-hub.es6.js"
+      ],
+      "name": "flare-referral-hub"
+    },
+    {
+      "files": [
         "js/cms/easter-egg-logo.es6.js"
       ],
       "name": "easter-egg-logo"

--- a/springfield/cms/templates/cms/referral_hub_page.html
+++ b/springfield/cms/templates/cms/referral_hub_page.html
@@ -64,3 +64,8 @@
     {% endfor %}
   </div>
 {% endblock pre_footer %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('flare-referral-hub') }}
+{% endblock %}


### PR DESCRIPTION
## One-line summary

Track referral share buttons as `widget_action` in analytics.

## Testing

- Open the referral share page (steps below if you don't already have one locally)
    - Pull down the production database locally
    - Open nightly
    - Turn your VPN to US
    - Pick "Share Nightly" to open the referral page.
    - Change the domain to localhost:8000
- Click each button
- Log the dataLayer in your console and see that there is an event for each one