### PR TITLE
[WT-1423] Make Jinja IncludeContentsExtension thread safe

### DIFF
--- a/springfield/base/tests/test_jinja_extensions.py
+++ b/springfield/base/tests/test_jinja_extensions.py
@@ -1,0 +1,128 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import threading
+
+from jinja2 import DictLoader, Environment
+
+from springfield.jinja2 import ThreadSafeIncludeContentsExtension
+
+COMPONENTS = {
+    "components/box.html": "[{{ name }}|{{ contents.slot }}]",
+    "components/outer.html": "[outer|{{ contents.slot }}]",
+}
+
+
+def build_environment(extension):
+    return Environment(loader=DictLoader(COMPONENTS), extensions=[extension])
+
+
+# FUTURE: remove when django-includecontents releases a new version which fixes
+#         django-includecontents#11.
+class TestThreadSafeIncludeContentsExtension:
+    def test_concurrent_renders_do_not_leak_slot_content(self):
+        """
+        Slot content must land in the component that captured it, not whichever
+        component happens to be rendering in another thread.
+
+        django-includecontents 4.0.1 keeps a single ``_render_stack`` list on the
+        extension instance, and Jinja2 builds one extension per Environment. So
+        two threads rendering components at once push and pop frames on the same
+        list, and ``<content:...>`` blocks get written to ``stack[-1]``, which
+        may belong to the other thread.
+
+        This interleaving is forced with events rather than sleeps so the test is
+        deterministic:
+
+            1. A pushes its frame and blocks inside its <content:slot> body.
+            2. B pushes its frame, captures its own slot, and blocks. A's frame
+               is no longer on top of the shared stack.
+            3. A finishes its slot body and captures. If the stack was shared, the
+               write would land in B's frame: A loses its slot, B gets A's content.
+        """
+        env = build_environment(ThreadSafeIncludeContentsExtension)
+
+        a_inside_slot = threading.Event()
+        b_frame_pushed = threading.Event()
+        a_finished = threading.Event()
+
+        def gate_a():
+            a_inside_slot.set()
+            assert b_frame_pushed.wait(timeout=10), "B never pushed its frame"
+            return ""
+
+        def gate_b():
+            b_frame_pushed.set()
+            assert a_finished.wait(timeout=10), "A never finished rendering"
+            return ""
+
+        # Make gate_a and gate_b accessible to the templates
+        env.globals.update(gate_a=gate_a, gate_b=gate_b)
+
+        template_a = env.from_string(
+            """<include:box name="A">
+              <content:slot>{{ gate_a() }}A-SLOT</content:slot>
+            </include:box>"""
+        )
+        template_b = env.from_string(
+            """<include:box name="B">
+              <content:slot>B-SLOT</content:slot>
+              {{ gate_b() }}
+            </include:box>"""
+        )
+
+        results = {}
+
+        def render(key, template):
+            results[key] = template.render().strip()
+
+        thread_a = threading.Thread(target=render, args=("a", template_a))
+        thread_b = threading.Thread(target=render, args=("b", template_b))
+
+        thread_a.start()
+        assert a_inside_slot.wait(timeout=10), "A never reached its slot body"
+        thread_b.start()
+        thread_a.join(timeout=10)
+        a_finished.set()
+        thread_b.join(timeout=10)
+
+        assert results["a"] == "[A|A-SLOT]"
+        assert results["b"] == "[B|B-SLOT]"
+
+    def test_nested_components_share_a_render_stack(self):
+        """
+        Nesting relies on the outer and inner renders seeing the same stack.
+
+        Components render in an overlay environment, and Jinja's ``Extension.bind``
+        shallow-copies the extension for it. The thread-local stack has to be shared
+        across those copies the way the original list was.
+        """
+        env = build_environment(ThreadSafeIncludeContentsExtension)
+        template = env.from_string(
+            """<include:outer>
+              <content:slot><include:box name="inner">
+                <content:slot>DEEP</content:slot>
+              </include:box></content:slot>
+            </include:outer>"""
+        )
+
+        assert template.render().strip() == "[outer|[inner|DEEP]]"
+
+    def test_repeated_renders_do_not_accumulate_stack_frames(self):
+        """
+        A worker thread is reused across requests, so the stack must be clear after
+        every render.
+        """
+        env = build_environment(ThreadSafeIncludeContentsExtension)
+        template = env.from_string(
+            """<include:box name="A">
+              <content:slot>SLOT</content:slot>
+            </include:box>"""
+        )
+
+        for _ in range(3):
+            assert template.render().strip() == "[A|SLOT]"
+
+        extension = env.extensions[ThreadSafeIncludeContentsExtension.identifier]
+        assert extension._render_stack == []

--- a/springfield/jinja2.py
+++ b/springfield/jinja2.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import contextvars
+
 from includecontents.jinja2 import IncludeContentsExtension
 from jinja2 import Environment
 from wagtail.admin.jinja2tags import WagtailUserbarExtension
@@ -9,8 +11,64 @@ from wagtail.admin.jinja2tags import WagtailUserbarExtension
 from springfield.cms.templatetags.cms_tags import richtext
 
 
+class _ContextLocalRenderStack:
+    """
+    Data descriptor serving one ``_render_stack`` per thread or async task.
+
+    django-includecontents 4.0.1 stores its render stack as a plain list on the
+    extension instance, and Jinja2 builds one extension per Environment. Every
+    request thread therefore pushes and pops frames on the same list, so a
+    ``<content:...>`` block -- which is written to ``stack[-1]`` -- can land in a
+    component another thread is rendering. The visible result is slots that come
+    out empty or filled with another ``<include:...>`` tag's content.
+
+    The ContextVar lives in the extension's ``__dict__`` rather than on this
+    descriptor or the extension's ``__init__`` because Jinja renders components
+    in an overlay environment, and ``Extension.bind`` shallow-copies the
+    extension class for it. Sharing the var that way keeps nested components
+    pushing onto the same stack, the same as when it was a shared list.
+    """
+
+    _VAR_ATTR = "_render_stack_var"
+
+    def _var(self, extension):
+        var = extension.__dict__.get(self._VAR_ATTR)
+        if var is None:
+            var = contextvars.ContextVar("includecontents_render_stack")
+            extension.__dict__[self._VAR_ATTR] = var
+        return var
+
+    def __get__(self, extension, owner=None):
+        if extension is None:
+            return self
+        var = self._var(extension)
+        stack = var.get(None)
+        if not stack:
+            # Rebind whenever the stack is empty, i.e. at the start of every
+            # render tree. An asyncio task inherits a copy of its parent's
+            # context, so without this two tasks could mutate the same list.
+            stack = []
+            var.set(stack)
+        return stack
+
+    def __set__(self, extension, value):
+        self._var(extension).set(list(value))
+
+
+class ThreadSafeIncludeContentsExtension(IncludeContentsExtension):
+    """
+    ``IncludeContentsExtension`` with a render stack that is not shared between threads.
+
+    FUTURE: drop this subclass when django-includecontents releases a new version which
+            fixes django-includecontents#11.
+    """
+
+    _render_stack = _ContextLocalRenderStack()
+
+
 def custom_environment(**options):
-    options["extensions"] = options.get("extensions", []) + [IncludeContentsExtension, WagtailUserbarExtension]
+    extensions = [ThreadSafeIncludeContentsExtension, WagtailUserbarExtension]
+    options["extensions"] = options.get("extensions", []) + extensions
     env = Environment(**options)
     env.filters["richtext"] = richtext
 

--- a/springfield/settings/base.py
+++ b/springfield/settings/base.py
@@ -871,7 +871,9 @@ TEMPLATES = [
                 "django_jinja_markdown.extensions.MarkdownExtension",
                 "wagtail.jinja2tags.core",
                 "wagtail.images.jinja2tags.images",
-                "includecontents.jinja2.IncludeContentsExtension",
+                # FUTURE: revert to `includecontents.jinja2.IncludeContentsExtension` when django-includecontents
+                #         releases a new version which fixes django-includecontents#11.
+                "springfield.jinja2.ThreadSafeIncludeContentsExtension",
             ],
             "environment": "springfield.jinja2.custom_environment",
         },


### PR DESCRIPTION
## One-line summary

Fix thread-unsafe rendering bug in `django-includecontents` causing content to load incorrectly under concurrent requests.

## Significant changes and points to review

The `django-includecontents` package's Jinja2 extension (`includecontents.jinja2.IncludeContentsExtension`) has a bug: its plain list rendering stack (`self._render_stack`) is shared between threads because Jinja2 instantiates the extension once per environment. This resulted in slot content in `<include:..>` tags sometimes receiving content from other components or missing altogether.

This PR fixes the bug by subclassing `IncludeContentsExtension` and replacing the render stack with a thread-safe [`ContextVar`](https://docs.python.org/3/library/contextvars.html).

See SmileyChris/django-includecontents#11 for additional details. See SmileyChris/django-includecontents#12 for the fix in that library. (The fix differs from the one presented in this PR due to the ease of fixing the bug via subclassing the extension with an attribute versus rewriting several methods; both changes fix the reported issue.) Once `django-includecontents` releases a new version with this bug fixed, and this repo updates its dependency, then this PR can be reverted.

Note: this should unblock parallel Playwright testing.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1423

Closes #1590.

## Testing

1. Open several tabs (either site pages rendered by the CMS and/or pattern library views). Five should do.
2. Make a change to a CSS file, causing webpack to reload all of the tabs.
3. Check that all content was loaded in as expected: no empty blocks, or blocks with content from other pages.