### PR TITLE
[WT-1638] Ensure minor version component is included in WNP release notes link

### DIFF
--- a/springfield/firefox/templates/firefox/whatsnew/evergreen.html
+++ b/springfield/firefox/templates/firefox/whatsnew/evergreen.html
@@ -90,7 +90,7 @@
     </div>
 
     <aside class="mzp-l-content c-utilities">
-      {% set releasenotes_url = url('firefox.releases.index') if not version else '/firefox/%s/releasenotes/'|format(version) %}
+      {% set releasenotes_url = url('firefox.desktop.releasenotes', releasenotes_version, 'release') if releasenotes_version else url('firefox.releases.index') %}
       {% set releasenotes_link = 'href="%s" target="_blank"'|safe|format(releasenotes_url) %}
       <p>{{ ftl('whatsnew-release-notes', url=releasenotes_link) }}</p>
     </aside>

--- a/springfield/firefox/tests/test_views.py
+++ b/springfield/firefox/tests/test_views.py
@@ -622,6 +622,7 @@ class TestWhatsNew(TestCase):
         ctx = render_mock.call_args[0][2]
         assert template == ["firefox/whatsnew/evergreen.html"]
         assert ctx["version"] == "70.0"
+        assert ctx["releasenotes_version"] == "70.0"
         assert ctx["analytics_version"] == "70"
         assert ctx["entrypoint"] == "firefox.com-whatsnew70"
         assert ctx["campaign"] == "whatsnew70"
@@ -661,6 +662,27 @@ class TestWhatsNew(TestCase):
         assert ctx["utm_params"] == (
             "utm_source=firefox.com-whatsnew100nightly&utm_medium=referral&utm_campaign=whatsnew100nightly&entrypoint=firefox.com-whatsnew100nightly"
         )
+
+    @override_settings(DEV=True)
+    @patch.object(views, "ftl_file_is_active", lambda *x: True)
+    def test_releasenotes_version_adds_missing_minor(self, render_mock):
+        """A version that is only a major should gain the minor component release notes URLs require"""
+        req = self.rf.get("/en-US/whatsnew/")
+        self.view(req, version="153")
+        ctx = render_mock.call_args[0][2]
+        assert ctx["version"] == "153"
+        assert ctx["releasenotes_version"] == "153.0"
+
+    @override_settings(DEV=True)
+    @patch.object(views, "ftl_file_is_active", lambda *x: True)
+    def test_releasenotes_version_keeps_existing_minor(self, render_mock):
+        """Versions that already have a minor component should pass through unchanged"""
+        for version in ("153.0", "153.0beta", "153.0.1"):
+            with self.subTest(version=version):
+                req = self.rf.get("/en-US/whatsnew/")
+                self.view(req, version=version)
+                ctx = render_mock.call_args[0][2]
+                assert ctx["releasenotes_version"] == version
 
     # end context variable tests
 
@@ -789,6 +811,22 @@ class TestWhatsNew(TestCase):
                 assert match is not None, f"Path '{path}' should match pattern {expected_pattern_name} but didn't. Pattern: {regex.pattern}"
 
     # end URL routing tests
+
+
+class TestWhatsNewReleaseNotesLink(TestCase):
+    def test_major_only_version_links_to_versioned_release_notes(self):
+        """The evergreen WNP links to the release notes of the version it was served for"""
+        response = self.client.get("/en-US/whatsnew/153/")
+        doc = pq(response.content)
+        link = doc(".c-utilities a")
+        assert link.attr("href") == "/en-US/firefox/153.0/releasenotes/"
+
+    def test_beta_version_links_to_beta_release_notes(self):
+        """A version with a channel suffix keeps that suffix in the link"""
+        response = self.client.get("/en-US/whatsnew/153.0beta/")
+        doc = pq(response.content)
+        link = doc(".c-utilities a")
+        assert link.attr("href") == "/en-US/firefox/153.0beta/releasenotes/"
 
 
 class TestDetectChannel(TestCase):

--- a/springfield/firefox/views.py
+++ b/springfield/firefox/views.py
@@ -1064,6 +1064,10 @@ class WhatsnewView(L10nTemplateView):
         ctx["version"] = version
         ctx["num_version"] = num_version
 
+        # A What's New version may be a major on its own (e.g. "153"), while release
+        # notes URLs need a minor component too (e.g. "153.0").
+        ctx["releasenotes_version"] = f"{version}.0" if version and "." not in version else version
+
         # add analytics parameters to context for use in templates
         if channel not in pre_release_channels:
             channel = ""


### PR DESCRIPTION
## One-line summary

For non-CMS What’s New pages, the release notes link was broken for major versions since the minor component (i.e. `.0`) was missing from the URL. This ensures that’s included.

## Significant changes and points to review

Full disclosure, I used Claude Code for this change as I wasn’t totally familiar with this part of the codebase, the helpers that were available, and testing with Python. I reviewed the code and tested it works in the browser and with the automated tests.

## Issue / Bugzilla link

- https://mozilla-hub.atlassian.net/browse/WT-1638
- https://bugzilla.mozilla.org/show_bug.cgi?id=2063623

## Testing

Pull down and test that the release notes link in the page content goes to the correct place (e.g. link href is set to `/sv-SE/firefox/153.0/releasenotes/` — will redirect to the en-US version):

- Previously broken: http://localhost:8000/sv-SE/whatsnew/153/
    - Try a few different languages (e.g. `cy`)
- Not previously broken, but could be affected by the change (i.e. it’s in the code path): http://localhost:8000/sv-SE/whatsnew/153.0beta/
