### PR TITLE
Exclude referral pages from the sitemap

### DIFF
--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2848,6 +2848,7 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
         return True
 
     def get_sitemap_urls(self, request=None):
+        # Page 404s without a valid ref_key and is geo-restricted.
         return []
 
     def get_context(self, request, *args, **kwargs):
@@ -3016,6 +3017,7 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
         return True
 
     def get_sitemap_urls(self, request=None):
+        # Page 404s without a valid invitation and is geo-restricted.
         return []
 
     def clean(self):

--- a/springfield/cms/models/pages.py
+++ b/springfield/cms/models/pages.py
@@ -2843,6 +2843,13 @@ class ReferralHubPage(AbstractSpringfieldCMSPage):
     class Meta:
         verbose_name = "Referral Program: Referral Hub Page"
 
+    @property
+    def noindex(self):
+        return True
+
+    def get_sitemap_urls(self, request=None):
+        return []
+
     def get_context(self, request, *args, **kwargs):
         """
         Adds an invite_url to the context using the referral-hub ID
@@ -3003,6 +3010,13 @@ class ReferralGetFirefoxPage(AbstractSpringfieldCMSPage):
 
     class Meta:
         verbose_name = "Referral Program: Invitee / Get Firefox Page"
+
+    @property
+    def noindex(self):
+        return True
+
+    def get_sitemap_urls(self, request=None):
+        return []
 
     def clean(self):
         super().clean()

--- a/springfield/sitemaps/tests/test_utils.py
+++ b/springfield/sitemaps/tests/test_utils.py
@@ -11,7 +11,13 @@ from wagtail.models import Locale, Page, PageViewRestriction, Site
 
 from springfield.cms.models import BlogArticlePage, BlogIndexPage, BlogTopic, BlogTopicPage
 from springfield.cms.models.pages import HeroStyle
-from springfield.cms.tests.factories import LocaleFactory, SimpleRichTextPageFactory, StructuralPageFactory
+from springfield.cms.tests.factories import (
+    LocaleFactory,
+    ReferralGetFirefoxPageFactory,
+    ReferralHubPageFactory,
+    SimpleRichTextPageFactory,
+    StructuralPageFactory,
+)
 from springfield.sitemaps.utils import (
     _path_for_cms_url,
     get_wagtail_urls,
@@ -309,6 +315,19 @@ def test_get_wagtail_urls__alias_locale_pages_excluded(dummy_wagtail_pages):
     # pt-PT child page does not exist, so it must not appear — even though the
     # middleware would serve pt-BR content at the pt-PT URL.
     assert "pt-PT" not in urls["/test-page/child-page/"]
+
+
+def test_get_wagtail_urls__referral_pages_excluded():
+    """Referral pages require query parameters to serve content and
+    should never appear in the sitemap."""
+    site = Site.objects.get(is_default_site=True)
+    ReferralHubPageFactory(parent=site.root_page)
+    ReferralGetFirefoxPageFactory(parent=site.root_page)
+
+    urls = get_wagtail_urls()
+
+    assert "/invite/" not in urls
+    assert "/get-firefox/" not in urls
 
 
 @patch("springfield.sitemaps.utils.get_static_urls")


### PR DESCRIPTION
## Summary

`ReferralHubPage` (`/invite/`) and `ReferralGetFirefoxPage` (`/get-firefox/`) always 404 without query parameters (`ref_key` / `invitation`) and are geo-restricted, so they should not appear in the sitemap

This changeset:
1. Overrides `get_sitemap_urls()` to return `[]` on both models, so the sitemap pipeline skips them naturally
2. Sets `noindex = True` on both models as an extra mitigation

## Test plan

- [x] `pytest springfield/sitemaps/tests/test_utils.py -v` -- all 14 tests pass, including the new `test_get_wagtail_urls__referral_pages_excluded`
