### PR TITLE
Add animation as media option in tabs WT-1630

### DIFF
--- a/media/css/cms/components/flare-tabs.css
+++ b/media/css/cms/components/flare-tabs.css
@@ -63,13 +63,6 @@
         color: var(--theme-tabs-tab-color-hover);
     }
 
-    .fl-tab-image {
-        block-size: auto;
-        display: block;
-        margin: 0 auto var(--token-layout-xs);
-        max-inline-size: 100%;
-    }
-
     [role='tabpanel'].is-hidden {
         display: none;
     }
@@ -89,4 +82,26 @@
     .fl-tabs button[role='tab'] {
         min-inline-size: 122px;
     }
+}
+
+.fl-tab-panel-media {
+    display: flex;
+    justify-content: center;
+    position: relative;
+}
+
+.fl-tab-panel-media .fl-video {
+    block-size: 120px;
+    display: block;
+    inline-size: auto;
+    margin: 0 auto var(--token-spacing-xl);
+    max-inline-size: 100%;
+}
+
+.fl-tab-panel-media img {
+    block-size: auto;
+    display: block;
+    inline-size: auto;
+    margin: 0 auto var(--token-spacing-xl);
+    max-block-size: 120px;
 }

--- a/media/css/cms/pages/flare-referral-hub.css
+++ b/media/css/cms/pages/flare-referral-hub.css
@@ -52,11 +52,6 @@
         --tabs-inline-padding: var(--token-spacing-lg);
     }
 
-    .fl-referral-hub-page .fl-tabs .fl-tab-image {
-        margin-block-end: var(--token-spacing-xl);
-        max-inline-size: 110px;
-    }
-
     .fl-referral-hub-page .fl-tabs .fl-tab-heading {
         margin-block-end: 0;
     }

--- a/springfield/cms/blocks.py
+++ b/springfield/cms/blocks.py
@@ -1754,6 +1754,15 @@ class TabComparisonTableBlock(blocks.StreamBlock):
         label = "Comparison table"
 
 
+class TabMediaBlock(blocks.StreamBlock):
+    image = ImageVariantsBlock(required=False)
+    animation = AnimationBlock(required=False)
+
+    class Meta:
+        label = "Media"
+        template = "cms/blocks/media.html"
+
+
 class TabBlock(blocks.StructBlock):
     tab_name = blocks.CharBlock(label="Tab name")
     icon = IconChoiceBlock(required=False, label="Tab icon", help_text="Optional icon shown before the tab name in the tab list.")
@@ -1766,7 +1775,7 @@ class TabBlock(blocks.StructBlock):
         "Visitors on Firefox, or on a browser no tab claims, get the Chrome tab.",
     )
     heading = RichTextBlock(features=HEADING_TEXT_FEATURES, required=False)
-    image = ImageChooserBlock(required=False)
+    media = TabMediaBlock(max_num=1, required=False)
     description = RichTextBlock(features=EXPANDED_TEXT_FEATURES, required=False)
     referral_controls = TabReferralControlsBlock(max_num=1, min_num=0, required=False)
     impact_dash = TabImpactDashBlock(max_num=1, min_num=0, required=False)

--- a/springfield/cms/migrations/0145_migrate_tab_image_to_media.py
+++ b/springfield/cms/migrations/0145_migrate_tab_image_to_media.py
@@ -1,0 +1,121 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Converts TabBlock's old `image` field to the new `media` StreamBlock.
+# The old field was ImageChooserBlock (stores an int ID) but may also appear
+# as an ImageVariantsBlock dict {image: <id>, settings: {...}} in some databases.
+# Both formats are handled; the result is always a plain int ID in the media block.
+
+import json
+import uuid
+from collections.abc import MutableSequence
+
+from django.db import migrations
+
+
+def migrate_tab(list_item):
+    # ListBlock stores each tab as {"type": "item", "value": {...tab fields...}, "id": "..."}
+    if not isinstance(list_item, dict):
+        return list_item
+
+    tab = list_item.get("value")
+    if not isinstance(tab, dict) or "media" in tab:
+        return list_item
+
+    image = tab.get("image")
+
+    # Plain ImageChooserBlock int ID
+    if isinstance(image, int):
+        image_id = image
+    # ImageVariantsBlock dict {image: <id>, settings: {...}}
+    elif isinstance(image, dict) and isinstance(image.get("image"), int):
+        image_id = image["image"]
+    else:
+        return list_item
+
+    tab["media"] = [
+        {
+            "type": "image",
+            "id": uuid.uuid4().hex,
+            "value": {
+                "image": image_id,
+                "settings": {"dark_mode_image": None, "mobile_image": None, "dark_mode_mobile_image": None},
+            },
+        }
+    ]
+    del tab["image"]
+    return list_item
+
+
+def walk_and_transform(data):
+    if isinstance(data, dict):
+        if data.get("type") == "tabs":
+            value = data.get("value", {})
+            tabs = value.get("tabs", [])
+            if isinstance(tabs, (list, MutableSequence)):
+                value["tabs"] = [migrate_tab(tab) for tab in tabs]
+                data["value"] = value
+
+        for key, val in data.items():
+            if isinstance(val, (dict, list, MutableSequence)):
+                data[key] = walk_and_transform(val)
+
+    elif isinstance(data, (list, MutableSequence)):
+        for i, item in enumerate(data):
+            if isinstance(item, (dict, list, MutableSequence)):
+                data[i] = walk_and_transform(item)
+
+    return data
+
+
+def migrate_pages(apps, schema_editor):
+    ReferralHubPage = apps.get_model("cms", "ReferralHubPage")
+    ReferralGetFirefoxPage = apps.get_model("cms", "ReferralGetFirefoxPage")
+    Revision = apps.get_model("wagtailcore", "Revision")
+    ContentType = apps.get_model("contenttypes", "ContentType")
+
+    hub_ct = ContentType.objects.get_for_model(ReferralHubPage)
+    getff_ct = ContentType.objects.get_for_model(ReferralGetFirefoxPage)
+
+    for revision in Revision.objects.filter(content_type=hub_ct).iterator():
+        modified = False
+        for field in ("upper_content", "extra_content"):
+            if field in revision.content:
+                try:
+                    content = json.loads(revision.content[field])
+                    revision.content[field] = json.dumps(walk_and_transform(content))
+                    modified = True
+                except (json.JSONDecodeError, TypeError, KeyError):
+                    pass
+        if modified:
+            revision.save(update_fields=["content"])
+
+    for page in ReferralHubPage.objects.all():
+        page.upper_content.raw_data = walk_and_transform(page.upper_content.raw_data)
+        if page.extra_content:
+            page.extra_content.raw_data = walk_and_transform(page.extra_content.raw_data)
+        page.save(update_fields=["upper_content", "extra_content"])
+
+    for revision in Revision.objects.filter(content_type=getff_ct).iterator():
+        if "upper_content" in revision.content:
+            try:
+                content = json.loads(revision.content["upper_content"])
+                revision.content["upper_content"] = json.dumps(walk_and_transform(content))
+                revision.save(update_fields=["content"])
+            except (json.JSONDecodeError, TypeError, KeyError):
+                pass
+
+    for page in ReferralGetFirefoxPage.objects.all():
+        page.upper_content.raw_data = walk_and_transform(page.upper_content.raw_data)
+        page.save(update_fields=["upper_content"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0144_blogarticlepage_bottom_banner"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_pages, migrations.RunPython.noop),
+    ]

--- a/springfield/cms/templates/cms/blocks/tab.html
+++ b/springfield/cms/templates/cms/blocks/tab.html
@@ -5,17 +5,9 @@
 #}
 
 <div id="fl-tab-panel-{{ section_id }}-{{ tab_index }}" role="tabpanel" aria-labelledby="fl-tab-{{ section_id }}-{{ tab_index }}" class="fl-tab">
-  {% if value.image %}
-    {{ srcset_image(
-        value.image,
-        "width-{200,400,600,800,1000,1200}",
-        sizes="(min-width: 1024px) 50vw, 100vw",
-        width=value.image.width,
-        height=value.image.height,
-        loading="lazy",
-        class="fl-tab-image",
-    ) }}
-  {% endif %}
+  <div class="fl-tab-panel-media">
+  {% include_block value.media %}
+  </div>
   {% if value.heading %}
     <h2 class="fl-tab-heading fl-heading-sm">{{ value.heading|richtext|remove_p_tag }}</h2>
   {% endif %}

--- a/springfield/cms/tests/test_blocks.py
+++ b/springfield/cms/tests/test_blocks.py
@@ -4903,6 +4903,55 @@ def test_tab_block_rejects_firefox_as_a_detected_browser():
     assert "firefox" not in dict(DETECTED_BROWSER_CHOICES)
 
 
+def test_tab_block_renders_image_via_media_field(placeholder_images):
+    from django.conf import settings
+
+    raw = {
+        "tab_name": "Image tab",
+        "media": [
+            {
+                "type": "image",
+                "id": "aabbcc001122",
+                "value": {
+                    "image": settings.PLACEHOLDER_IMAGE_ID,
+                    "settings": {"dark_mode_image": None, "mobile_image": None, "dark_mode_mobile_image": None},
+                },
+            }
+        ],
+    }
+    block = TabBlock()
+    value = block.to_python(raw)
+    html = block.render(value, context={"section_id": "hub", "tab_index": 1})
+    soup = BeautifulSoup(html, "html.parser")
+    assert soup.find("div", class_="image-variants-display") is not None
+
+
+def test_tab_block_renders_animation_via_media_field(placeholder_images):
+    from django.conf import settings
+
+    raw = {
+        "tab_name": "Animation tab",
+        "media": [
+            {
+                "type": "animation",
+                "id": "ddeeff334455",
+                "value": {
+                    "video_url": "https://assets.mozilla.net/video/red-pandas.webm",
+                    "alt": "Red pandas playing",
+                    "poster": settings.PLACEHOLDER_IMAGE_ID,
+                    "playback": "autoplay_loop",
+                },
+            }
+        ],
+    }
+    block = TabBlock()
+    value = block.to_python(raw)
+    html = block.render(value, context={"section_id": "hub", "tab_index": 1})
+    soup = BeautifulSoup(html, "html.parser")
+    panel = soup.find("div", id="fl-tab-panel-hub-1")
+    assert panel.find("video") is not None
+
+
 def _email_href(html):
     return BeautifulSoup(html, "html.parser").find("a", class_="fl-referral-controls-share-email")["href"]
 


### PR DESCRIPTION
## One-line summary

Add animation as media option in tabs

## Significant changes and points to review

- replace the tab image block with a media block
- associated data migration
- associated style changes fl-tab-image → fl-tab-panel-media

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1630

## Testing

- get prod DB (or set up a referral hub page with an image on it locally)
- run the migration and make sure the image is still there and the right size
- swap the image for an animation (you can use https://assets.mozilla.net/video/smartwindow/TAB_e.webm)
- check display