### PR TITLE
Make 0144 bottom_banner migration idempotent

### DIFF
--- a/springfield/cms/migrations/0144_blogarticlepage_bottom_banner.py
+++ b/springfield/cms/migrations/0144_blogarticlepage_bottom_banner.py
@@ -9,27 +9,42 @@ from django.db import migrations
 import springfield.cms.fields
 
 
+class AddFieldIfColumnExists(migrations.AddField):
+    """
+    AddField that skips schema application when the column is already there.
+
+    This migration was applied to some databases while it was numbered 0141,
+    but was then renamed to 0144. Those databases should skip the column
+    addition, but other databases still need the column added.
+    """
+
+    def _column_exists(self, schema_editor, state, app_label):
+        model = state.apps.get_model(app_label, self.model_name)
+        column_name = model._meta.get_field(self.name).column
+        with schema_editor.connection.cursor() as cursor:
+            table_columns = schema_editor.connection.introspection.get_table_description(cursor, model._meta.db_table)
+        return any(existing.name == column_name for existing in table_columns)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if not self._column_exists(schema_editor, to_state, app_label):
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if self._column_exists(schema_editor, from_state, app_label):
+            super().database_backwards(app_label, schema_editor, from_state, to_state)
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("cms", "0143_merge_20260818_2040"),
     ]
 
     operations = [
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.AddField(
-                    model_name="blogarticlepage",
-                    name="bottom_banner",
-                    field=springfield.cms.fields.StreamField(
-                        blank=True, block_lookup={}, help_text="Optional banner to be displayed at the bottom of the article content."
-                    ),
-                ),
-            ],
-            database_operations=[
-                migrations.RunSQL(
-                    sql="ALTER TABLE cms_blogarticlepage ADD COLUMN IF NOT EXISTS bottom_banner jsonb DEFAULT '[]'",
-                    reverse_sql="ALTER TABLE cms_blogarticlepage DROP COLUMN IF EXISTS bottom_banner",
-                ),
-            ],
+        AddFieldIfColumnExists(
+            model_name="blogarticlepage",
+            name="bottom_banner",
+            field=springfield.cms.fields.StreamField(
+                blank=True, block_lookup={}, help_text="Optional banner to be displayed at the bottom of the article content."
+            ),
         ),
     ]

--- a/springfield/cms/migrations/0144_blogarticlepage_bottom_banner.py
+++ b/springfield/cms/migrations/0144_blogarticlepage_bottom_banner.py
@@ -15,11 +15,21 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="blogarticlepage",
-            name="bottom_banner",
-            field=springfield.cms.fields.StreamField(
-                blank=True, block_lookup={}, help_text="Optional banner to be displayed at the bottom of the article content."
-            ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="blogarticlepage",
+                    name="bottom_banner",
+                    field=springfield.cms.fields.StreamField(
+                        blank=True, block_lookup={}, help_text="Optional banner to be displayed at the bottom of the article content."
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE cms_blogarticlepage ADD COLUMN IF NOT EXISTS bottom_banner jsonb DEFAULT '[]'",
+                    reverse_sql="ALTER TABLE cms_blogarticlepage DROP COLUMN IF EXISTS bottom_banner",
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
PR #1744 renumbered the migration in this changeset from `0141` to `0144`, but it's already been applied in Dev, Stage and Prod.

Databases that already applied the old 0141 have the column but not the new migration record, so Django tries to `AddField` again and hits `DuplicateColumn` whicih causes an error running migrations and kills the rollout of the new deployment.

Hopefully, we can fix this by using `SeparateDatabaseAndState` with `ADD COLUMN IF NOT EXISTS` – that will make it safe for the deployed envs with the old migration number and also for any fresh runs of recent migrations (eg demo servers that haven't been used for a while, or the sqlite db export tool)
