### PR TITLE
User routing - fixes from local testing

### DIFF
--- a/media/css/cms/routing/resolver.scss
+++ b/media/css/cms/routing/resolver.scss
@@ -6,15 +6,50 @@
 
 @use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
+// This page loads none of the site CSS, so without its own colours it inherits whatever canvas
+// the browser paints — black on dark for anyone in dark mode. These mirror the flare tokens;
+// keep them in step with media/css/cms/variables/flare-{light,dark}-theme.css. Mirrored rather
+// than imported because those files take the bundle from ~600 bytes to ~35 KB.
+:root {
+    --routing-resolver-background: #fff; // --token-color-white
+    --routing-resolver-text: #15141a; // --token-color-black-4
+    --routing-resolver-link: #6132bc; // --token-color-link-purple
+    // Named only, never loaded: with no @font-face the brand face is used when the visitor
+    // already has it and falls through to the system stack otherwise, so this costs no request.
+    --routing-resolver-font: 'Mozilla Text VF', -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', sans-serif;
+
+    // Match form controls and scrollbars to the ground we paint.
+    color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --routing-resolver-background: #210340; // --token-color-dark-purple
+        --routing-resolver-text: #fff; // --token-color-white
+        --routing-resolver-link: #c7a8ff; // --token-color-soft-purple-4
+    }
+}
+
+body {
+    background: var(--routing-resolver-background);
+    margin: 0;
+}
+
 .routing-resolver {
     @include text-body-lg;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    color: var(--routing-resolver-text);
+    font-family: var(--routing-resolver-font);
     min-block-size: 100vh;
     padding: $spacing-lg;
     text-align: center;
+}
+
+.routing-resolver a {
+    color: var(--routing-resolver-link);
 }
 
 // The escape hatch is in the markup from the start — it has to work with no JS and no
@@ -32,9 +67,12 @@
 // A keyboard user can reach the link on their first Tab, long before the delay is up, and
 // `both` holds it at opacity 0 until then — focus with nothing to see. Anyone who has
 // focused it is by definition not waiting for a redirect, so drop the animation entirely
-// and show it. Pointer users keep the delayed reveal.
-.routing-resolver-escape:focus,
-.routing-resolver-escape:focus-visible {
+// and show it. Pointer users keep the delayed reveal, since they cannot click what they
+// cannot see.
+// `:focus-within`, not `:focus`: this class is on the <p>, while the thing that takes focus
+// is the <a> inside it. A <p> is not focusable, so `:focus` on it never matches and the
+// reveal never fires.
+.routing-resolver-escape:focus-within {
     animation: none;
     opacity: 1;
 }

--- a/media/js/cms/routing/readers.es6.js
+++ b/media/js/cms/routing/readers.es6.js
@@ -263,8 +263,8 @@ export function createUITourReader(options) {
  *
  *   - `oldversion` is a version signal (Firefox's just-updated flow sends it); its value
  *     is normalized the same way `firefox_version` is (bare / rv: / fully-qualified).
- *   - `locale` is the page locale, read from an explicit `?locale=` override and falling
- *     back to the `<html lang>` attribute (server-rendered on the resolver page).
+ *   - `locale` is the page locale, read from the `<html lang>` attribute (server-rendered on
+ *     the resolver page) and never from a query param.
  *   - `language` is that same locale with the region dropped, so one condition covers
  *     every regional variant of a language.
  *
@@ -308,10 +308,12 @@ export function createUrlReader(options) {
                     descriptor.name === 'locale' ||
                     descriptor.name === 'language'
                 ) {
-                    // Explicit ?locale= wins; otherwise fall back to <html lang>.
-                    const locale = params.has('locale')
-                        ? params.get('locale')
-                        : htmlLang();
+                    // The page locale, from the server-rendered <html lang>. Deliberately
+                    // not readable from a query param — that would let a visitor choose
+                    // which variant they are routed to. This case must stay ahead of the
+                    // generic param branch below, which would otherwise honour ?locale=
+                    // and ?language=. Staff preview goes through ?preview_signal=.
+                    const locale = htmlLang();
                     if (locale) {
                         // `language` is the same value with the region dropped, so one
                         // condition matches every regional variant.

--- a/springfield/admin/templates/wagtailadmin/routing/rules_index.html
+++ b/springfield/admin/templates/wagtailadmin/routing/rules_index.html
@@ -32,10 +32,12 @@
           <td>{{ row.rule.conditions.count }}</td>
           <td>
             {% if row.problem %}
-              {# Two different situations, deliberately styled differently: a target that is
-                 simply not translated or published *yet* clears itself, while the rest need
-                 an author to change the rule. One badge for both would train authors to
-                 ignore the column during every normal staged translation. #}
+              {% comment %}
+                Two different situations, deliberately styled differently: a target that is
+                simply not translated or published *yet* clears itself, while the rest need
+                an author to change the rule. One badge for both would train authors to
+                ignore the column during every normal staged translation.
+              {% endcomment %}
               {% if row.problem.pending %}
                 <span class="routing-badge routing-badge--pending">{% trans "Waiting" %}</span>
               {% else %}

--- a/springfield/cms/routing/models.py
+++ b/springfield/cms/routing/models.py
@@ -411,15 +411,7 @@ class RoutingConfig(models.Model):
     def is_paused_for(cls, page):
         """Whether routing is paused for ``page``. A missing record reads as not paused.
 
-        Read through the page object rather than querying the live table, because the page
-        handed to us is not always the live one: in a Wagtail preview it is built by
-        ``get_latest_revision_as_object()``, and the staged ``routing_config`` lives on *that*
-        object. Querying the table would report the live pause state while every other field
-        on the page previews as staged.
-
-        Live semantics are unchanged — a draft save stages the pause, publishing makes it real.
-
-        Any row saying paused counts, so a duplicate left behind by a database that predates
-        the uniqueness constraint cannot shadow a pause by being read first.
+        Any row saying paused counts, so a duplicate left by a database predating the
+        uniqueness constraint cannot shadow a pause by being read first.
         """
         return any(config.routing_paused for config in page.routing_config.all())

--- a/springfield/cms/routing/tests/test_admin_views.py
+++ b/springfield/cms/routing/tests/test_admin_views.py
@@ -100,6 +100,21 @@ def test_listing_marks_a_healthy_rule_as_firing(admin_client):
     assert "Will fire" in _status_cell(content, "Healthy rule")
 
 
+def test_listing_renders_no_raw_template_syntax(admin_client):
+    """These are Django templates, where ``{# … #}`` comments out a single line only — a
+    multi-line one prints verbatim into the page."""
+    # The comment sits inside the ``{% if row.problem %}`` branch, so the rule must have a
+    # problem for the status column to render it at all.
+    rule = _matchable(_rule_on("syntax-canonical", "Syntax"))
+    rule.name = "Syntax rule"
+    rule.save()
+    rule.target.unpublish()
+
+    content = admin_client.get(reverse("cms_routing_rules")).content.decode("utf-8")
+    for marker in ("{#", "#}", "{%"):
+        assert marker not in content, f"raw template syntax {marker!r} rendered into the rules listing"
+
+
 def test_listing_flags_an_unpublished_target_as_waiting(admin_client):
     # Publishing the variant is work already in flight, so this must not read as an error.
     rule = _matchable(_rule_on("draft-target-canonical", "Draft target"))

--- a/springfield/cms/routing/tests/test_models.py
+++ b/springfield/cms/routing/tests/test_models.py
@@ -551,9 +551,9 @@ def test_any_paused_config_counts_as_paused(tree):
 
 
 def test_a_page_built_from_a_revision_reports_its_staged_pause(tree):
-    # A Wagtail preview builds the page with get_latest_revision_as_object(), so the staged
-    # config lives on *that* object. Reading the live table instead would report the live
-    # pause state while every other field on the page previews as staged.
+    # Reads through the page object, so a page built from a revision reports the staged value
+    # while the live page reports the published one. Nothing serves routing from a revision
+    # today — Wagtail preview bypasses the routing serve path entirely.
     RoutingConfig.objects.create(page=tree.canonical, routing_paused=False)
     page = tree.canonical
     config = page.routing_config.first()

--- a/springfield/cms/routing/tests/test_resolver.py
+++ b/springfield/cms/routing/tests/test_resolver.py
@@ -223,6 +223,26 @@ def test_the_resolver_offers_a_way_out_that_does_not_depend_on_javascript(routed
     assert not escape.find_parents("noscript")
 
 
+def test_the_resolver_paints_its_own_colours_in_both_schemes():
+    """It loads none of the site CSS, so without its own colours it inherits the browser's
+    canvas — black-on-dark for a visitor in dark mode."""
+    stylesheet = (settings.ROOT_PATH / "media" / "css" / "cms" / "routing" / "resolver.scss").read_text()
+
+    assert "--routing-resolver-background" in stylesheet
+    assert "--routing-resolver-text" in stylesheet
+    assert "prefers-color-scheme: dark" in stylesheet
+
+
+def test_the_escape_link_reveals_itself_on_focus():
+    """The class sits on the ``<p>`` while the ``<a>`` inside takes focus, so keying the reveal
+    off ``:focus`` matches nothing and a keyboard user focuses a transparent element."""
+    stylesheet = (settings.ROOT_PATH / "media" / "css" / "cms" / "routing" / "resolver.scss").read_text()
+
+    assert ".routing-resolver-escape:focus-within" in stylesheet
+    for dead in (".routing-resolver-escape:focus,", ".routing-resolver-escape:focus-visible"):
+        assert dead not in stylesheet, f"{dead} can never match — the class is on a non-focusable <p>"
+
+
 def _render_for(routed_page, request):
     """Render the resolver for a specific request, so its query string reaches the template."""
     response = render_resolver(request, routed_page.canonical)

--- a/springfield/cms/routing/v1_signals.py
+++ b/springfield/cms/routing/v1_signals.py
@@ -162,8 +162,9 @@ registry.register(
     )
 )
 
-# Read from an explicit `?locale=` override, falling back to the page's `<html lang>`.
-# A string, not an enum, for the reason in value_lists: the set is lazy and data-backed.
+# Read from the page's `<html lang>`, never from a query param — a visitor must not be able to
+# choose their own locale. A string, not an enum, for the reason in value_lists: the set is lazy
+# and data-backed.
 registry.register(
     RoutingSignal(
         name="locale",

--- a/tests/unit/spec/cms/routing/readers.js
+++ b/tests/unit/spec/cms/routing/readers.js
@@ -306,15 +306,15 @@ describe('cms/routing/readers.es6.js', function () {
             expect(await reader.read({ name: 'locale' })).toEqual('de');
         });
 
-        it('prefers an explicit ?locale= over <html lang>', async function () {
+        it('ignores ?locale=, so a visitor cannot pick their own locale', async function () {
             const reader = createUrlReader({
                 search: '?locale=pt-BR',
                 lang: 'de'
             });
-            expect(await reader.read({ name: 'locale' })).toEqual('pt-BR');
+            expect(await reader.read({ name: 'locale' })).toEqual('de');
         });
 
-        it('is unavailable when neither ?locale= nor <html lang> is set', async function () {
+        it('is unavailable when <html lang> is not set', async function () {
             const reader = createUrlReader({ search: '', lang: null });
             expect(await settle(reader.read({ name: 'locale' }))).toBe(
                 REJECTED
@@ -333,12 +333,14 @@ describe('cms/routing/readers.es6.js', function () {
             expect(await reader.read({ name: 'language' })).toEqual('de');
         });
 
-        it('derives language from an explicit ?locale= override too', async function () {
+        it('ignores ?locale= and ?language= when deriving language', async function () {
+            // Both must be special-cased ahead of the generic "read any param by signal
+            // name" branch, or that branch would honour them.
             const reader = createUrlReader({
-                search: '?locale=pt-BR',
+                search: '?locale=pt-BR&language=pt',
                 lang: 'de'
             });
-            expect(await reader.read({ name: 'language' })).toEqual('pt');
+            expect(await reader.read({ name: 'language' })).toEqual('de');
         });
 
         it('is unavailable for language when no locale can be determined', async function () {


### PR DESCRIPTION
### Summary

Three defects found by walking the 52-check manual live pass on the merged User Routing framework, plus one hardening. None were visible to the 429 automated tests.

### Notable changes

**`media/css/cms/routing/resolver.scss`**
- Escape link reveal `:focus` → `:focus-within`. The class is on the `<p>` while the `<a>` takes focus, so the rule never matched — a keyboard user focused an invisible link. This is the #1704 a11y bug, believed fixed.
- Paints its own background/text/link colours, mirroring the flare tokens. Was inheriting the browser canvas: 1.21:1 contrast in dark mode, now 18.23:1. Mirrored not imported — importing takes the bundle 600 B → 35 KB, and CSP `style-src` has no `'unsafe-inline'`.

**`springfield/admin/templates/wagtailadmin/routing/rules_index.html`**
- Multi-line `{# ... #}` → `{% comment %}`. It was printing template source into the rules listing.

**`media/js/cms/routing/readers.es6.js`**, `v1_signals.py`
- `locale`/`language` no longer read the query string. Reverts an affordance added in #1704: a visitor could append `?locale=de` and self-select a variant. Must stay ahead of the generic param branch, or `?language=` starts working too. Staff `?preview_signal=` unaffected.

**`springfield/cms/routing/models.py`**
- `is_paused_for()` docstring corrected — it justified itself with a Wagtail-preview case that can't occur.

### Testing

432 Python tests (429 + 3 new), 755 JS specs. Each new test fails against the old code. No migrations.

Confirmed in-browser: focus reveal with a real Tab keypress, contrast measured on the rendered page, and staff-preview vs visitor-spoof driven end-to-end against the same `locale is de` rule — staff routed, visitor didn't.