### PR TITLE
[WT-1652] Draft sharing link for translated pages

### DIFF
--- a/media/js/cms/wagtailadmin-translation-draftsharing.es6.js
+++ b/media/js/cms/wagtailadmin-translation-draftsharing.es6.js
@@ -43,6 +43,15 @@ export async function createSharingLink(button) {
         if (!response.ok) {
             labelNode.nodeValue = originalLabel;
             button.disabled = false;
+            document.dispatchEvent(
+                new CustomEvent('w-messages:add', {
+                    detail: {
+                        clear: true,
+                        text: 'Error generating sharing URL',
+                        type: 'error'
+                    }
+                })
+            );
             return;
         }
 
@@ -70,6 +79,15 @@ export async function createSharingLink(button) {
     } catch (error) {
         labelNode.nodeValue = originalLabel;
         button.disabled = false;
+        document.dispatchEvent(
+            new CustomEvent('w-messages:add', {
+                detail: {
+                    clear: true,
+                    text: 'Error generating sharing URL',
+                    type: 'error'
+                }
+            })
+        );
     }
 }
 

--- a/media/js/cms/wagtailadmin-translation-draftsharing.es6.js
+++ b/media/js/cms/wagtailadmin-translation-draftsharing.es6.js
@@ -131,7 +131,7 @@ export function initTranslationDraftsharing(options) {
     return observer;
 }
 
-// Auto-run only when there is a button (so there is something to share). Skips otherwise.
+// Auto-run only when there is a button. Skips otherwise.
 if (typeof document !== 'undefined' && document.getElementById(TEMPLATE_ID)) {
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function () {

--- a/media/js/cms/wagtailadmin-translation-draftsharing.es6.js
+++ b/media/js/cms/wagtailadmin-translation-draftsharing.es6.js
@@ -1,0 +1,125 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Places the draft sharing button into the translation editor's action menu.
+ *
+ * The editor footer is rendered by React from a fixed set of props, so there is no
+ * server-side hook for adding an action to it. The button is rendered into a
+ * `<template>` element by the `translation_draftsharing_button` tag and moved into
+ * the menu here, then re-inserted whenever React rebuilds the footer.
+ */
+
+const TEMPLATE_ID = 'translation-draftsharing-button';
+const MENU_SELECTOR =
+    'footer .actions--primary [data-w-dropdown-target="content"]';
+const BUTTON_SELECTOR = '[data-translation-draftsharing]';
+
+function getCsrfToken() {
+    const config = document.querySelector('script#wagtail-config');
+    return config ? JSON.parse(config.textContent).CSRF_TOKEN : '';
+}
+
+export async function createSharingLink(button) {
+    const labelNode = button.lastChild;
+    const originalLabel = labelNode.textContent;
+    button.disabled = true;
+    labelNode.nodeValue = 'Copying...';
+
+    try {
+        const response = await window.fetch(button.dataset.url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                Accept: 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRFToken': getCsrfToken()
+            }
+        });
+        if (!response.ok) {
+            labelNode.nodeValue = originalLabel;
+            button.disabled = false;
+            return;
+        }
+
+        const data = await response.json();
+        const url = window.location.origin + data.url;
+        try {
+            await navigator.clipboard.writeText(url);
+            labelNode.nodeValue = 'Copied!';
+        } catch (error) {
+            labelNode.nodeValue = 'Created!';
+            document.dispatchEvent(
+                new CustomEvent('w-messages:add', {
+                    detail: {
+                        clear: true,
+                        text: 'Draft sharing URL: ' + url,
+                        type: 'success'
+                    }
+                })
+            );
+        }
+        window.setTimeout(function () {
+            labelNode.nodeValue = originalLabel;
+            button.disabled = false;
+        }, 3000);
+    } catch (error) {
+        labelNode.nodeValue = originalLabel;
+        button.disabled = false;
+    }
+}
+
+export function placeDraftsharingButton(root) {
+    const template = document.querySelector('#' + TEMPLATE_ID);
+    if (!template) {
+        return null;
+    }
+    const scope = root || document;
+
+    // The w-dropdown controller moves this node into a Tippy popper, so it has to be
+    // looked up again on every pass.
+    const menu = scope.querySelector(MENU_SELECTOR);
+    if (!menu || menu.querySelector(BUTTON_SELECTOR)) {
+        return null;
+    }
+
+    menu.appendChild(template.content.cloneNode(true));
+    const button = menu.querySelector(BUTTON_SELECTOR);
+    button.addEventListener('click', function (event) {
+        event.preventDefault();
+        createSharingLink(button);
+    });
+    return button;
+}
+
+export function initTranslationDraftsharing(options) {
+    const opts = options || {};
+    const root = opts.root || document.querySelector('.js-translation-editor');
+    if (!root) {
+        return null;
+    }
+
+    placeDraftsharingButton(root);
+
+    if (typeof MutationObserver === 'undefined') return null;
+    const observer = new MutationObserver(function () {
+        placeDraftsharingButton(root);
+    });
+    observer.observe(root, { childList: true, subtree: true });
+    return observer;
+}
+
+// Auto-run only when there is a button (so there is something to share). Skips otherwise.
+if (typeof document !== 'undefined' && document.getElementById(TEMPLATE_ID)) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            initTranslationDraftsharing();
+        });
+    } else {
+        initTranslationDraftsharing();
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -529,6 +529,12 @@
     },
     {
       "files": [
+        "js/cms/wagtailadmin-translation-draftsharing.es6.js"
+      ],
+      "name": "wagtailadmin-translation-draftsharing"
+    },
+    {
+      "files": [
         "js/firefox/download/desktop/download.js"
       ],
       "name": "firefox_desktop_download"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -529,12 +529,6 @@
     },
     {
       "files": [
-        "js/cms/wagtailadmin-translation-draftsharing.es6.js"
-      ],
-      "name": "wagtailadmin-translation-draftsharing"
-    },
-    {
-      "files": [
         "js/firefox/download/desktop/download.js"
       ],
       "name": "firefox_desktop_download"
@@ -867,6 +861,12 @@
         "js/cms/wagtailadmin-locale-badges.js"
       ],
       "name": "wagtailadmin-locale-badges"
+    },
+    {
+      "files": [
+        "js/cms/wagtailadmin-translation-draftsharing.es6.js"
+      ],
+      "name": "wagtailadmin-translation-draftsharing"
     },
     {
       "files": [

--- a/springfield/admin/templates/wagtail_localize/admin/edit_translation.html
+++ b/springfield/admin/templates/wagtail_localize/admin/edit_translation.html
@@ -1,0 +1,23 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "wagtail_localize/admin/edit_translation.html" %}
+{% comment %}
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+{% endcomment %}
+
+{% comment %}
+Adds the draft sharing button to the translation editor.
+{% endcomment %}
+
+{% load cms_draftsharing_tags %}
+
+{% block content %}
+    {{ block.super }}
+    {% translation_draftsharing_button translation instance %}
+{% endblock %}

--- a/springfield/admin/templates/wagtail_localize/admin/edit_translation.html
+++ b/springfield/admin/templates/wagtail_localize/admin/edit_translation.html
@@ -1,10 +1,6 @@
-{#
- This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#}
-
 {% extends "wagtail_localize/admin/edit_translation.html" %}
+
+{% comment %} SKIP LICENSE INSERTION {% endcomment %}
 {% comment %}
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/springfield/admin/templates/wagtaildraftsharing/translation_action_menu_item.html
+++ b/springfield/admin/templates/wagtaildraftsharing/translation_action_menu_item.html
@@ -1,0 +1,26 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% comment %}
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+{% endcomment %}
+
+{% comment %}
+Draft sharing button for a translated page. type="button" is required: this markup is
+relocated into the translation editor's footer, which is a POST form that publishes the
+page when submitted.
+{% endcomment %}
+
+{% load wagtailadmin_tags %}
+
+<button type="button"
+        class="button"
+        data-translation-draftsharing
+        data-url="{{ create_url }}">
+    {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
+</button>

--- a/springfield/admin/templates/wagtaildraftsharing/translation_action_menu_item.html
+++ b/springfield/admin/templates/wagtaildraftsharing/translation_action_menu_item.html
@@ -1,9 +1,4 @@
-{#
- This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#}
-
+{% comment %} SKIP LICENSE INSERTION {% endcomment %}
 {% comment %}
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,9 +6,9 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% endcomment %}
 
 {% comment %}
-Draft sharing button for a translated page. type="button" is required: this markup is
-relocated into the translation editor's footer, which is a POST form that publishes the
-page when submitted.
+Draft sharing button for a translated page. type="button" is required:
+this markup is relocated into the translation editor's footer, which is
+a POST form that publishes the page when submitted.
 {% endcomment %}
 
 {% load wagtailadmin_tags %}

--- a/springfield/cms/admin_views.py
+++ b/springfield/cms/admin_views.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import logging
 
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST
@@ -60,7 +60,10 @@ def create_translation_sharing_link(request, translation_id):
     and cleans up revisions for this page's expired links.
     """
     translation = get_object_or_404(Translation, id=translation_id)
-    page = translation.get_target_instance()
+    try:
+        page = translation.get_target_instance()
+    except ObjectDoesNotExist:
+        raise Http404
     if not isinstance(page, Page):
         raise Http404
     if not page.permissions_for_user(request.user).can_edit():

--- a/springfield/cms/admin_views.py
+++ b/springfield/cms/admin_views.py
@@ -67,7 +67,7 @@ def create_translation_sharing_link(request, translation_id):
         raise PermissionDenied
 
     deleted_count = delete_dead_sharing_revisions(page)
-    logger.info("%d expired link revisions(s) deleted for translation page ID=%d", deleted_count, page.pk)
+    logger.info("%d expired link revision(s) deleted for translation page ID=%d", deleted_count, page.pk)
 
     link = reusable_sharing_link(translation, page)
     if link is None:

--- a/springfield/cms/admin_views.py
+++ b/springfield/cms/admin_views.py
@@ -1,15 +1,23 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import logging
 
-
-from django.http import JsonResponse
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.decorators.http import require_POST
 
 from wagtail.admin.views.pages.listing import IndexView
 from wagtail.admin.views.tags import TAGS_AUTOCOMPLETE_LIMIT
-from wagtail.models import Locale
+from wagtail.models import Locale, Page
+from wagtail_localize.models import Translation
+from wagtaildraftsharing.models import WagtaildraftsharingLink
 
+from springfield.cms.draftsharing import create_detached_revision, delete_dead_sharing_revisions, reusable_sharing_link
 from springfield.cms.models import BlogTag
+
+logger = logging.getLogger(__name__)
 
 
 class ContentSearchView(IndexView):
@@ -42,3 +50,28 @@ def blog_tag_autocomplete(request):
         .values_list("name", flat=True)[:TAGS_AUTOCOMPLETE_LIMIT]
     )
     return JsonResponse(list(names), safe=False)
+
+
+@require_POST
+def create_translation_sharing_link(request, translation_id):
+    """Returns a draft-sharing URL for a translated page's unpublished translation.
+
+    Reuses an existing link when the translation has not changed since it was made,
+    and cleans up revisions for this page's expired links.
+    """
+    translation = get_object_or_404(Translation, id=translation_id)
+    page = translation.get_target_instance()
+    if not isinstance(page, Page):
+        raise Http404
+    if not page.permissions_for_user(request.user).can_edit():
+        raise PermissionDenied
+
+    deleted_count = delete_dead_sharing_revisions(page)
+    logger.info("%d expired link revisions(s) deleted for translation page ID=%d", deleted_count, page.pk)
+
+    link = reusable_sharing_link(translation, page)
+    if link is None:
+        revision = create_detached_revision(translation, page, request.user)
+        link = WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=request.user)
+
+    return JsonResponse({"url": link.url})

--- a/springfield/cms/admin_views.py
+++ b/springfield/cms/admin_views.py
@@ -4,6 +4,7 @@
 import logging
 
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.db import transaction
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST
@@ -14,7 +15,7 @@ from wagtail.models import Locale, Page
 from wagtail_localize.models import Translation
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 
-from springfield.cms.draftsharing import create_detached_revision, delete_dead_sharing_revisions, reusable_sharing_link
+from springfield.cms.draftsharing import create_detached_revision, delete_dead_sharing_revisions
 from springfield.cms.models import BlogTag
 
 logger = logging.getLogger(__name__)
@@ -55,9 +56,7 @@ def blog_tag_autocomplete(request):
 @require_POST
 def create_translation_sharing_link(request, translation_id):
     """Returns a draft-sharing URL for a translated page's unpublished translation.
-
-    Reuses an existing link when the translation has not changed since it was made,
-    and cleans up revisions for this page's expired links.
+    Also cleans up revisions for this page's expired links.
     """
     translation = get_object_or_404(Translation, id=translation_id)
     try:
@@ -70,10 +69,10 @@ def create_translation_sharing_link(request, translation_id):
         raise PermissionDenied
 
     deleted_count = delete_dead_sharing_revisions(page)
-    logger.info("%d expired link revision(s) deleted for translation page ID=%d", deleted_count, page.pk)
+    if deleted_count:
+        logger.info("%d expired link revision(s) deleted for translation page ID=%d", deleted_count, page.pk)
 
-    link = reusable_sharing_link(translation, page)
-    if link is None:
+    with transaction.atomic():
         revision = create_detached_revision(translation, page, request.user)
         link = WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=request.user)
 

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -39,11 +39,16 @@ def create_detached_revision(translation, page, user):
     )
 
 
-def latest_translation_edit(translation):
+def latest_translation_content_change(translation):
     """When this `translation`'s content was last changed, or None.
 
-    Covers both translated strings and segment overrides. Rows flagged with an error
-    are excluded: a failed publish updates their timestamp, but they are not rendered.
+    Covers:
+    - translated strings
+    - segment overrides
+    - source page (fills any segment that is not translated)
+
+    Rows flagged with an error are excluded: a failed publish updates their timestamp,
+    but they are not rendered.
     """
     context_ids = StringSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
     latest_updates = [
@@ -57,8 +62,19 @@ def latest_translation_edit(translation):
             context_id__in=context_ids,
             has_error=False,
         ).aggregate(latest=Max("updated_at"))["latest"],
+        translation.source.last_updated_at,
     ]
     return max([latest_update for latest_update in latest_updates if latest_update], default=None)
+
+
+# def latest_shareable_content_change(translation):
+#     """When the content for `translation` last changed.
+#
+#     Covers both the translated strings and the source page, whose text fills any segment
+#     that is not translated.
+#     """
+#     changes = [translation.source.last_updated_at, latest_translation_edit(translation)]
+#     return max(change for change in changes if change is not None)
 
 
 def _links_for_page(page):
@@ -77,13 +93,12 @@ def reusable_sharing_link(translation, page):
 
     Allows repeated shares to return the same link instead of creating a duplicate revision.
     """
-    active_links_for_page = _active_links_for_page(page).order_by("-revision__created_at")
-
-    latest_edit = latest_translation_edit(translation)
-    if latest_edit is not None:
-        active_links_for_page = active_links_for_page.filter(revision__created_at__gte=latest_edit)
-
-    return active_links_for_page.first()
+    return (
+        _active_links_for_page(page)
+        .filter(revision__created_at__gte=latest_translation_content_change(translation))
+        .order_by("-revision__created_at")
+        .first()
+    )
 
 
 def delete_dead_sharing_revisions(page):
@@ -116,7 +131,7 @@ def has_shareable_translation_draft(translation, page):
     if page.last_published_at is None:
         return True
 
-    latest_edit = latest_translation_edit(translation)
-    if latest_edit is None:
+    latest_content_change = latest_translation_content_change(translation)
+    if latest_content_change is None:
         return False
-    return latest_edit > page.last_published_at
+    return latest_content_change > page.last_published_at

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -9,11 +9,12 @@
 # These helpers create revisions for the pending translation that exists solely to be
 # shared, without altering the page itself.
 
+from datetime import timedelta
+
 from django.db import transaction
-from django.db.models import Max, Q
+from django.db.models import Q
 
 from wagtail.models import Revision
-from wagtail_localize.models import OverridableSegment, SegmentOverride, StringSegment, StringTranslation
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 from wagtaildraftsharing.utils import tz_aware_utc_now
 
@@ -33,12 +34,15 @@ def create_detached_revision(translation, page, user):
         fallback=True,
     )
     specific_page = page.specific
+    latest_revision_created_at = page.latest_revision.created_at if page.latest_revision else tz_aware_utc_now()
     return Revision.objects.create(
         content_object=specific_page,
         base_content_type=specific_page.get_base_content_type(),
         user=user,
         content=pending.serializable_data(),
         object_str=f"{SHARE_REVISION_PREFIX} {pending}",
+        # Ensure this revision is never the official latest revision
+        created_at=latest_revision_created_at - timedelta(seconds=1),
     )
 
 
@@ -80,41 +84,20 @@ def delete_dead_sharing_revisions(page):
     return len(revisions_to_delete)
 
 
-def latest_translation_content_change(translation):
-    """When this `translation`'s content was last changed, or None.
-
-    Covers:
-    - translated strings
-    - segment overrides
-    - source page (fills any segment that is not translated)
-
-    Rows flagged with an error are excluded: a failed publish updates their timestamp,
-    but they are not rendered.
-    """
-    string_context_ids = StringSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
-    override_context_ids = OverridableSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
-    latest_updates = [
-        StringTranslation.objects.filter(
-            locale_id=translation.target_locale_id,
-            context_id__in=string_context_ids,
-            has_error=False,
-        ).aggregate(latest=Max("updated_at"))["latest"],
-        SegmentOverride.objects.filter(
-            locale_id=translation.target_locale_id,
-            context_id__in=override_context_ids,
-            has_error=False,
-        ).aggregate(latest=Max("updated_at"))["latest"],
-        translation.source.last_updated_at,
-    ]
-    return max(latest_update for latest_update in latest_updates if latest_update)
+def _shareable_content(instance):
+    # The ephemeral instance rebuilds `slug` from the source page (as a `SynchronizedField`) but `wagtail-localize`
+    # makes the saved page's slug unique via `find_available_slug()`, so the two will always disagree. Ignore it.
+    return {k: v for k, v in instance.serializable_data().items() if k != "slug"}
 
 
 def has_shareable_translation_draft(translation, page):
-    """Whether this translated page holds content that has not been published yet."""
+    """Whether this translated page has content different from what is published."""
     if not page.live:
         return True
     if page.last_published_at is None:
         return True
 
-    latest_content_change = latest_translation_content_change(translation)
-    return latest_content_change > page.last_published_at
+    # Compare content directly to handle complexity of string translations, segment overrides,
+    # errors, and source page fallback.
+    pending = translation.source.get_ephemeral_translated_instance(translation.target_locale, fallback=True)
+    return _shareable_content(pending) != _shareable_content(page.specific)

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -82,22 +82,3 @@ def delete_dead_sharing_revisions(page):
             # Revision has a custom `delete` method
             revision.delete()
     return len(revisions_to_delete)
-
-
-def _shareable_content(instance):
-    # The ephemeral instance rebuilds `slug` from the source page (as a `SynchronizedField`) but `wagtail-localize`
-    # makes the saved page's slug unique via `find_available_slug()`, so the two will always disagree. Ignore it.
-    return {k: v for k, v in instance.serializable_data().items() if k != "slug"}
-
-
-def has_shareable_translation_draft(translation, page):
-    """Whether this translated page has content different from what is published."""
-    if not page.live:
-        return True
-    if page.last_published_at is None:
-        return True
-
-    # Compare content directly to handle complexity of string translations, segment overrides,
-    # errors, and source page fallback.
-    pending = translation.source.get_ephemeral_translated_instance(translation.target_locale, fallback=True)
-    return _shareable_content(pending) != _shareable_content(page.specific)

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -17,6 +17,9 @@ from wagtail_localize.models import SegmentOverride, StringSegment, StringTransl
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 from wagtaildraftsharing.utils import tz_aware_utc_now
 
+# Marker on `Revision.object_str` for revisions created solely for draft sharing
+SHARE_REVISION_PREFIX = "[draft-sharing]"
+
 
 def create_detached_revision(translation, page, user):
     """Create a revision for the pending translation that is not the page's latest.
@@ -26,7 +29,7 @@ def create_detached_revision(translation, page, user):
     """
     pending = translation.source.get_ephemeral_translated_instance(
         translation.target_locale,
-        # Untranslated strings will fallback to the original page's text
+        # Untranslated strings will fall back to the original page's text
         fallback=True,
     )
     specific_page = page.specific
@@ -35,7 +38,7 @@ def create_detached_revision(translation, page, user):
         base_content_type=specific_page.get_base_content_type(),
         user=user,
         content=pending.serializable_data(),
-        object_str=str(pending),
+        object_str=f"{SHARE_REVISION_PREFIX} {pending}",
     )
 
 
@@ -65,16 +68,6 @@ def latest_translation_content_change(translation):
         translation.source.last_updated_at,
     ]
     return max([latest_update for latest_update in latest_updates if latest_update], default=None)
-
-
-# def latest_shareable_content_change(translation):
-#     """When the content for `translation` last changed.
-#
-#     Covers both the translated strings and the source page, whose text fills any segment
-#     that is not translated.
-#     """
-#     changes = [translation.source.last_updated_at, latest_translation_edit(translation)]
-#     return max(change for change in changes if change is not None)
 
 
 def _links_for_page(page):
@@ -112,7 +105,11 @@ def delete_dead_sharing_revisions(page):
     active_revision_ids = _active_links_for_page(page).values_list("revision_id", flat=True)
 
     revisions_to_delete = (
-        Revision.objects.for_instance(page).filter(id__in=linked_revision_ids).exclude(id__in=active_revision_ids).exclude(id__in=protected_ids)
+        Revision.objects.for_instance(page)
+        .filter(object_str__startswith=SHARE_REVISION_PREFIX)
+        .filter(id__in=linked_revision_ids)
+        .exclude(id__in=active_revision_ids)
+        .exclude(id__in=protected_ids)
     )
     if not revisions_to_delete:
         return 0

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -1,0 +1,100 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Draft sharing for translated pages.
+#
+# wagtail-localize does not create draft revision for pages as its translations change,
+# so `wagtaildraftsharing` cannot natively create sharing links for translated pages.
+# These helpers create revisions for the pending translation that exists solely to be
+# shared, without altering the page itself.
+
+from django.db.models import Max, Q
+
+from wagtail.models import Revision
+from wagtail_localize.models import SegmentOverride, StringSegment, StringTranslation
+from wagtaildraftsharing.models import WagtaildraftsharingLink
+from wagtaildraftsharing.utils import tz_aware_utc_now
+
+
+def create_detached_revision(translation, page, user):
+    """Create a revision for the pending translation that is not the page's latest.
+
+    The revision exists only so a sharing link has something to point at. Nothing
+    about the live page changes.
+    """
+    pending = translation.source.get_ephemeral_translated_instance(
+        translation.target_locale,
+        # Untranslated strings will fallback to the original page's text
+        fallback=True,
+    )
+    specific_page = page.specific
+    return Revision.objects.create(
+        content_object=specific_page,
+        base_content_type=specific_page.get_base_content_type(),
+        user=user,
+        content=pending.serializable_data(),
+        object_str=str(pending),
+    )
+
+
+def latest_translation_edit(translation):
+    """When this `translation`'s content was last changed, or None.
+
+    Covers both translated strings and segment overrides. Rows flagged with an error
+    are excluded: a failed publish updates their timestamp, but they are not rendered.
+    """
+    context_ids = StringSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
+    latest_updates = [
+        StringTranslation.objects.filter(
+            locale_id=translation.target_locale_id,
+            context_id__in=context_ids,
+            has_error=False,
+        ).aggregate(latest=Max("updated_at"))["latest"],
+        SegmentOverride.objects.filter(
+            locale_id=translation.target_locale_id,
+            context_id__in=context_ids,
+            has_error=False,
+        ).aggregate(latest=Max("updated_at"))["latest"],
+    ]
+    return max([latest_update for latest_update in latest_updates if latest_update], default=None)
+
+
+def _links_for_page(page):
+    """All sharing links for `page`'s revisions."""
+    return WagtaildraftsharingLink.objects.filter(revision__in=Revision.objects.for_instance(page))
+
+
+def _active_links_for_page(page):
+    """Active sharing links for `page`."""
+    now = tz_aware_utc_now()
+    return _links_for_page(page).filter(is_active=True).filter(Q(active_until__isnull=True) | Q(active_until__gt=now))
+
+
+def reusable_sharing_link(translation, page):
+    """An existing link whose revision already contains the current translation, or None.
+
+    Allows repeated shares to return the same link instead of creating a duplicate revision.
+    """
+    active_links_for_page = _active_links_for_page(page).order_by("-revision__created_at")
+
+    latest_edit = latest_translation_edit(translation)
+    if latest_edit is not None:
+        active_links_for_page = active_links_for_page.filter(revision__created_at__gte=latest_edit)
+
+    return active_links_for_page.first()
+
+
+def delete_dead_sharing_revisions(page):
+    """Delete `page`'s revisions used solely by now-inactive sharing links. Returns
+    the number of deleted revisions.
+
+    Deleting the revision cascades to its links.
+    """
+    protected_ids = [pk for pk in (page.latest_revision_id, page.live_revision_id) if pk]
+    linked_revision_ids = _links_for_page(page).values_list("revision_id", flat=True)
+    active_revision_ids = _active_links_for_page(page).values_list("revision_id", flat=True)
+
+    dead = Revision.objects.for_instance(page).filter(id__in=linked_revision_ids).exclude(id__in=active_revision_ids).exclude(id__in=protected_ids)
+    deleted_count, __ = dead.delete()
+    return deleted_count

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -46,17 +46,6 @@ def create_detached_revision(translation, page, user):
     )
 
 
-def _links_for_page(page):
-    """All sharing links for `page`'s revisions."""
-    return WagtaildraftsharingLink.objects.filter(revision__in=Revision.objects.for_instance(page))
-
-
-def _active_links_for_page(page):
-    """Active sharing links for `page`."""
-    now = tz_aware_utc_now()
-    return _links_for_page(page).filter(is_active=True).filter(Q(active_until__isnull=True) | Q(active_until__gt=now))
-
-
 def delete_dead_sharing_revisions(page):
     """Delete `page`'s revisions used solely by now-inactive sharing links. Returns
     the number of deleted revisions.
@@ -64,13 +53,17 @@ def delete_dead_sharing_revisions(page):
     Deleting the revision cascades to its links.
     """
     protected_ids = [pk for pk in (page.latest_revision_id, page.live_revision_id) if pk]
-    linked_revision_ids = _links_for_page(page).values_list("revision_id", flat=True)
-    active_revision_ids = _active_links_for_page(page).values_list("revision_id", flat=True)
+    now = tz_aware_utc_now()
+    active_revision_ids = (
+        WagtaildraftsharingLink.objects.filter(revision__in=Revision.objects.for_instance(page))
+        .filter(is_active=True)
+        .filter(Q(active_until__isnull=True) | Q(active_until__gt=now))
+        .values_list("revision_id", flat=True)
+    )
 
     revisions_to_delete = (
         Revision.objects.for_instance(page)
         .filter(object_str__startswith=SHARE_REVISION_PREFIX)
-        .filter(id__in=linked_revision_ids)
         .exclude(id__in=active_revision_ids)
         .exclude(id__in=protected_ids)
     )

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -9,6 +9,7 @@
 # These helpers create revisions for the pending translation that exists solely to be
 # shared, without altering the page itself.
 
+from django.db import transaction
 from django.db.models import Max, Q
 
 from wagtail.models import Revision
@@ -95,9 +96,17 @@ def delete_dead_sharing_revisions(page):
     linked_revision_ids = _links_for_page(page).values_list("revision_id", flat=True)
     active_revision_ids = _active_links_for_page(page).values_list("revision_id", flat=True)
 
-    dead = Revision.objects.for_instance(page).filter(id__in=linked_revision_ids).exclude(id__in=active_revision_ids).exclude(id__in=protected_ids)
-    deleted_count, __ = dead.delete()
-    return deleted_count
+    revisions_to_delete = (
+        Revision.objects.for_instance(page).filter(id__in=linked_revision_ids).exclude(id__in=active_revision_ids).exclude(id__in=protected_ids)
+    )
+    if not revisions_to_delete:
+        return 0
+
+    with transaction.atomic():
+        for revision in revisions_to_delete:
+            # Revision has a custom `delete` method
+            revision.delete()
+    return len(revisions_to_delete)
 
 
 def has_shareable_translation_draft(translation, page):

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -13,7 +13,7 @@ from django.db import transaction
 from django.db.models import Max, Q
 
 from wagtail.models import Revision
-from wagtail_localize.models import SegmentOverride, StringSegment, StringTranslation
+from wagtail_localize.models import OverridableSegment, SegmentOverride, StringSegment, StringTranslation
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 from wagtaildraftsharing.utils import tz_aware_utc_now
 
@@ -42,34 +42,6 @@ def create_detached_revision(translation, page, user):
     )
 
 
-def latest_translation_content_change(translation):
-    """When this `translation`'s content was last changed, or None.
-
-    Covers:
-    - translated strings
-    - segment overrides
-    - source page (fills any segment that is not translated)
-
-    Rows flagged with an error are excluded: a failed publish updates their timestamp,
-    but they are not rendered.
-    """
-    context_ids = StringSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
-    latest_updates = [
-        StringTranslation.objects.filter(
-            locale_id=translation.target_locale_id,
-            context_id__in=context_ids,
-            has_error=False,
-        ).aggregate(latest=Max("updated_at"))["latest"],
-        SegmentOverride.objects.filter(
-            locale_id=translation.target_locale_id,
-            context_id__in=context_ids,
-            has_error=False,
-        ).aggregate(latest=Max("updated_at"))["latest"],
-        translation.source.last_updated_at,
-    ]
-    return max([latest_update for latest_update in latest_updates if latest_update], default=None)
-
-
 def _links_for_page(page):
     """All sharing links for `page`'s revisions."""
     return WagtaildraftsharingLink.objects.filter(revision__in=Revision.objects.for_instance(page))
@@ -79,19 +51,6 @@ def _active_links_for_page(page):
     """Active sharing links for `page`."""
     now = tz_aware_utc_now()
     return _links_for_page(page).filter(is_active=True).filter(Q(active_until__isnull=True) | Q(active_until__gt=now))
-
-
-def reusable_sharing_link(translation, page):
-    """An existing link whose revision already contains the current translation, or None.
-
-    Allows repeated shares to return the same link instead of creating a duplicate revision.
-    """
-    return (
-        _active_links_for_page(page)
-        .filter(revision__created_at__gte=latest_translation_content_change(translation))
-        .order_by("-revision__created_at")
-        .first()
-    )
 
 
 def delete_dead_sharing_revisions(page):
@@ -121,6 +80,35 @@ def delete_dead_sharing_revisions(page):
     return len(revisions_to_delete)
 
 
+def latest_translation_content_change(translation):
+    """When this `translation`'s content was last changed, or None.
+
+    Covers:
+    - translated strings
+    - segment overrides
+    - source page (fills any segment that is not translated)
+
+    Rows flagged with an error are excluded: a failed publish updates their timestamp,
+    but they are not rendered.
+    """
+    string_context_ids = StringSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
+    override_context_ids = OverridableSegment.objects.filter(source_id=translation.source_id).values_list("context_id", flat=True)
+    latest_updates = [
+        StringTranslation.objects.filter(
+            locale_id=translation.target_locale_id,
+            context_id__in=string_context_ids,
+            has_error=False,
+        ).aggregate(latest=Max("updated_at"))["latest"],
+        SegmentOverride.objects.filter(
+            locale_id=translation.target_locale_id,
+            context_id__in=override_context_ids,
+            has_error=False,
+        ).aggregate(latest=Max("updated_at"))["latest"],
+        translation.source.last_updated_at,
+    ]
+    return max(latest_update for latest_update in latest_updates if latest_update)
+
+
 def has_shareable_translation_draft(translation, page):
     """Whether this translated page holds content that has not been published yet."""
     if not page.live:
@@ -129,6 +117,4 @@ def has_shareable_translation_draft(translation, page):
         return True
 
     latest_content_change = latest_translation_content_change(translation)
-    if latest_content_change is None:
-        return False
     return latest_content_change > page.last_published_at

--- a/springfield/cms/draftsharing.py
+++ b/springfield/cms/draftsharing.py
@@ -98,3 +98,16 @@ def delete_dead_sharing_revisions(page):
     dead = Revision.objects.for_instance(page).filter(id__in=linked_revision_ids).exclude(id__in=active_revision_ids).exclude(id__in=protected_ids)
     deleted_count, __ = dead.delete()
     return deleted_count
+
+
+def has_shareable_translation_draft(translation, page):
+    """Whether this translated page holds content that has not been published yet."""
+    if not page.live:
+        return True
+    if page.last_published_at is None:
+        return True
+
+    latest_edit = latest_translation_edit(translation)
+    if latest_edit is None:
+        return False
+    return latest_edit > page.last_published_at

--- a/springfield/cms/templatetags/cms_draftsharing_tags.py
+++ b/springfield/cms/templatetags/cms_draftsharing_tags.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django import template
+from django.urls import reverse
+from django.utils.html import format_html
+
+from wagtail.models import Page
+from wagtaildraftsharing.wagtail_hooks import DraftsharingPageActionMenuItem
+
+from springfield.cms.draftsharing import has_shareable_translation_draft
+
+register = template.Library()
+
+
+class TranslationDraftsharingMenuItem(DraftsharingPageActionMenuItem):
+    """The `wagtaildraftsharing` action menu button for translated pages."""
+
+    template_name = "wagtaildraftsharing/translation_action_menu_item.html"
+
+    def __init__(self, translation, **kwargs):
+        super().__init__(**kwargs)
+        self.translation = translation
+
+    def get_context_data(self, parent_context):
+        context = super().get_context_data(parent_context)
+        context["create_url"] = reverse("cms_translation_draftsharing_create", args=[self.translation.id])
+        return context
+
+
+@register.simple_tag(takes_context=True)
+def translation_draftsharing_button(context, translation, instance):
+    """
+    Returns the draft sharing button for a translated page inside a `<template>`
+    element. Returns an empty string when there is nothing unpublished and for
+    snippets (which share this editor but have no page to share).
+
+    The translation editor's action menu is rendered by React, so the button is moved
+    into place by `wagtailadmin-translation-draftsharing.es6.js`.
+    """
+    if not isinstance(instance, Page):
+        return ""
+    if not has_shareable_translation_draft(translation, instance):
+        return ""
+
+    menu_item = TranslationDraftsharingMenuItem(translation=translation)
+    button = menu_item.render_html({"request": context["request"], "page": instance})
+    return format_html('<template id="translation-draftsharing-button">{}</template>', button)

--- a/springfield/cms/templatetags/cms_draftsharing_tags.py
+++ b/springfield/cms/templatetags/cms_draftsharing_tags.py
@@ -9,8 +9,6 @@ from django.utils.html import format_html
 from wagtail.models import Page
 from wagtaildraftsharing.wagtail_hooks import DraftsharingPageActionMenuItem
 
-from springfield.cms.draftsharing import has_shareable_translation_draft
-
 register = template.Library()
 
 
@@ -33,15 +31,13 @@ class TranslationDraftsharingMenuItem(DraftsharingPageActionMenuItem):
 def translation_draftsharing_button(context, translation, instance):
     """
     Returns the draft sharing button for a translated page inside a `<template>`
-    element. Returns an empty string when there is nothing unpublished and for
-    snippets (which share this editor but have no page to share).
+    element. Returns an empty string for snippets (which share this editor but have
+    no page to share).
 
     The translation editor's action menu is rendered by React, so the button is moved
     into place by `wagtailadmin-translation-draftsharing.es6.js`.
     """
     if not isinstance(instance, Page):
-        return ""
-    if not has_shareable_translation_draft(translation, instance):
         return ""
 
     menu_item = TranslationDraftsharingMenuItem(translation=translation)

--- a/springfield/cms/tests/conftest.py
+++ b/springfield/cms/tests/conftest.py
@@ -1,13 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 
 import pytest
 import wagtail_factories
-from wagtail.models import Locale, Page, Site
+from wagtail.models import Locale, Page, Revision, Site
+from wagtail_localize.models import StringSegment, StringTranslation, Translation, TranslationSource
 
 from springfield.cms.blocks import DownloadFirefoxButtonBlock
 from springfield.cms.fixtures.base_fixtures import get_flare_docs_index_page, get_placeholder_images
@@ -385,6 +387,51 @@ def site_with_en_de_fr_it_homepages_and_some_translations(site_with_en_de_fr_it_
     it_translation = fr_page.copy_for_translation(it_locale)
     it_translation.title = "Italian Translation"
     it_translation.save_revision().publish()
+
+
+@pytest.fixture
+def translated_page(minimal_site):
+    """
+    An en-US page translated into French, published, with no edits since publication.
+    """
+    source_page = SimpleRichTextPageFactory(
+        title="Switch to Firefox",
+        slug="switch-to-firefox",
+        parent=minimal_site.root_page,
+    )
+    locale = Locale.objects.get(language_code="fr")
+
+    source, _ = TranslationSource.get_or_create_from_instance(source_page)
+    translation = Translation.objects.create(source=source, target_locale=locale, enabled=True)
+    translation.save_target(publish=True)
+
+    # Publish target revision explicitly because save_target() publishes on transaction commit
+    page = translation.get_target_instance()
+    Revision.objects.for_instance(page).order_by("-created_at").first().publish()
+    page.refresh_from_db()
+
+    return SimpleNamespace(source_page=source_page, page=page, translation=translation, locale=locale)
+
+
+@pytest.fixture
+def translated_page_with_pending_edit(translated_page):
+    """
+    A translated page whose translation memory has been edited since publication.
+    """
+    segment = StringSegment.objects.filter(source=translated_page.translation.source).first()
+    StringTranslation.objects.update_or_create(
+        translation_of_id=segment.string_id,
+        locale=translated_page.locale,
+        context_id=segment.context_id,
+        defaults={
+            "data": "Passer à Firefox",
+            "translation_type": StringTranslation.TRANSLATION_TYPE_MANUAL,
+            "tool_name": "",
+            "has_error": False,
+            "field_error": "",
+        },
+    )
+    return translated_page
 
 
 @pytest.fixture

--- a/springfield/cms/tests/test_translation_draftsharing_button.py
+++ b/springfield/cms/tests/test_translation_draftsharing_button.py
@@ -7,98 +7,33 @@ from django.urls import reverse
 import pytest
 from pytest_django.asserts import assertInHTML
 from wagtail.models import Locale
-from wagtail_localize.models import StringTranslation, Translation, TranslationSource
+from wagtail_localize.models import Translation, TranslationSource
 
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture
-def get_edit_page_html(admin_client):
+def test_shown_in_translation_edit_view(admin_client, translated_page):
+    create_share_url = reverse("cms_translation_draftsharing_create", args=[translated_page.translation.pk])
+    expected_button_html = f"""
+    <template id="translation-draftsharing-button">
+        <button type="button"
+                class="button"
+                data-translation-draftsharing
+                data-url="{create_share_url}">
+            <svg class="icon icon-view icon" aria-hidden="true">
+                <use href="#icon-view"></use>
+            </svg>
+            Create draft sharing link
+        </button>
+    </template>
+    """
+    edit_url = reverse("wagtailadmin_pages:edit", args=[translated_page.page.id])
 
-    def _get_edit_page_html(page):
-        url = reverse("wagtailadmin_pages:edit", args=[page.id])
+    response = admin_client.get(edit_url)
 
-        response = admin_client.get(url)
-
-        assert response.status_code == 200
-        return response.content.decode()
-
-    return _get_edit_page_html
-
-
-@pytest.fixture
-def assert_button_in_page(get_edit_page_html):
-
-    def _assert_button_in_page(page, translation):
-        create_share_url = reverse("cms_translation_draftsharing_create", args=[translation.pk])
-        expected_button_html = f"""
-        <template id="translation-draftsharing-button">
-            <button type="button"
-                    class="button"
-                    data-translation-draftsharing
-                    data-url="{create_share_url}">
-                <svg class="icon icon-view icon" aria-hidden="true">
-                    <use href="#icon-view"></use>
-                </svg>
-                Create draft sharing link
-            </button>
-        </template>
-        """
-
-        page_html = get_edit_page_html(page)
-
-        assertInHTML(expected_button_html, page_html)
-
-    return _assert_button_in_page
-
-
-@pytest.fixture
-def assert_button_not_in_page(get_edit_page_html):
-
-    def _assert_button_not_in_page(page):
-        page_html = get_edit_page_html(page)
-
-        assert "translation-draftsharing-button" not in page_html
-
-    return _assert_button_not_in_page
-
-
-def test_shown_when_a_translation_edit_is_unpublished(assert_button_in_page, translated_page_with_pending_edit):
-    assert_button_in_page(translated_page_with_pending_edit.page, translated_page_with_pending_edit.translation)
-
-
-def test_shown_when_the_page_is_not_live(assert_button_in_page, translated_page):
-    translated_page.page.live = False
-    translated_page.page.save(update_fields=["live"])
-
-    assert_button_in_page(translated_page.page, translated_page.translation)
-
-
-def test_shown_when_live_but_never_published(assert_button_in_page, translated_page):
-    """Imported content can be live with no last_published_at; treat it as shareable."""
-    translated_page.page.last_published_at = None
-    translated_page.page.save(update_fields=["last_published_at"])
-
-    assert_button_in_page(translated_page.page, translated_page.translation)
-
-
-def test_shown_when_source_page_has_changed(assert_button_in_page, translated_page):
-    source_page = translated_page.source_page
-    source_page.title += "!"
-    source_page.save()
-    TranslationSource.update_or_create_from_instance(source_page)
-
-    assert_button_in_page(translated_page.page, translated_page.translation)
-
-
-def test_hidden_when_nothing_has_changed_since_publication(assert_button_not_in_page, translated_page):
-    assert_button_not_in_page(translated_page.page)
-
-
-def test_hidden_when_the_only_pending_edit_has_an_error(assert_button_not_in_page, translated_page_with_pending_edit):
-    StringTranslation.objects.filter(locale=translated_page_with_pending_edit.locale).update(has_error=True)
-
-    assert_button_not_in_page(translated_page_with_pending_edit.page)
+    assert response.status_code == 200
+    page_html = response.content.decode()
+    assertInHTML(expected_button_html, page_html)
 
 
 def test_button_not_rendered_in_translated_snippet_editor(admin_client, pretranslated_phrase_snippet):

--- a/springfield/cms/tests/test_translation_draftsharing_button.py
+++ b/springfield/cms/tests/test_translation_draftsharing_button.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 import pytest
 from pytest_django.asserts import assertInHTML
 from wagtail.models import Locale
-from wagtail_localize.models import OverridableSegment, SegmentOverride, StringTranslation, Translation, TranslationSource
+from wagtail_localize.models import StringTranslation, Translation, TranslationSource
 
 pytestmark = pytest.mark.django_db
 
@@ -78,18 +78,6 @@ def test_shown_when_live_but_never_published(assert_button_in_page, translated_p
     """Imported content can be live with no last_published_at; treat it as shareable."""
     translated_page.page.last_published_at = None
     translated_page.page.save(update_fields=["last_published_at"])
-
-    assert_button_in_page(translated_page.page, translated_page.translation)
-
-
-def test_shown_when_a_segment_override_is_pending(assert_button_in_page, translated_page):
-    segment = OverridableSegment.objects.filter(source=translated_page.translation.source).first()
-    SegmentOverride.objects.create(
-        locale=translated_page.locale,
-        context=segment.context,
-        data_json='"overridden"',
-        has_error=False,
-    )
 
     assert_button_in_page(translated_page.page, translated_page.translation)
 

--- a/springfield/cms/tests/test_translation_draftsharing_button.py
+++ b/springfield/cms/tests/test_translation_draftsharing_button.py
@@ -1,0 +1,132 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.urls import reverse
+
+import pytest
+from pytest_django.asserts import assertInHTML
+from wagtail.models import Locale
+from wagtail_localize.models import SegmentOverride, StringSegment, StringTranslation, Translation, TranslationSource
+
+from springfield.cms.tests.factories import WagtailUserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def editor():
+    return WagtailUserFactory(is_superuser=True)
+
+
+@pytest.fixture
+def get_edit_page_html(client, editor):
+
+    def _get_edit_page_html(page):
+        url = reverse("wagtailadmin_pages:edit", args=[page.id])
+        client.force_login(editor)
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        return response.content.decode()
+
+    return _get_edit_page_html
+
+
+@pytest.fixture
+def assert_button_in_page(get_edit_page_html):
+
+    def _assert_button_in_page(page, translation):
+        create_share_url = reverse("cms_translation_draftsharing_create", args=[translation.pk])
+        expected_button_html = f"""
+        <template id="translation-draftsharing-button">
+            <button type="button"
+                    class="button"
+                    data-translation-draftsharing
+                    data-url="{create_share_url}">
+                <svg class="icon icon-view icon" aria-hidden="true">
+                    <use href="#icon-view"></use>
+                </svg>
+                Create draft sharing link
+            </button>
+        </template>
+        """
+
+        page_html = get_edit_page_html(page)
+
+        assertInHTML(expected_button_html, page_html)
+
+    return _assert_button_in_page
+
+
+@pytest.fixture
+def assert_button_not_in_page(get_edit_page_html):
+
+    def _assert_button_not_in_page(page):
+        page_html = get_edit_page_html(page)
+
+        assert "translation-draftsharing-button" not in page_html
+
+    return _assert_button_not_in_page
+
+
+def test_shown_when_a_translation_edit_is_unpublished(assert_button_in_page, translated_page_with_pending_edit):
+    assert_button_in_page(translated_page_with_pending_edit.page, translated_page_with_pending_edit.translation)
+
+
+def test_shown_when_the_page_is_not_live(assert_button_in_page, translated_page):
+    translated_page.page.live = False
+    translated_page.page.save(update_fields=["live"])
+
+    assert_button_in_page(translated_page.page, translated_page.translation)
+
+
+def test_shown_when_live_but_never_published(assert_button_in_page, translated_page):
+    """Imported content can be live with no last_published_at; treat it as shareable."""
+    translated_page.page.last_published_at = None
+    translated_page.page.save(update_fields=["last_published_at"])
+
+    assert_button_in_page(translated_page.page, translated_page.translation)
+
+
+def test_shown_when_a_segment_override_is_pending(assert_button_in_page, translated_page):
+    segment = StringSegment.objects.filter(source=translated_page.translation.source).first()
+    SegmentOverride.objects.create(
+        locale=translated_page.locale,
+        context=segment.context,
+        data_json='"overridden"',
+        has_error=False,
+    )
+
+    assert_button_in_page(translated_page.page, translated_page.translation)
+
+
+def test_hidden_when_nothing_has_changed_since_publication(assert_button_not_in_page, translated_page):
+    assert_button_not_in_page(translated_page.page)
+
+
+def test_hidden_when_the_only_pending_edit_has_an_error(assert_button_not_in_page, translated_page_with_pending_edit):
+    StringTranslation.objects.filter(locale=translated_page_with_pending_edit.locale).update(has_error=True)
+
+    assert_button_not_in_page(translated_page_with_pending_edit.page)
+
+
+def test_button_not_rendered_in_translated_snippet_editor(client, pretranslated_phrase_snippet, editor):
+    """edit_translation.html is shared with snippets, which have no page to share."""
+    # Create a translatable snippet with an enabled Translation for the snippet editor path
+    locale = Locale.objects.create(language_code="fr")
+    # Use copy_for_translation rather than save_target which depends on on_commit behaviour
+    translated_snippet = pretranslated_phrase_snippet.copy_for_translation(locale)
+    translated_snippet.save()
+    source, __ = TranslationSource.get_or_create_from_instance(pretranslated_phrase_snippet)
+    Translation.objects.create(source=source, target_locale=locale, enabled=True)
+
+    client.force_login(editor)
+    url = reverse("wagtailsnippets_cms_pretranslatedphrase:edit", args=[translated_snippet.pk])
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    page_html = response.content.decode()
+    assert "translation-draftsharing-button" not in page_html

--- a/springfield/cms/tests/test_translation_draftsharing_button.py
+++ b/springfield/cms/tests/test_translation_draftsharing_button.py
@@ -9,24 +9,16 @@ from pytest_django.asserts import assertInHTML
 from wagtail.models import Locale
 from wagtail_localize.models import SegmentOverride, StringSegment, StringTranslation, Translation, TranslationSource
 
-from springfield.cms.tests.factories import WagtailUserFactory
-
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def editor():
-    return WagtailUserFactory(is_superuser=True)
-
-
-@pytest.fixture
-def get_edit_page_html(client, editor):
+def get_edit_page_html(admin_client):
 
     def _get_edit_page_html(page):
         url = reverse("wagtailadmin_pages:edit", args=[page.id])
-        client.force_login(editor)
 
-        response = client.get(url)
+        response = admin_client.get(url)
 
         assert response.status_code == 200
         return response.content.decode()
@@ -112,7 +104,7 @@ def test_hidden_when_the_only_pending_edit_has_an_error(assert_button_not_in_pag
     assert_button_not_in_page(translated_page_with_pending_edit.page)
 
 
-def test_button_not_rendered_in_translated_snippet_editor(client, pretranslated_phrase_snippet, editor):
+def test_button_not_rendered_in_translated_snippet_editor(admin_client, pretranslated_phrase_snippet):
     """edit_translation.html is shared with snippets, which have no page to share."""
     # Create a translatable snippet with an enabled Translation for the snippet editor path
     locale = Locale.objects.create(language_code="fr")
@@ -122,10 +114,9 @@ def test_button_not_rendered_in_translated_snippet_editor(client, pretranslated_
     source, __ = TranslationSource.get_or_create_from_instance(pretranslated_phrase_snippet)
     Translation.objects.create(source=source, target_locale=locale, enabled=True)
 
-    client.force_login(editor)
     url = reverse("wagtailsnippets_cms_pretranslatedphrase:edit", args=[translated_snippet.pk])
 
-    response = client.get(url)
+    response = admin_client.get(url)
 
     assert response.status_code == 200
     page_html = response.content.decode()

--- a/springfield/cms/tests/test_translation_draftsharing_button.py
+++ b/springfield/cms/tests/test_translation_draftsharing_button.py
@@ -94,6 +94,15 @@ def test_shown_when_a_segment_override_is_pending(assert_button_in_page, transla
     assert_button_in_page(translated_page.page, translated_page.translation)
 
 
+def test_shown_when_source_page_has_changed(assert_button_in_page, translated_page):
+    source_page = translated_page.source_page
+    source_page.title += "!"
+    source_page.save()
+    TranslationSource.update_or_create_from_instance(source_page)
+
+    assert_button_in_page(translated_page.page, translated_page.translation)
+
+
 def test_hidden_when_nothing_has_changed_since_publication(assert_button_not_in_page, translated_page):
     assert_button_not_in_page(translated_page.page)
 

--- a/springfield/cms/tests/test_translation_draftsharing_button.py
+++ b/springfield/cms/tests/test_translation_draftsharing_button.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 import pytest
 from pytest_django.asserts import assertInHTML
 from wagtail.models import Locale
-from wagtail_localize.models import SegmentOverride, StringSegment, StringTranslation, Translation, TranslationSource
+from wagtail_localize.models import OverridableSegment, SegmentOverride, StringTranslation, Translation, TranslationSource
 
 pytestmark = pytest.mark.django_db
 
@@ -83,7 +83,7 @@ def test_shown_when_live_but_never_published(assert_button_in_page, translated_p
 
 
 def test_shown_when_a_segment_override_is_pending(assert_button_in_page, translated_page):
-    segment = StringSegment.objects.filter(source=translated_page.translation.source).first()
+    segment = OverridableSegment.objects.filter(source=translated_page.translation.source).first()
     SegmentOverride.objects.create(
         locale=translated_page.locale,
         context=segment.context,

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -176,6 +176,18 @@ def test_deletes_revision_whose_only_link_is_inactive(existing_sharing_link, pos
         existing_sharing_link.refresh_from_db()
 
 
+def test_deletes_revision_with_no_links(existing_sharing_link, post):
+    """If the link is deleted, then the revision should still be cleaned up."""
+    revision_with_expired_link = existing_sharing_link.revision
+    existing_sharing_link.delete()
+
+    response = post()
+
+    assert response.status_code == 200
+    with pytest.raises(Revision.DoesNotExist):
+        revision_with_expired_link.refresh_from_db()
+
+
 def test_does_not_delete_revision_with_one_active_link(editor, existing_sharing_link, post, translated_page_with_pending_edit):
     revision = existing_sharing_link.revision
     expired_sharing_link = WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=editor)

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -6,6 +6,7 @@
 
 from datetime import timedelta
 
+from django.contrib.auth.models import Group, Permission
 from django.urls import reverse
 from django.utils import timezone
 
@@ -56,13 +57,16 @@ def test_anonymous_user_not_permitted(client, translated_page_with_pending_edit,
 
 
 def test_user_without_edit_permission_not_permitted(admin_client, translated_page_with_pending_edit, url):
-    no_access = WagtailUserFactory(username="no-access", is_superuser=False)
-    admin_client.force_login(no_access, backend="django.contrib.auth.backends.ModelBackend")
+    no_edit_perm = WagtailUserFactory(username="admin-only")
+    admin_only = Group.objects.create(name="Admin access only")
+    admin_only.permissions.add(Permission.objects.get(content_type__app_label="wagtailadmin", codename="access_admin"))
+    no_edit_perm.groups.add(admin_only)
+    admin_client.force_login(no_edit_perm, backend="django.contrib.auth.backends.ModelBackend")
 
     response = admin_client.post(url(translated_page_with_pending_edit.translation.pk))
 
     assert response.status_code == 302
-    assert response.url.startswith("/cms-admin/login/")
+    assert response.url == "/cms-admin/"
     assert WagtaildraftsharingLink.objects.exists() is False
 
 

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -34,12 +34,11 @@ def url():
 
 
 @pytest.fixture
-def post(client, editor, translated_page_with_pending_edit, url):
+def post(admin_client, translated_page_with_pending_edit, url):
     translation_id = translated_page_with_pending_edit.translation.pk
 
     def _post():
-        client.force_login(editor)
-        return client.post(url(translation_id))
+        return admin_client.post(url(translation_id))
 
     return _post
 
@@ -56,35 +55,31 @@ def test_anonymous_user_not_permitted(client, translated_page_with_pending_edit,
     assert WagtaildraftsharingLink.objects.exists() is False
 
 
-def test_user_without_edit_permission_not_permitted(client, translated_page_with_pending_edit, url):
+def test_user_without_edit_permission_not_permitted(admin_client, translated_page_with_pending_edit, url):
     no_access = WagtailUserFactory(username="no-access", is_superuser=False)
-    client.force_login(no_access)
+    admin_client.force_login(no_access, backend="django.contrib.auth.backends.ModelBackend")
 
-    response = client.post(url(translated_page_with_pending_edit.translation.pk))
+    response = admin_client.post(url(translated_page_with_pending_edit.translation.pk))
 
     assert response.status_code == 302
     assert response.url.startswith("/cms-admin/login/")
     assert WagtaildraftsharingLink.objects.exists() is False
 
 
-def test_get_is_rejected(client, editor, translated_page_with_pending_edit, url):
-    client.force_login(editor)
-
-    response = client.get(url(translated_page_with_pending_edit.translation.pk))
+def test_get_is_rejected(admin_client, translated_page_with_pending_edit, url):
+    response = admin_client.get(url(translated_page_with_pending_edit.translation.pk))
 
     assert response.status_code == 405
 
 
-def test_unknown_translation_returns_404(client, editor, url):
-    client.force_login(editor)
-
-    response = client.post(url(999999), follow=True)
+def test_unknown_translation_returns_404(admin_client, url):
+    response = admin_client.post(url(999999), follow=True)
 
     assert response.status_code == 404
     assert WagtaildraftsharingLink.objects.exists() is False
 
 
-def test_returns_sharing_url_without_changing_page(client, post, translated_page_with_pending_edit):
+def test_returns_sharing_url_without_changing_page(admin_client, post, translated_page_with_pending_edit):
     response = post()
 
     assert response.status_code == 200
@@ -97,18 +92,18 @@ def test_returns_sharing_url_without_changing_page(client, post, translated_page
     data = response.json()
     assert data["url"] == sharing_link.url
 
-    client.logout()
+    admin_client.logout()
     unpublished_text = "Passer à Firefox"
 
     # Shared page preview shows unpublished translation
-    shared_response = client.get(sharing_link.url)
+    shared_response = admin_client.get(sharing_link.url)
 
     assert shared_response.status_code == 200
     assert shared_response["X-Robots-Tag"] == "noindex, nofollow"
     assert unpublished_text in shared_response.content.decode()
 
     # Change to public page is not published
-    public_response = client.get(translated_page_with_pending_edit.page.url)
+    public_response = admin_client.get(translated_page_with_pending_edit.page.url)
 
     assert public_response.status_code == 200
     assert unpublished_text not in public_response.content.decode()

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -106,6 +106,7 @@ def test_returns_sharing_url_without_changing_page(admin_client, post, translate
     sharing_link = WagtaildraftsharingLink.objects.get()
     revision = Revision.objects.for_instance(translated_page_with_pending_edit.page).order_by("-created_at").first()
     assert sharing_link.revision == revision
+    assert revision.object_str.startswith("[draft-sharing] ")
     expected_url = reverse("wagtaildraftsharing:view", args=[sharing_link.key])
     assert sharing_link.url == expected_url
     data = response.json()
@@ -139,7 +140,7 @@ def existing_sharing_link(editor, translated_page_with_pending_edit):
         base_content_type=page.get_base_content_type(),
         user=editor,
         content=page.serializable_data(),
-        object_str=str(page),
+        object_str=f"[draft-sharing] {page}",
     )
     return WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=editor)
 
@@ -223,7 +224,7 @@ def test_different_page_sharing_link_is_not_reused(editor, post, translated_page
         base_content_type=source.get_base_content_type(),
         user=editor,
         content=source.serializable_data(),
-        object_str=str(source),
+        object_str=f"[draft-sharing] {source}",
     )
     source_link = WagtaildraftsharingLink.objects.create_for_revision(revision=source_revision, user=editor)
     source_sharing_url = source_link.url
@@ -288,7 +289,7 @@ def test_does_not_delete_expired_link_revision_from_other_page(editor, existing_
         base_content_type=source.get_base_content_type(),
         user=editor,
         content=source.serializable_data(),
-        object_str=str(source),
+        object_str=f"[draft-sharing] {source}",
     )
     source_link = WagtaildraftsharingLink.objects.create_for_revision(revision=source_revision, user=editor)
     source_link.is_active = False
@@ -302,3 +303,19 @@ def test_does_not_delete_expired_link_revision_from_other_page(editor, existing_
     assert Revision.objects.count() == existing_revision_count
     existing_sharing_link.refresh_from_db()
     source_link.refresh_from_db()
+
+
+def test_does_not_delete_normal_revision(editor, existing_sharing_link, post, translated_page_with_pending_edit):
+    """Revisions used for draft sharing are marked with a prefix - only those should be deleted."""
+    existing_sharing_link.is_active = False
+    existing_sharing_link.save(update_fields=["is_active"])
+    revision = existing_sharing_link.revision
+    revision.object_str = "Do not delete"
+    revision.save(update_fields=["object_str"])
+
+    response = post()
+
+    assert response.status_code == 200
+    # No revisions or links deleted
+    revision.refresh_from_db()
+    existing_sharing_link.refresh_from_db()

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 import pytest
 from wagtail.models import Locale, Revision
-from wagtail_localize.models import StringSegment, StringTranslation, Translation, TranslationSource
+from wagtail_localize.models import Translation, TranslationSource
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 
 from springfield.cms.tests.factories import SimpleRichTextPageFactory, WagtailUserFactory
@@ -145,98 +145,6 @@ def existing_sharing_link(editor, translated_page_with_pending_edit):
     return WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=editor)
 
 
-@pytest.fixture
-def existing_sharing_url(existing_sharing_link):
-    return existing_sharing_link.url
-
-
-def test_reuses_existing_sharing_link(existing_sharing_url, post):
-    existing_revision_count = Revision.objects.count()
-
-    response = post()
-
-    assert response.status_code == 200
-
-    url = response.json()["url"]
-    assert url == existing_sharing_url
-    assert Revision.objects.count() == existing_revision_count
-    assert WagtaildraftsharingLink.objects.count() == 1
-
-
-def test_creates_new_sharing_link_for_edits(existing_sharing_url, post, translated_page_with_pending_edit):
-    segment = StringSegment.objects.filter(source=translated_page_with_pending_edit.translation.source).first()
-    StringTranslation.objects.filter(
-        translation_of_id=segment.string_id,
-        locale=translated_page_with_pending_edit.locale,
-        context_id=segment.context_id,
-    ).update(data="Encore changé", updated_at=timezone.now() + timedelta(minutes=5))
-
-    response = post()
-
-    assert response.status_code == 200
-
-    url = response.json()["url"]
-    assert url != existing_sharing_url
-    assert WagtaildraftsharingLink.objects.count() == 2
-
-
-def test_creates_new_sharing_link_for_source_page_changes(existing_sharing_url, post, translated_page_with_pending_edit):
-    source_page = translated_page_with_pending_edit.source_page
-    source_page.title += "!"
-    source_page.save()
-    TranslationSource.update_or_create_from_instance(source_page)
-
-    response = post()
-
-    assert response.status_code == 200
-
-    url = response.json()["url"]
-    assert url != existing_sharing_url
-    assert WagtaildraftsharingLink.objects.count() == 2
-
-
-def test_deactivated_sharing_link_is_not_reused(existing_sharing_url, post):
-    WagtaildraftsharingLink.objects.update(is_active=False)
-
-    response = post()
-
-    assert response.status_code == 200
-
-    url = response.json()["url"]
-    assert url != existing_sharing_url
-
-
-def test_expired_sharing_link_is_not_reused(existing_sharing_url, post):
-    WagtaildraftsharingLink.objects.update(active_until=timezone.now() - timedelta(days=1))
-
-    response = post()
-
-    assert response.status_code == 200
-
-    url = response.json()["url"]
-    assert url != existing_sharing_url
-
-
-def test_different_page_sharing_link_is_not_reused(editor, post, translated_page_with_pending_edit):
-    source = translated_page_with_pending_edit.source_page.specific
-    source_revision = Revision.objects.create(
-        content_object=source,
-        base_content_type=source.get_base_content_type(),
-        user=editor,
-        content=source.serializable_data(),
-        object_str=f"[draft-sharing] {source}",
-    )
-    source_link = WagtaildraftsharingLink.objects.create_for_revision(revision=source_revision, user=editor)
-    source_sharing_url = source_link.url
-
-    response = post()
-
-    assert response.status_code == 200
-
-    url = response.json()["url"]
-    assert url != source_sharing_url
-
-
 def test_deletes_revision_whose_only_link_expired(existing_sharing_link, post):
     existing_sharing_link.active_until = timezone.now() - timedelta(days=1)
     existing_sharing_link.save(update_fields=["active_until"])
@@ -300,7 +208,7 @@ def test_does_not_delete_expired_link_revision_from_other_page(editor, existing_
 
     assert response.status_code == 200
     # No revisions or links deleted
-    assert Revision.objects.count() == existing_revision_count
+    assert Revision.objects.count() == existing_revision_count + 1
     existing_sharing_link.refresh_from_db()
     source_link.refresh_from_db()
 

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -1,0 +1,275 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Tests for the `cms_translation_draftsharing_create` view
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from wagtail.models import Revision
+from wagtail_localize.models import StringSegment, StringTranslation
+from wagtaildraftsharing.models import WagtaildraftsharingLink
+
+from springfield.cms.tests.factories import WagtailUserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def editor():
+    return WagtailUserFactory(is_superuser=True)
+
+
+@pytest.fixture
+def url():
+
+    def _url(translation_id):
+        return reverse("cms_translation_draftsharing_create", args=[translation_id])
+
+    return _url
+
+
+@pytest.fixture
+def post(client, editor, translated_page_with_pending_edit, url):
+    translation_id = translated_page_with_pending_edit.translation.pk
+
+    def _post():
+        client.force_login(editor)
+        return client.post(url(translation_id))
+
+    return _post
+
+
+def test_url(url):
+    assert url(123) == "/cms-admin/translation-draftsharing/123/"
+
+
+def test_anonymous_user_not_permitted(client, translated_page_with_pending_edit, url):
+    response = client.post(url(translated_page_with_pending_edit.translation.pk))
+
+    assert response.status_code == 302
+    assert response.url.startswith("/cms-admin/login/")
+    assert WagtaildraftsharingLink.objects.exists() is False
+
+
+def test_user_without_edit_permission_not_permitted(client, translated_page_with_pending_edit, url):
+    no_access = WagtailUserFactory(username="no-access", is_superuser=False)
+    client.force_login(no_access)
+
+    response = client.post(url(translated_page_with_pending_edit.translation.pk))
+
+    assert response.status_code == 302
+    assert response.url.startswith("/cms-admin/login/")
+    assert WagtaildraftsharingLink.objects.exists() is False
+
+
+def test_get_is_rejected(client, editor, translated_page_with_pending_edit, url):
+    client.force_login(editor)
+
+    response = client.get(url(translated_page_with_pending_edit.translation.pk))
+
+    assert response.status_code == 405
+
+
+def test_unknown_translation_returns_404(client, editor, url):
+    client.force_login(editor)
+
+    response = client.post(url(999999), follow=True)
+
+    assert response.status_code == 404
+    assert WagtaildraftsharingLink.objects.exists() is False
+
+
+def test_returns_sharing_url_without_changing_page(client, post, translated_page_with_pending_edit):
+    response = post()
+
+    assert response.status_code == 200
+
+    sharing_link = WagtaildraftsharingLink.objects.get()
+    revision = Revision.objects.for_instance(translated_page_with_pending_edit.page).order_by("-created_at").first()
+    assert sharing_link.revision == revision
+    expected_url = reverse("wagtaildraftsharing:view", args=[sharing_link.key])
+    assert sharing_link.url == expected_url
+    data = response.json()
+    assert data["url"] == sharing_link.url
+
+    client.logout()
+    unpublished_text = "Passer à Firefox"
+
+    # Shared page preview shows unpublished translation
+    shared_response = client.get(sharing_link.url)
+
+    assert shared_response.status_code == 200
+    assert shared_response["X-Robots-Tag"] == "noindex, nofollow"
+    assert unpublished_text in shared_response.content.decode()
+
+    # Change to public page is not published
+    public_response = client.get(translated_page_with_pending_edit.page.url)
+
+    assert public_response.status_code == 200
+    assert unpublished_text not in public_response.content.decode()
+
+
+@pytest.fixture
+def existing_sharing_link(editor, translated_page_with_pending_edit):
+    """
+    Sharing link for the `translated_page_with_pending_edit` fixture.
+    """
+    page = translated_page_with_pending_edit.page
+    revision = Revision.objects.create(
+        content_object=page,
+        base_content_type=page.get_base_content_type(),
+        user=editor,
+        content=page.serializable_data(),
+        object_str=str(page),
+    )
+    return WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=editor)
+
+
+@pytest.fixture
+def existing_sharing_url(existing_sharing_link):
+    return existing_sharing_link.url
+
+
+def test_reuses_existing_sharing_link(existing_sharing_url, post):
+    existing_revision_count = Revision.objects.count()
+
+    response = post()
+
+    assert response.status_code == 200
+
+    url = response.json()["url"]
+    assert url == existing_sharing_url
+    assert Revision.objects.count() == existing_revision_count
+    assert WagtaildraftsharingLink.objects.count() == 1
+
+
+def test_creates_new_sharing_link_for_edits(existing_sharing_url, post, translated_page_with_pending_edit):
+    segment = StringSegment.objects.filter(source=translated_page_with_pending_edit.translation.source).first()
+    StringTranslation.objects.filter(
+        translation_of_id=segment.string_id,
+        locale=translated_page_with_pending_edit.locale,
+        context_id=segment.context_id,
+    ).update(data="Encore changé", updated_at=timezone.now() + timedelta(minutes=5))
+
+    response = post()
+
+    assert response.status_code == 200
+
+    url = response.json()["url"]
+    assert url != existing_sharing_url
+    assert WagtaildraftsharingLink.objects.count() == 2
+
+
+def test_deactivated_sharing_link_is_not_reused(existing_sharing_url, post):
+    WagtaildraftsharingLink.objects.update(is_active=False)
+
+    response = post()
+
+    assert response.status_code == 200
+
+    url = response.json()["url"]
+    assert url != existing_sharing_url
+
+
+def test_expired_sharing_link_is_not_reused(existing_sharing_url, post):
+    WagtaildraftsharingLink.objects.update(active_until=timezone.now() - timedelta(days=1))
+
+    response = post()
+
+    assert response.status_code == 200
+
+    url = response.json()["url"]
+    assert url != existing_sharing_url
+
+
+def test_different_page_sharing_link_is_not_reused(editor, post, translated_page_with_pending_edit):
+    source = translated_page_with_pending_edit.source_page.specific
+    source_revision = Revision.objects.create(
+        content_object=source,
+        base_content_type=source.get_base_content_type(),
+        user=editor,
+        content=source.serializable_data(),
+        object_str=str(source),
+    )
+    source_link = WagtaildraftsharingLink.objects.create_for_revision(revision=source_revision, user=editor)
+    source_sharing_url = source_link.url
+
+    response = post()
+
+    assert response.status_code == 200
+
+    url = response.json()["url"]
+    assert url != source_sharing_url
+
+
+def test_deletes_revision_whose_only_link_expired(existing_sharing_link, post):
+    existing_sharing_link.active_until = timezone.now() - timedelta(days=1)
+    existing_sharing_link.save(update_fields=["active_until"])
+    # `existing_sharing_link` is now expired
+    revision_with_expired_link = existing_sharing_link.revision
+
+    response = post()
+
+    assert response.status_code == 200
+    with pytest.raises(Revision.DoesNotExist):
+        revision_with_expired_link.refresh_from_db()
+    with pytest.raises(WagtaildraftsharingLink.DoesNotExist):
+        existing_sharing_link.refresh_from_db()
+
+
+def test_deletes_revision_whose_only_link_is_inactive(existing_sharing_link, post):
+    existing_sharing_link.is_active = False
+    existing_sharing_link.save(update_fields=["is_active"])
+    # `existing_sharing_link` is now inactive
+    revision_with_expired_link = existing_sharing_link.revision
+
+    response = post()
+
+    assert response.status_code == 200
+    with pytest.raises(Revision.DoesNotExist):
+        revision_with_expired_link.refresh_from_db()
+    with pytest.raises(WagtaildraftsharingLink.DoesNotExist):
+        existing_sharing_link.refresh_from_db()
+
+
+def test_does_not_delete_revision_with_one_active_link(editor, existing_sharing_link, post, translated_page_with_pending_edit):
+    revision = existing_sharing_link.revision
+    expired_sharing_link = WagtaildraftsharingLink.objects.create_for_revision(revision=revision, user=editor)
+    expired_sharing_link.active_until = timezone.now() - timedelta(days=1)
+    expired_sharing_link.save(update_fields=["active_until"])
+
+    response = post()
+
+    assert response.status_code == 200
+    # No revisions or links deleted
+    revision.refresh_from_db()
+    existing_sharing_link.refresh_from_db()
+    expired_sharing_link.refresh_from_db()
+
+
+def test_does_not_delete_expired_link_revision_from_other_page(editor, existing_sharing_link, post, translated_page_with_pending_edit):
+    source = translated_page_with_pending_edit.source_page.specific
+    source_revision = Revision.objects.create(
+        content_object=source,
+        base_content_type=source.get_base_content_type(),
+        user=editor,
+        content=source.serializable_data(),
+        object_str=str(source),
+    )
+    source_link = WagtaildraftsharingLink.objects.create_for_revision(revision=source_revision, user=editor)
+    source_link.is_active = False
+    source_link.save(update_fields=["is_active"])
+    existing_revision_count = Revision.objects.count()
+
+    response = post()
+
+    assert response.status_code == 200
+    # No revisions or links deleted
+    assert Revision.objects.count() == existing_revision_count
+    existing_sharing_link.refresh_from_db()
+    source_link.refresh_from_db()

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -104,9 +104,10 @@ def test_returns_sharing_url_without_changing_page(admin_client, post, translate
     assert response.status_code == 200
 
     sharing_link = WagtaildraftsharingLink.objects.get()
-    revision = Revision.objects.for_instance(translated_page_with_pending_edit.page).order_by("-created_at").first()
+    page = translated_page_with_pending_edit.page
+    revision = Revision.objects.for_instance(page).get(object_str__startswith="[draft-sharing]")
     assert sharing_link.revision == revision
-    assert revision.object_str.startswith("[draft-sharing] ")
+    assert revision.created_at < page.latest_revision.created_at  # Do not usurp the actual latest revision
     expected_url = reverse("wagtaildraftsharing:view", args=[sharing_link.key])
     assert sharing_link.url == expected_url
     data = response.json()
@@ -123,7 +124,7 @@ def test_returns_sharing_url_without_changing_page(admin_client, post, translate
     assert unpublished_text in shared_response.content.decode()
 
     # Change to public page is not published
-    public_response = admin_client.get(translated_page_with_pending_edit.page.url)
+    public_response = admin_client.get(page.url)
 
     assert public_response.status_code == 200
     assert unpublished_text not in public_response.content.decode()

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -179,6 +179,21 @@ def test_creates_new_sharing_link_for_edits(existing_sharing_url, post, translat
     assert WagtaildraftsharingLink.objects.count() == 2
 
 
+def test_creates_new_sharing_link_for_source_page_changes(existing_sharing_url, post, translated_page_with_pending_edit):
+    source_page = translated_page_with_pending_edit.source_page
+    source_page.title += "!"
+    source_page.save()
+    TranslationSource.update_or_create_from_instance(source_page)
+
+    response = post()
+
+    assert response.status_code == 200
+
+    url = response.json()["url"]
+    assert url != existing_sharing_url
+    assert WagtaildraftsharingLink.objects.count() == 2
+
+
 def test_deactivated_sharing_link_is_not_reused(existing_sharing_url, post):
     WagtaildraftsharingLink.objects.update(is_active=False)
 

--- a/springfield/cms/tests/test_translation_draftsharing_view.py
+++ b/springfield/cms/tests/test_translation_draftsharing_view.py
@@ -11,11 +11,11 @@ from django.urls import reverse
 from django.utils import timezone
 
 import pytest
-from wagtail.models import Revision
-from wagtail_localize.models import StringSegment, StringTranslation
+from wagtail.models import Locale, Revision
+from wagtail_localize.models import StringSegment, StringTranslation, Translation, TranslationSource
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 
-from springfield.cms.tests.factories import WagtailUserFactory
+from springfield.cms.tests.factories import SimpleRichTextPageFactory, WagtailUserFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -78,6 +78,21 @@ def test_get_is_rejected(admin_client, translated_page_with_pending_edit, url):
 
 def test_unknown_translation_returns_404(admin_client, url):
     response = admin_client.post(url(999999), follow=True)
+
+    assert response.status_code == 404
+    assert WagtaildraftsharingLink.objects.exists() is False
+
+
+def test_translation_without_a_target_page_returns_404(admin_client, minimal_site, url):
+    source_page = SimpleRichTextPageFactory(title="Not yet synced", slug="not-yet-synced", parent=minimal_site.root_page)
+    source, __ = TranslationSource.get_or_create_from_instance(source_page)
+    translation = Translation.objects.create(
+        source=source,
+        target_locale=Locale.objects.get(language_code="fr"),
+        enabled=True,
+    )
+
+    response = admin_client.post(url(translation.pk), follow=True)
 
     assert response.status_code == 404
     assert WagtaildraftsharingLink.objects.exists() is False

--- a/springfield/cms/wagtail_hooks.py
+++ b/springfield/cms/wagtail_hooks.py
@@ -33,7 +33,7 @@ from wagtail.snippets.views.snippets import IndexView, SnippetViewSet
 from wagtail.whitelist import check_url
 
 from springfield.base.templatetags.helpers import css_bundle
-from springfield.cms.admin_views import ContentSearchView, blog_tag_autocomplete
+from springfield.cms.admin_views import ContentSearchView, blog_tag_autocomplete, create_translation_sharing_link
 from springfield.cms.blocks import regenerate_analytics_ids
 from springfield.cms.models import (
     AbstractSpringfieldCMSPage,
@@ -63,6 +63,11 @@ def register_cms_admin_urls():
         path("content-search/", ContentSearchView.as_view(), name="cms_content_search"),
         path("content-search/results/", ContentSearchView.as_view(results_only=True), name="cms_content_search_results"),
         path("blog-tag-autocomplete/", blog_tag_autocomplete, name="cms_blog_tag_autocomplete"),
+        path(
+            "translation-draftsharing/<int:translation_id>/",
+            create_translation_sharing_link,
+            name="cms_translation_draftsharing_create",
+        ),
     ]
 
 

--- a/springfield/cms/wagtail_hooks.py
+++ b/springfield/cms/wagtail_hooks.py
@@ -185,6 +185,16 @@ def routing_condition_help_js():
     )
 
 
+@hooks.register("insert_global_admin_js")
+def translation_draftsharing_js():
+    """Deliver the script that moves the draft sharing button into the translation editor.
+
+    Loaded on every admin page; the script does nothing unless the editor rendered the
+    button template.
+    """
+    return format_html('<script type="module" src="{}"></script>', static("js/wagtailadmin-translation-draftsharing.js"))
+
+
 class FXAEntityElementHandler(InlineEntityElementHandler):
     """
     Database HTML to Draft.js ContentState.

--- a/tests/unit/spec/cms/forms/wagtailadmin-translation-draftsharing.js
+++ b/tests/unit/spec/cms/forms/wagtailadmin-translation-draftsharing.js
@@ -1,0 +1,159 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    placeDraftsharingButton,
+    createSharingLink
+} from '../../../../../media/js/cms/wagtailadmin-translation-draftsharing.es6.js';
+
+const BUTTON_HTML = `<button type="button" class="button" data-translation-draftsharing
+    data-url="/cms-admin/translation-draftsharing/37/">
+        <svg></svg>
+        Create draft sharing link
+    </button>`;
+
+function buildEditor(withTemplate) {
+    const root = document.createElement('div');
+    const template = withTemplate
+        ? `<template id="translation-draftsharing-button">
+            ${BUTTON_HTML}
+          </template>`
+        : '';
+    root.innerHTML = `${template}
+        <footer class="footer">
+          <form method="POST">
+            <nav class="actions actions--primary footer__container">
+              <div data-w-dropdown-target="content"></div>
+            </nav>
+          </form>
+        </footer>`;
+    document.body.appendChild(root);
+    return root;
+}
+
+describe('wagtailadmin-translation-draftsharing', function () {
+    let root;
+
+    afterEach(function () {
+        if (root) {
+            root.remove();
+        }
+        root = null;
+    });
+
+    describe('placeDraftsharingButton', function () {
+        it('moves the button into the action menu list', function () {
+            root = buildEditor(true);
+            placeDraftsharingButton(root);
+            const menu = root.querySelector(
+                '[data-w-dropdown-target="content"]'
+            );
+            expect(
+                menu.querySelector('[data-translation-draftsharing]')
+            ).not.toBeNull();
+        });
+
+        it('does nothing when there is no button template', function () {
+            root = buildEditor(false);
+            placeDraftsharingButton(root);
+            const menu = root.querySelector(
+                '[data-w-dropdown-target="content"]'
+            );
+            expect(menu.children.length).toEqual(0);
+        });
+
+        it('does nothing when the footer has not mounted yet', function () {
+            root = document.createElement('div');
+            root.innerHTML = `<template id="translation-draftsharing-button">
+                ${BUTTON_HTML}
+                </template>`;
+            document.body.appendChild(root);
+            expect(function () {
+                placeDraftsharingButton(root);
+            }).not.toThrow();
+        });
+
+        it('does not add duplicate buttons', function () {
+            root = buildEditor(true);
+            placeDraftsharingButton(root);
+            placeDraftsharingButton(root);
+            placeDraftsharingButton(root);
+            const menu = root.querySelector(
+                '[data-w-dropdown-target="content"]'
+            );
+            expect(
+                menu.querySelectorAll('[data-translation-draftsharing]').length
+            ).toEqual(1);
+        });
+
+        it('re-inserts the button after the footer is re-rendered', function () {
+            root = buildEditor(true);
+            placeDraftsharingButton(root);
+            root.querySelector('[data-w-dropdown-target="content"]').innerHTML =
+                '';
+            placeDraftsharingButton(root);
+            const menu = root.querySelector(
+                '[data-w-dropdown-target="content"]'
+            );
+            expect(
+                menu.querySelectorAll('[data-translation-draftsharing]').length
+            ).toEqual(1);
+        });
+    });
+
+    describe('createSharingLink', function () {
+        beforeEach(function () {
+            const config = document.createElement('script');
+            config.id = 'wagtail-config';
+            config.type = 'application/json';
+            config.textContent = JSON.stringify({ CSRF_TOKEN: 'test-token' });
+            document.body.appendChild(config);
+        });
+
+        afterEach(function () {
+            document.getElementById('wagtail-config').remove();
+        });
+
+        it('posts to the button url with the csrf token', async function () {
+            root = buildEditor(true);
+            placeDraftsharingButton(root);
+            const button = root.querySelector(
+                '[data-translation-draftsharing]'
+            );
+            spyOn(window, 'fetch').and.returnValue(
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ url: '/shared/abc/' })
+                })
+            );
+
+            await createSharingLink(button);
+
+            const [url, options] = window.fetch.calls.mostRecent().args;
+            expect(url).toEqual('/cms-admin/translation-draftsharing/37/');
+            expect(options.method).toEqual('POST');
+            expect(options.headers['X-CSRFToken']).toEqual('test-token');
+        });
+
+        it('restores the button icon and label when the request fails', async function () {
+            root = buildEditor(true);
+            placeDraftsharingButton(root);
+            const button = root.querySelector(
+                '[data-translation-draftsharing]'
+            );
+            const original = button.textContent;
+            spyOn(window, 'fetch').and.returnValue(
+                Promise.resolve({ ok: false })
+            );
+
+            await createSharingLink(button);
+
+            expect(button.textContent).toEqual(original);
+            expect(button.querySelector('svg')).not.toBeNull();
+            expect(button.disabled).toBeFalse();
+        });
+    });
+});

--- a/tests/unit/spec/cms/forms/wagtailadmin-translation-draftsharing.js
+++ b/tests/unit/spec/cms/forms/wagtailadmin-translation-draftsharing.js
@@ -105,16 +105,28 @@ describe('wagtailadmin-translation-draftsharing', function () {
     });
 
     describe('createSharingLink', function () {
+        let writeText;
+
         beforeEach(function () {
             const config = document.createElement('script');
             config.id = 'wagtail-config';
             config.type = 'application/json';
             config.textContent = JSON.stringify({ CSRF_TOKEN: 'test-token' });
             document.body.appendChild(config);
+
+            // Stub the copy step (never settles in headed Chrome)
+            writeText = jasmine
+                .createSpy('writeText')
+                .and.returnValue(Promise.resolve());
+            Object.defineProperty(navigator, 'clipboard', {
+                value: { writeText },
+                configurable: true
+            });
         });
 
         afterEach(function () {
             document.getElementById('wagtail-config').remove();
+            delete navigator.clipboard;
         });
 
         it('posts to the button url with the csrf token', async function () {
@@ -136,6 +148,28 @@ describe('wagtailadmin-translation-draftsharing', function () {
             expect(url).toEqual('/cms-admin/translation-draftsharing/37/');
             expect(options.method).toEqual('POST');
             expect(options.headers['X-CSRFToken']).toEqual('test-token');
+        });
+
+        it('copies the returned url to the clipboard', async function () {
+            root = buildEditor(true);
+            placeDraftsharingButton(root);
+            const button = root.querySelector(
+                '[data-translation-draftsharing]'
+            );
+            const shareURL = '/shared/abc/';
+            spyOn(window, 'fetch').and.returnValue(
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ url: shareURL })
+                })
+            );
+
+            await createSharingLink(button);
+
+            expect(writeText).toHaveBeenCalledWith(
+                window.location.origin + shareURL
+            );
+            expect(button.textContent).toContain('Copied!');
         });
 
         it('restores the button icon and label when the request fails', async function () {


### PR DESCRIPTION
## One-line summary

Add a draft sharing link (publicly accessible) to the page action menu of translated pages.

## Significant changes and points to review

The [`wagtail-localize` library](https://wagtail-localize.org/) renders translated pages' action menu with a React app independent of the [`register_page_action_menu_item` Wagtail hook](https://docs.wagtail.org/en/7.1/reference/hooks.html#register-page-action-menu-item), so the "Create draft sharing link" button implemented by the [`wagtaildraftsharing` library](https://github.com/torchbox/wagtaildraftsharing/) are not automatically added to the menu of translated pages. Furthermore, translated pages do not have `Revision` objects to build draft sharing links off of.

This PR adapts `wagtaildraftsharing` to `wagtail-localize`'s translated pages:
- `edit_translation.html` template extended to add a "Create draft sharing link" button to translation pages via a template tag.
- JS to move the button to the page's action menu and implement its async request and response handling.
- A new `cms_translation_draftsharing_create` view to create a revision for the translated page and return a `WagtaildraftsharingLink` for it (re-using `wagtaildraftsharing` functionality).
  - The view cleans up expired/inactive links (and their revisions) for the page. Revision deletions are restricted to those created solely for draft sharing.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1652

## Testing

<img width="237" height="301" alt="image" src="https://github.com/user-attachments/assets/f6706a54-71e2-45ad-90fe-214aac369081" />

- Go to a translated page that has unpublished edits.
- Click on the "Create draft sharing link" button in the action menu.
- Open the copied URL in a new browsing context.
- Verify the page is a preview of the translated page with the unpublished edits.

Clean up inactive links:
- Go to ["Sharing Links"](http://localhost:8000/cms-admin/wagtaildraftsharing/).
- Mark the translated page's sharing link as inactive.
- Click on the "Create draft sharing link" button in the translated page's action menu again.
- Verify a new link was generated for the page and the old link was deleted.

Clean up expired links:
- Go to ["Sharing Links"](http://localhost:8000/cms-admin/wagtaildraftsharing/).
- Mark the translated page's sharing link as expired ("Active until" in the past).
- Click on the "Create draft sharing link" button in the translated page's action menu again.
- Verify a new link was generated for the page and the old link was deleted.