### PR TITLE
Hotfix sqlite db export  redux

### DIFF
--- a/springfield/cms/routing/mixins.py
+++ b/springfield/cms/routing/mixins.py
@@ -13,10 +13,9 @@ lives in the routing tables keyed to ``wagtailcore.Page``), so adopting it produ
 migration**.
 """
 
-import logging
 from contextlib import contextmanager
 
-from django.db import OperationalError, ProgrammingError, models
+from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 import waffle
@@ -24,12 +23,11 @@ from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.admin.panels import HelpPanel, InlinePanel, MultiFieldPanel, ObjectList, TabbedInterface
 from wagtail.utils.decorators import cached_classmethod
 
+from springfield.base.config_manager import config
 from springfield.cms.routing.dispatch import SERVE_PREVIEW, SERVE_RESOLVER, USER_ROUTING_SWITCH, decide_routing
 from springfield.cms.routing.models import RoutingConfig, localized_target, rule_panels
 from springfield.cms.routing.params import LOOP_BREAKER_PARAM
 from springfield.cms.routing.signals import registry
-
-logger = logging.getLogger(__name__)
 
 # Consumer-agnostic guidance shown at the top of the "User Routing" tab. Kept
 # generic (no per-consumer specifics) and localized; HTML is allowed in a HelpPanel.
@@ -246,15 +244,9 @@ class RoutingMixin(models.Model):
         """
         # The mixin itself is abstract and so can't be instantiated; it also declares no
         # trigger, so there is nothing to derive until a concrete consumer adopts it.
-        if cls._meta.abstract:
+        if cls._meta.abstract or config("SQLITE_EXPORT_MODE", parser=bool, default="false"):
             return None
-        try:
-            trigger = cls().get_routing_trigger()
-        except (OperationalError, ProgrammingError):
-            # Fresh DB: Page.__init__ queries django_content_type which
-            # may not exist yet (e.g. export-db-to-sqlite before migrate).
-            logger.info("Skipping routing arming-param derivation for %s: DB tables not ready", cls.__name__)
-            return None
+        trigger = cls().get_routing_trigger()
         param = getattr(trigger, "param_name", None)
         return param if param in registry else None
 

--- a/springfield/cms/routing/tests/test_mixins.py
+++ b/springfield/cms/routing/tests/test_mixins.py
@@ -46,6 +46,17 @@ def test_arming_param_is_none_without_a_trigger():
     assert RoutingMixin.get_routing_arming_param() is None
 
 
+@pytest.mark.django_db
+def test_arming_param_skipped_in_sqlite_export_mode(monkeypatch):
+    from springfield.cms.models.pages import WhatsNewPage2026
+
+    # Without the env var, a concrete consumer returns its arming param.
+    assert WhatsNewPage2026.get_routing_arming_param() is not None
+
+    monkeypatch.setenv("SQLITE_EXPORT_MODE", "True")
+    assert WhatsNewPage2026.get_routing_arming_param() is None
+
+
 # ---------------------------------------------------------------------------
 # The mixin adds no database fields, so adoption produces no migration.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
At the moment, the DB export script fails due to content type issues - `3c922bb55` fixed a separate but related `contenttypes` problem, but caused another one down the line: 

`cls().get_routing_trigger()` instantiates a `Page`, which queries`django_content_type` in `Page.__init__`. During `export-db-to-sqlite.sh` that table has been purged, so `get_for_model` silently re-creates rows that then collide with the fixture data at loaddata time.

The fix is (hopefully) to be really honesst about skip the derivation when `SQLITE_EXPORT_MODE` is set, matching the pattern used in data migrations that also need to stay out of the export path. While it's not elegant, it is much lower risk and less likely to create confusion than various other options around checking for `django.apps` readiness etc

