### PR TITLE
Add three UITour routing signals for user routing & fix fxa_signed_in

### DIFF
--- a/media/js/cms/routing/readers.es6.js
+++ b/media/js/cms/routing/readers.es6.js
@@ -24,6 +24,7 @@ import {
     PER_UITOUR_KEY_TIMEOUT_MS,
     normalizeVersion
 } from './evaluator.es6';
+import { detectBrowser, isBrave } from '../components/flare-browser-detect.es6';
 
 // Source identifiers, mirroring the Python Source enum values.
 export const SOURCE_CDN_GEO = 'cdn_geo';
@@ -78,7 +79,7 @@ export function createGeoReader(options) {
 /**
  * User-Agent — read via Mozilla.Client, the canonical UA parser. Its UA
  * methods work in any browser (returning falsey off Firefox), so it is not Firefox-
- * gated. Injectable `client`.
+ * gated. Injectable `client`, `navigator`, and `isBrave`.
  */
 export function createUserAgentReader(options) {
     const opts = options || {};
@@ -86,6 +87,7 @@ export function createUserAgentReader(options) {
         opts.client || (mozillaGlobal() ? mozillaGlobal().Client : null);
     const nav =
         opts.navigator || (typeof navigator !== 'undefined' ? navigator : null);
+    const detectBraveBrowser = opts.isBrave || isBrave;
     return {
         read: function (descriptor) {
             return new Promise(function (resolve, reject) {
@@ -102,6 +104,25 @@ export function createUserAgentReader(options) {
                     } else {
                         reject();
                     }
+                    return;
+                }
+                if (descriptor.name === 'browser_name') {
+                    // Also checked before the Mozilla.Client guard: this is UA sniffing,
+                    // available off Firefox too. Brave reports Chrome's user agent
+                    // verbatim, so it's only worth the extra async API check when UA
+                    // detection lands on Chrome — every other result is unambiguous.
+                    if (!nav || !nav.userAgent) {
+                        reject();
+                        return;
+                    }
+                    const detected = detectBrowser(nav.userAgent);
+                    if (detected !== 'chrome') {
+                        resolve(detected);
+                        return;
+                    }
+                    detectBraveBrowser().then(function (brave) {
+                        resolve(brave ? 'brave' : 'chrome');
+                    });
                     return;
                 }
                 if (!client) {
@@ -177,15 +198,19 @@ export function aiControlsPosture(config) {
     return 'neutral';
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 // Per-signal extraction from a UITour getConfiguration() payload. Firefox-specific and
 // therefore quarantined here. Field names verified against UITour.sys.mjs in
-// mozilla-central.
+// mozilla-central. Extractors are called with the config object and the current time
+// (ms); only `days_since_last_session` needs the latter.
 const UITOUR_EXTRACTORS = {
     is_default_browser: function (config) {
         return config.defaultBrowser;
     },
-    // `sync.setup` is prefHasUserValue("services.sync.username") — it reports that sync is
-    // configured, which is close to but not the same as being signed in to a Firefox Account.
+    // Reads the `fxa` key: `config.setup` here is `!!(await fxAccounts.getSignedInUser())`,
+    // a genuine signed-in check. The `sync` key's `setup` field only reports that Sync has
+    // been configured, and is marked deprecated in UITour.sys.mjs.
     fxa_signed_in: function (config) {
         return config.setup;
     },
@@ -196,6 +221,24 @@ const UITOUR_EXTRACTORS = {
             ? config.profileCreatedWeeksAgo
             : undefined;
     },
+    // `previousSessionEnd` is a ms timestamp written only when Firefox fully quits, and
+    // defaults to `0` when no previous session was ever recorded. `0` is treated as
+    // unavailable rather than computed through, which would otherwise read as decades
+    // lapsed for a brand-new profile.
+    days_since_last_session: function (config, now) {
+        const previousSessionEnd = config.previousSessionEnd;
+        if (typeof previousSessionEnd !== 'number' || previousSessionEnd <= 0) {
+            return undefined;
+        }
+        return Math.floor((now - previousSessionEnd) / MS_PER_DAY);
+    },
+    // Whole weeks, reported directly, mirroring profile_age_weeks. `null` means the
+    // profile has never been reset.
+    profile_reset_weeks_ago: function (config) {
+        return typeof config.profileResetWeeksAgo === 'number'
+            ? config.profileResetWeeksAgo
+            : undefined;
+    },
     ai_controls: aiControlsPosture
 };
 
@@ -203,13 +246,14 @@ const UITOUR_EXTRACTORS = {
  * UITour — Firefox-only browser state, read via a ping-gated getConfiguration under a
  * per-key budget. A ping or getConfiguration that never answers
  * leaves the read pending until the budget expires, then rejects (⇒ not-matched).
- * Injectable `uiTour` and `timeout`.
+ * Injectable `uiTour`, `timeout`, and `now`.
  */
 export function createUITourReader(options) {
     const opts = options || {};
     const uiTour =
         opts.uiTour || (mozillaGlobal() ? mozillaGlobal().UITour : null);
     const timeout = opts.timeout || PER_UITOUR_KEY_TIMEOUT_MS;
+    const now = opts.now || Date.now;
     return {
         read: function (descriptor) {
             return new Promise(function (resolve, reject) {
@@ -243,7 +287,7 @@ export function createUITourReader(options) {
                             }
                             settled = true;
                             window.clearTimeout(timer);
-                            const value = extractor(config || {});
+                            const value = extractor(config || {}, now());
                             if (value === undefined || value === null) {
                                 reject();
                             } else {

--- a/springfield/cms/routing/tests/test_v1_signals.py
+++ b/springfield/cms/routing/tests/test_v1_signals.py
@@ -22,6 +22,8 @@ EXPECTED_SIGNALS = {
     "is_default_browser": (Source.UITOUR, ValueType.BOOLEAN),
     "profile_age_weeks": (Source.UITOUR, ValueType.INTEGER),
     "fxa_signed_in": (Source.UITOUR, ValueType.BOOLEAN),
+    "days_since_last_session": (Source.UITOUR, ValueType.INTEGER),
+    "profile_reset_weeks_ago": (Source.UITOUR, ValueType.INTEGER),
     "ai_controls": (Source.UITOUR, ValueType.ENUM),
     "utm_source": (Source.URL, ValueType.STRING),
     "utm_medium": (Source.URL, ValueType.STRING),
@@ -30,6 +32,7 @@ EXPECTED_SIGNALS = {
     "locale": (Source.URL, ValueType.STRING),
     "language": (Source.URL, ValueType.STRING),
     "browser_language": (Source.USER_AGENT, ValueType.STRING),
+    "browser_name": (Source.USER_AGENT, ValueType.ENUM),
 }
 
 
@@ -104,6 +107,21 @@ def test_is_firefox_notes_cross_platform_coverage():
     assert "Android" in description
 
 
+def test_fxa_signed_in_reads_the_fxa_key_not_the_deprecated_sync_key():
+    # `sync.setup` only reports that Sync is configured, which UITour.sys.mjs itself marks
+    # deprecated; `fxa.setup` is the account's actual signed-in state.
+    fxa_signed_in = registry.get("fxa_signed_in")
+    assert fxa_signed_in.browser_state_key == "fxa"
+
+
+def test_days_since_last_session_notes_it_measures_since_the_browser_closed():
+    # The sharpest trap in this signal: it's days since Firefox last quit, not days since
+    # the visitor was last active. A long-running session that never restarts reads as
+    # lapsed until it does.
+    description = str(registry.get("days_since_last_session").description)
+    assert "closed" in description
+
+
 # ---------------------------------------------------------------------------
 # oldversion + locale: URL-derived, replacing a dedicated lapsed_user.
 # ---------------------------------------------------------------------------
@@ -152,3 +170,20 @@ def test_locale_and_language_descriptions_point_authors_at_each_other():
     # The pair is only useful if an author can tell which one they want.
     assert "language" in str(registry.get("locale").description)
     assert "en-US" in str(registry.get("language").description)
+
+
+def test_browser_name_is_read_from_the_user_agent_not_uitour():
+    # UA sniffing, not UITour: it must work off Firefox too, to identify the browsers it
+    # names.
+    browser_name = registry.get("browser_name")
+    assert browser_name.source is Source.USER_AGENT
+    assert browser_name.value_type is ValueType.ENUM
+    assert {value.value for value in browser_name.enum_values} == {
+        "firefox",
+        "chrome",
+        "edge",
+        "opera",
+        "safari",
+        "brave",
+        "other",
+    }

--- a/springfield/cms/routing/v1_signals.py
+++ b/springfield/cms/routing/v1_signals.py
@@ -107,10 +107,39 @@ registry.register(
 registry.register(
     RoutingSignal(
         name="fxa_signed_in",
+        # Reads the `fxa` key, not the deprecated `sync` key: `sync.setup` only reports
+        # that Sync has been configured, which is not the same as being signed in.
         description=_("Whether the visitor is signed in to a Firefox Account."),
         source=Source.UITOUR,
         value_type=ValueType.BOOLEAN,
-        browser_state_key="sync",
+        browser_state_key="fxa",
+    )
+)
+
+registry.register(
+    RoutingSignal(
+        name="days_since_last_session",
+        # `previousSessionEnd` is written only when Firefox fully quits, so this measures
+        # days since the browser was last *closed*, not since the visitor was last active —
+        # a long-running session that never restarts reads as lapsed until it does. Landed
+        # in Firefox 155 (2026-08-05); reads unavailable on older releases and for a
+        # profile with no recorded previous session.
+        description=_("How many whole days since the visitor's previous Firefox session ended (i.e. since Firefox was last closed)."),
+        source=Source.UITOUR,
+        value_type=ValueType.INTEGER,
+        browser_state_key="appinfo",
+    )
+)
+
+registry.register(
+    RoutingSignal(
+        name="profile_reset_weeks_ago",
+        # Whole weeks, reported directly, mirroring profile_age_weeks. Unavailable if the
+        # visitor has never reset (refreshed) their profile.
+        description=_("How many whole weeks since the visitor last reset (refreshed) their Firefox profile."),
+        source=Source.UITOUR,
+        value_type=ValueType.INTEGER,
+        browser_state_key="appinfo",
     )
 )
 
@@ -202,5 +231,27 @@ registry.register(
         ),
         source=Source.USER_AGENT,
         value_type=ValueType.STRING,
+    )
+)
+
+# Coarse user-agent detection, matching the browsers our own comparison tables name
+# (TabBlock's "Detected browser" field). Works off Firefox too, unlike the UITour
+# signals above. Brave ships Chrome's user agent verbatim, so it is only distinguished
+# from Chrome by an extra, best-effort browser API check.
+registry.register(
+    RoutingSignal(
+        name="browser_name",
+        description=_("The visitor's browser (Firefox, Chrome, Edge, Opera, Safari, or Brave), or “other” for anything else."),
+        source=Source.USER_AGENT,
+        value_type=ValueType.ENUM,
+        enum_values=(
+            EnumValue("firefox", _("Firefox")),
+            EnumValue("chrome", _("Chrome")),
+            EnumValue("edge", _("Edge")),
+            EnumValue("opera", _("Opera")),
+            EnumValue("safari", _("Safari")),
+            EnumValue("brave", _("Brave")),
+            EnumValue("other", _("Other")),
+        ),
     )
 )

--- a/tests/unit/spec/cms/routing/readers.js
+++ b/tests/unit/spec/cms/routing/readers.js
@@ -211,6 +211,74 @@ describe('cms/routing/readers.es6.js', function () {
                 REJECTED
             );
         });
+
+        describe('browser_name', function () {
+            it('reads a non-Chrome browser straight from UA detection, without Mozilla.Client', async function () {
+                const reader = createUserAgentReader({
+                    client: null,
+                    navigator: {
+                        userAgent:
+                            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0'
+                    }
+                });
+                expect(await reader.read({ name: 'browser_name' })).toEqual(
+                    'firefox'
+                );
+            });
+
+            it('skips the Brave check entirely when detection is not Chrome', async function () {
+                const isBraveSpy = jasmine
+                    .createSpy('isBrave')
+                    .and.returnValue(Promise.resolve(true));
+                const reader = createUserAgentReader({
+                    navigator: {
+                        userAgent:
+                            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59'
+                    },
+                    isBrave: isBraveSpy
+                });
+                expect(await reader.read({ name: 'browser_name' })).toEqual(
+                    'edge'
+                );
+                // Confirms Brave, which reports Chrome's UA verbatim, is only worth
+                // asking about when UA detection actually lands on Chrome.
+                expect(isBraveSpy).not.toHaveBeenCalled();
+            });
+
+            it('asks the Brave check when detection lands on Chrome, and upgrades the result', async function () {
+                const reader = createUserAgentReader({
+                    navigator: {
+                        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36'
+                    },
+                    isBrave: () => Promise.resolve(true)
+                });
+                expect(await reader.read({ name: 'browser_name' })).toEqual(
+                    'brave'
+                );
+            });
+
+            it('stays chrome when the Brave check says no', async function () {
+                const reader = createUserAgentReader({
+                    navigator: {
+                        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36'
+                    },
+                    isBrave: () => Promise.resolve(false)
+                });
+                expect(await reader.read({ name: 'browser_name' })).toEqual(
+                    'chrome'
+                );
+            });
+
+            it('is unavailable when there is no user agent to sniff', async function () {
+                const reader = createUserAgentReader({
+                    navigator: { userAgent: '' }
+                });
+                const outcome = await settle(
+                    reader.read({ name: 'browser_name' })
+                );
+                expect(outcome).toBe(REJECTED);
+            });
+        });
     });
 
     describe('UITour reader', function () {
@@ -251,6 +319,103 @@ describe('cms/routing/readers.es6.js', function () {
             const outcome = await settle(
                 reader.read({
                     name: 'is_default_browser',
+                    browserStateKey: 'appinfo'
+                })
+            );
+            expect(outcome).toBe(REJECTED);
+        });
+
+        it('reads fxa_signed_in from the fxa key, not the deprecated sync key', async function () {
+            const uiTour = {
+                ping: (cb) => cb(),
+                getConfiguration: (key, cb) => {
+                    // Only the `fxa` key reports a genuine signed-in check; `sync` would
+                    // report Sync-configured instead.
+                    expect(key).toEqual('fxa');
+                    cb({ setup: true, accountStateOK: true });
+                }
+            };
+            const reader = createUITourReader({ uiTour: uiTour, timeout: 100 });
+            const value = await reader.read({
+                name: 'fxa_signed_in',
+                browserStateKey: 'fxa'
+            });
+            expect(value).toBe(true);
+        });
+
+        describe('days_since_last_session', function () {
+            const NOW = 1_735_000_000_000; // arbitrary fixed instant
+
+            function readerFor(previousSessionEnd) {
+                const uiTour = {
+                    ping: (cb) => cb(),
+                    getConfiguration: (key, cb) => cb({ previousSessionEnd })
+                };
+                return createUITourReader({
+                    uiTour: uiTour,
+                    timeout: 100,
+                    now: () => NOW
+                });
+            }
+
+            it('reports whole days since the previous session ended', async function () {
+                const twentyEightDaysAgo = NOW - 28 * 24 * 60 * 60 * 1000;
+                const reader = readerFor(twentyEightDaysAgo);
+                const value = await reader.read({
+                    name: 'days_since_last_session',
+                    browserStateKey: 'appinfo'
+                });
+                expect(value).toEqual(28);
+            });
+
+            it('is unavailable when no previous session was ever recorded', async function () {
+                // UITour's own sentinel for "nothing recorded yet" is 0, not undefined —
+                // treating it as a real timestamp would read as decades lapsed.
+                const reader = readerFor(0);
+                const outcome = await settle(
+                    reader.read({
+                        name: 'days_since_last_session',
+                        browserStateKey: 'appinfo'
+                    })
+                );
+                expect(outcome).toBe(REJECTED);
+            });
+
+            it('is unavailable when the field is missing (older Firefox)', async function () {
+                const reader = readerFor(undefined);
+                const outcome = await settle(
+                    reader.read({
+                        name: 'days_since_last_session',
+                        browserStateKey: 'appinfo'
+                    })
+                );
+                expect(outcome).toBe(REJECTED);
+            });
+        });
+
+        it('reads profile_reset_weeks_ago directly, whole weeks', async function () {
+            const uiTour = {
+                ping: (cb) => cb(),
+                getConfiguration: (key, cb) => cb({ profileResetWeeksAgo: 3 })
+            };
+            const reader = createUITourReader({ uiTour: uiTour, timeout: 100 });
+            const value = await reader.read({
+                name: 'profile_reset_weeks_ago',
+                browserStateKey: 'appinfo'
+            });
+            expect(value).toEqual(3);
+        });
+
+        it('is unavailable for profile_reset_weeks_ago when the profile was never reset', async function () {
+            const uiTour = {
+                ping: (cb) => cb(),
+                getConfiguration: (key, cb) =>
+                    cb({ profileResetWeeksAgo: null })
+            };
+            const reader = createUITourReader({ uiTour: uiTour, timeout: 100 });
+            const outcome = await settle(
+                reader.read({
+                    name: 'profile_reset_weeks_ago',
                     browserStateKey: 'appinfo'
                 })
             );


### PR DESCRIPTION
## One-line summary
Add three UITour routing signals (`days_since_last_session`, `profile_reset_weeks_ago`, `browser_name`) and fix `fxa_signed_in` to read the correct UITour key.

## Significant changes and points to review
- **New signals** (`springfield/cms/routing/v1_signals.py`, `media/js/cms/routing/readers.es6.js`): `days_since_last_session` for lapsed-user targeting (Firefox 155+ only; fails closed on older Firefox and on a never-recorded session — the `0` sentinel is deliberately not treated as a real value), `profile_reset_weeks_ago` (same shape as the existing `profile_age_weeks`), and `browser_name` (Chrome/Edge/Opera/Safari/Brave/Firefox/other via UA sniffing, reusing the existing browser-comparison detection code rather than duplicating it).
- **Fix, most important to review**: `fxa_signed_in` was reading the deprecated `sync` UITour key (`sync.setup`, meaning "Sync configured"), not `fxa` (`fxa.setup`, meaning "actually signed in to a Firefox Account") — its own description already claimed the latter. Repointed to `fxa`, no extra read cost since it's still one UITour call.
- Manually verified live: `fxa_signed_in` and `days_since_last_session` confirmed correct via real routing rules in Firefox Nightly/Chromium; `profile_reset_weeks_ago` untested live (needs a Firefox-refreshed profile) but is structurally identical to the already-proven `profile_age_weeks` path.

## Issue / Bugzilla link


## Testing
- `pytest springfield/cms/routing/` (34 passed) and `npm run jasmine` (766 specs) both green.
- To manually verify: create a canonical + variant page under an existing WhatsNewIndexPage, add a `RoutingRule`/`RoutingCondition` on one of the new signals, flip the `user_routing` waffle switch on locally, and visit with `?utm_source=update`.