### PR TITLE
Set SQLITE_EXPORT_MODE for loaddata in export script

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -252,6 +252,7 @@ echo "Purged data that was automatically added via Django/Wagtail migrations"
 
 # Load the data, getting the contenttypes table in first
 PROD_DETAILS_STORAGE=product_details.storage.PDFileStorage \
+SQLITE_EXPORT_MODE=True \
     python manage.py loaddata \
         "/tmp/export_contenttypes.json" \
         "/tmp/export_wagtail_locales.json" \


### PR DESCRIPTION
Fix db export blow-up due to content types being double declared. 

We thought we'd fixed this with a specific env-var check, but not quite: the env var was only set for the migrate step. 

The loaddata command also runs Django system checks, which trigger ContentType.objects.get_for_model() via the routing mixin. 

After the purge step that re-creates rows in django_content_type, colliding with the fixture data at load time.
