### PR TITLE
WT-1660: Add "newsletter-form" id to the newsletter form component

### DIFF
--- a/media/css/cms/flare-base.css
+++ b/media/css/cms/flare-base.css
@@ -75,6 +75,13 @@ html {
     text-size-adjust: 100%;
     accent-color: var(--fl-theme-accent-color);
     color: white;
+    scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
 }
 
 body {

--- a/springfield/cms/templates/components/newsletter-form.html
+++ b/springfield/cms/templates/components/newsletter-form.html
@@ -8,7 +8,7 @@
 {% set form_template = form_template or "cms/newsletter_form.html" %}
 {% set illustration = illustration or "kit" %}
 
-<div class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
+<div id="newsletter-form" class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
   {% if illustration != "none" %}
   <div class="fl-newsletterform-illustration">
     {% if illustration == "globe" %}


### PR DESCRIPTION
## One-line summary
This PR adds a fixed "newsletter-form" id to the newsletter form component, allowing buttons with an anchor to link to it.

## Significant changes and points to review

I've also added smooth scroll behavior to anchors, except for users with preferred reduced motion on.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1660

## Testing
Open a WNP, set a button with a link to an anchor, set the value as "newsletter-form", and test that the button sends you to the newsletter form section of the page