### PR TITLE
WT-1660: Change new newsletter id to "newsletter", to prevent id conflicts

### DIFF
--- a/springfield/cms/templates/components/newsletter-form.html
+++ b/springfield/cms/templates/components/newsletter-form.html
@@ -8,7 +8,7 @@
 {% set form_template = form_template or "cms/newsletter_form.html" %}
 {% set illustration = illustration or "kit" %}
 
-<div id="newsletter-form" class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
+<div id="newsletter" class="fl-newsletterform-cta {% if theme %}fl-force-{{ theme }}-theme{% endif %}" data-state="default">
   {% if illustration != "none" %}
   <div class="fl-newsletterform-illustration">
     {% if illustration == "globe" %}


### PR DESCRIPTION
## One-line summary

Change new newsletter id to "newsletter", to prevent id conflicts

## Testing

Run the integration tests and validate they stopped breaking.