### PR TITLE
feat: add 'ESR' suffix to links on release notes when it's for an ESR version

### DIFF
--- a/springfield/firefox/templates/firefox/releases/index.html
+++ b/springfield/firefox/templates/firefox/releases/index.html
@@ -38,7 +38,7 @@
         {% if versions.minor -%}
         <ol class="fl-c-releases-list-minor">
           {% for version in versions.minor -%}
-          <li>{{ get_flare_link(int_version, version, 'secondary') }}</li>
+          <li>{{ get_flare_link(int_version, version.version_string, 'secondary', version.is_esr) }}</li>
           {% endfor -%}
         </ol>
         {% endif -%}
@@ -75,11 +75,11 @@
   {%- endif -%}
 {% endmacro %}
 
-{% macro get_flare_link(int_version, version, theme) %}
+{% macro get_flare_link(int_version, version, theme, is_esr=False) %}
   <!-- Add .0 for primary (Major) release text. Link must remain in versions.major format -->
   {%- if int_version < 2 -%}
     <a class="fl-c-pill fl-t-pill-{{ theme }}" href="/firefox/releases/{{ version }}.html">{{ version }}{% if theme == 'primary' %}.0{% endif %}</a>
   {%- else -%}
-    <a class="fl-c-pill fl-t-pill-{{ theme }}" href="/firefox/{{ version }}/releasenotes/">{{ version }}{% if theme == 'primary' %}.0{% endif %}</a>
+    <a class="fl-c-pill fl-t-pill-{{ theme }}" href="/firefox/{{ version }}/releasenotes/">{{ version }}{% if theme == 'primary' %}.0{% endif %}{% if is_esr %} ESR{% endif %}</a>
   {%- endif -%}
 {% endmacro %}

--- a/springfield/releasenotes/tests/test_views.py
+++ b/springfield/releasenotes/tests/test_views.py
@@ -92,33 +92,52 @@ def test_releases_index(render_mock, rf):
 
     expected_data = {
         "releases": [
-            (101.0, {"major": "101.0", "minor": ["101.2"]}),
+            (
+                101.0,
+                {
+                    "major": "101.0",
+                    "minor": [
+                        {"version_string": "101.2", "is_esr": True},
+                    ],
+                },
+            ),
             (
                 100.0,
                 {
                     "major": "100.0",
-                    "minor": ["100.1", "100.2"],
+                    "minor": [
+                        {"version_string": "100.1", "is_esr": True},
+                        {"version_string": "100.2", "is_esr": True},
+                    ],
                 },
             ),
             (
                 96.0,
                 {
                     "major": "96.0",
-                    "minor": ["96.5"],
+                    "minor": [
+                        {"version_string": "96.5", "is_esr": True},
+                    ],
                 },
             ),
             (
                 33.1,
                 {
                     "major": "33.1",
-                    "minor": ["33.1.1"],
+                    "minor": [
+                        {"version_string": "33.1.1", "is_esr": False},
+                    ],
                 },
             ),
             (
                 33.0,
                 {
                     "major": "33.0",
-                    "minor": ["33.0.1", "33.0.2", "33.0.3"],
+                    "minor": [
+                        {"version_string": "33.0.1", "is_esr": False},
+                        {"version_string": "33.0.2", "is_esr": False},
+                        {"version_string": "33.0.3", "is_esr": False},
+                    ],
                 },
             ),
             (
@@ -126,20 +145,81 @@ def test_releases_index(render_mock, rf):
                 {
                     "major": "3.6",
                     "minor": [
-                        "3.6.2",
-                        "3.6.3",
-                        "3.6.4",
-                        "3.6.6",
-                        "3.6.7",
-                        "3.6.8",
-                        "3.6.9",
-                        "3.6.10",
-                        "3.6.11",
-                        "3.6.12",
-                        "3.6.13",
-                        "3.6.14",
-                        "3.6.15",
-                        "3.6.16",
+                        {"version_string": "3.6.2", "is_esr": False},
+                        {"version_string": "3.6.3", "is_esr": False},
+                        {"version_string": "3.6.4", "is_esr": False},
+                        {"version_string": "3.6.6", "is_esr": False},
+                        {"version_string": "3.6.7", "is_esr": False},
+                        {"version_string": "3.6.8", "is_esr": False},
+                        {"version_string": "3.6.9", "is_esr": False},
+                        {"version_string": "3.6.10", "is_esr": False},
+                        {"version_string": "3.6.11", "is_esr": False},
+                        {"version_string": "3.6.12", "is_esr": False},
+                        {"version_string": "3.6.13", "is_esr": False},
+                        {"version_string": "3.6.14", "is_esr": False},
+                        {"version_string": "3.6.15", "is_esr": False},
+                        {"version_string": "3.6.16", "is_esr": False},
+                    ],
+                },
+            ),
+        ],
+    }
+    render_mock.assert_called_once_with(
+        request,
+        "firefox/releases/index.html",
+        expected_data,
+    )
+
+
+@patch("springfield.firefox.views.l10n_utils.render")
+def test_releases_index__esr_annotation(render_mock, rf):
+    """ESR point releases (nonzero second segment) are flagged,
+    but 50.1.0 is excluded as a known non-ESR exception."""
+
+    mock_major_releases_val = {
+        "50.0": "2016-11-15",
+        "115.0": "2023-07-04",
+    }
+    mock_minor_releases_val = {
+        "50.0.1": "2016-11-28",
+        "50.0.2": "2016-12-01",
+        "50.1.0": "2016-12-13",
+        "115.0.1": "2023-07-06",
+        "115.0.2": "2023-07-11",
+        "115.1.0": "2023-08-01",
+        "115.2.0": "2023-08-29",
+    }
+
+    request = rf.get("/")
+
+    with patch("springfield.releasenotes.views.firefox_desktop") as mock_firefox_desktop:
+        mock_firefox_desktop.firefox_history_major_releases = mock_major_releases_val
+        mock_firefox_desktop.firefox_history_stability_releases = mock_minor_releases_val
+
+        releases_index(request, "Firefox")
+
+    expected_data = {
+        "releases": [
+            (
+                115.0,
+                {
+                    "major": "115.0",
+                    "minor": [
+                        {"version_string": "115.0.1", "is_esr": False},
+                        {"version_string": "115.0.2", "is_esr": False},
+                        {"version_string": "115.1.0", "is_esr": True},
+                        {"version_string": "115.2.0", "is_esr": True},
+                    ],
+                },
+            ),
+            (
+                50.0,
+                {
+                    "major": "50.0",
+                    "minor": [
+                        {"version_string": "50.0.1", "is_esr": False},
+                        {"version_string": "50.0.2", "is_esr": False},
+                        {"version_string": "50.1.0", "is_esr": False},
                     ],
                 },
             ),

--- a/springfield/releasenotes/views.py
+++ b/springfield/releasenotes/views.py
@@ -278,11 +278,16 @@ def releases_index(request, product):
         major_pattern = r"^" + re.escape(
             f"{major_version:.0f}." if major_version > 4 and release not in ["33.0", "33.1"] else f"{major_version:.1f}."
         )
+        non_esr_releases = {"33.1", "50.0"}
         releases[major_version] = {
             "major": release,
-            "minor": sorted(
-                [x for x in minor_releases if re.findall(major_pattern, x) if x not in major_releases], key=lambda x: [int(y) for y in x.split(".")]
-            ),
+            "minor": [
+                {"version_string": x, "is_esr": major_version > 4 and x.split(".")[1] != "0" and release not in non_esr_releases}
+                for x in sorted(
+                    [x for x in minor_releases if re.findall(major_pattern, x) if x not in major_releases],
+                    key=lambda x: [int(y) for y in x.split(".")],
+                )
+            ],
         }
 
     return l10n_utils.render(request, f"{product.lower()}/releases/index.html", {"releases": sorted(releases.items(), reverse=True)})


### PR DESCRIPTION
This changeset shows "ESR" in the link labels when the release notes being linked to are for ESR.

For example, see FF 140

<img width="1071" height="744" alt="Screenshot 2026-08-27 at 17 15 21" src="https://github.com/user-attachments/assets/7cc687bc-79e0-4ca9-aa24-f4dad74609c6" />


This assumes that all ESR versions have a non-zero value for Y in the X.Y.Z versioning pattern, which does also match the data we get from releasse-notes.

There is also support for exceptions like 50.1.0 which was not ESR.

The list comprehension is pretty intense, but breaks down fine when you walk through it slowly.

BZ ticket https://bugzilla.mozilla.org/show_bug.cgi?id=2066059

## Testing

0. Start on `main`, not this branch
1. Look the 140.x release at http://localhost:8000/en-US/releases/ 
2. Confirm that the 140.0.X pills link to FF Release relnotes
3. Confirm that 140.1.X pills link to ESR notes but the pill has no visual indication
4. Switch to this branch, restart Django, reload
3. Confirm that 140.1.X pills now mention "ESR" in their label and still correctly link to ESR notes
